### PR TITLE
Add asset publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,8 @@
 variables:
   Build.Repository.Clean: true
   _TeamName: DotNetCore
+  _DotNetPublishToBlobFeed : true
+  _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
   
   # Variables for public PR builds
   ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'github')) }}:
@@ -18,7 +20,11 @@ variables:
     _SignType: test
     _SignArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
     _OfficialBuildIdArgs: /p:OfficialBuildId=$(Build.BuildNumber)
-    _PublishArgs: '/p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat) /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)'
+    _PublishArgs: /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+      /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
+      /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+      /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+      /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
  
 resources:
   containers:
@@ -52,6 +58,12 @@ phases:
         release:
           _BuildConfig: Release
     steps:
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'official')) }}:
+      - task: AzureKeyVault@1
+        inputs:
+          azureSubscription: 'DotNet-Engineering-Services_KeyVault'
+          KeyVaultName: EngKeyVault
+          SecretsFilter: 'dotnetfeed-storage-access-key-1,microsoft-symbol-server-pat,symweb-symbol-server-pat'
     # workaround for dotnet/arcade#1425 (revert to cibuild.cmd once fixed)
     - script: eng\build-no-publish.cmd 
         -configuration $(_BuildConfig)
@@ -186,3 +198,14 @@ phases:
       condition: always()
     variables:
       _HelixBuildConfig: $(_BuildConfig)
+
+# Closing Phase for publishing - must come after and list all other jobs
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'official')) }}:
+  - template: /eng/common/templates/phases/publish-build-assets.yml
+    parameters:
+      dependsOn:
+        - Windows
+        - macOS
+        - Linux
+      queue:
+        name: Hosted VS2017

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
   Build.Repository.Clean: true
-  _TeamName: DotNetCore
+  _TeamName: AspNetCore
   _DotNetPublishToBlobFeed : true
   _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
   
@@ -17,7 +17,7 @@ variables:
   ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'official')) }}:
     _HelixType: build/product
     _HelixSource: official/aspnet/AspNetCore-Tooling/$(Build.SourceBranch)
-    _SignType: test
+    _SignType: real
     _SignArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
     _OfficialBuildIdArgs: /p:OfficialBuildId=$(Build.BuildNumber)
     _PublishArgs: /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)

--- a/src/Razor/src/Directory.Build.props
+++ b/src/Razor/src/Directory.Build.props
@@ -7,6 +7,7 @@
     <PackageTags>aspnetcore;cshtml;razor</PackageTags>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
+    <IncludeSymbols>true</IncludeSymbols>
 
     <!-- In theory we want to have this property set, but our pipeline doesn't set the access tokens yet -->
     <PublishWindowsPdb Condition="'$(DotNetSymbolServerTokenMsdl)'!='' and '$(DotNetSymbolServerTokenSymWeb)'!=''">true</PublishWindowsPdb>

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/Microsoft.NET.Sdk.Razor.csproj
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/Microsoft.NET.Sdk.Razor.csproj
@@ -58,26 +58,8 @@
     <Copy SourceFiles="@(ProjectOutput)" DestinationFiles="$(SdkOutputPath)tasks\%(RecursiveDir)%(FileName)%(Extension)" />
   </Target>
 
-  <ItemGroup>
-    <SignedPackageFile Include="$(SdkOutputPath)tasks\net46\$(TargetName).dll" Certificate="$(AssemblySigningCertName)"  />
-    <SignedPackageFile Include="$(SdkOutputPath)tasks\netstandard2.0\$(TargetName).dll" Certificate="$(AssemblySigningCertName)"  />
-    <SignedPackageFile Include="$(SdkOutputPath)extensions\**\*.dll" Certificate="$(AssemblySigningCertName)"  />
-
-    <SignedPackageFile Include="$(SdkOutputPath)tools\netcoreapp3.0\rzc.dll" Certificate="$(AssemblySigningCertName)" />
-    <SignedPackageFile Include="$(SdkOutputPath)tools\netcoreapp3.0\Newtonsoft.Json.dll" Certificate="$(AssemblySigning3rdPartyCertName)" />
-
-    <!-- Binaries that should be signed by corefx/roslyn -->
-    <ExcludePackageFileFromSigning Include="$(SdkOutputPath)tools\netcoreapp3.0\Microsoft.CodeAnalysis.dll" />
-    <ExcludePackageFileFromSigning Include="$(SdkOutputPath)tools\netcoreapp3.0\Microsoft.CodeAnalysis.CSharp.dll" />
-    <ExcludePackageFileFromSigning Include="$(SdkOutputPath)tools\netcoreapp3.0\runtimes\unix\lib\netstandard1.3\System.Text.Encoding.CodePages.dll" />
-    <ExcludePackageFileFromSigning Include="$(SdkOutputPath)tools\netcoreapp3.0\runtimes\win\lib\netstandard1.3\System.Text.Encoding.CodePages.dll" />
-  </ItemGroup>
-
   <Target Name="PopulateNuspec" AfterTargets="InitializeStandardNuspecProperties" DependsOnTargets="LayoutDependencies">
-
     <PropertyGroup>
-      <!-- Make sure we create a symbols.nupkg -->
-      <IncludeSymbols>true</IncludeSymbols>
       <NuspecProperties>
         id=$(MSBuildProjectName);
         version=$(PackageVersion);


### PR DESCRIPTION
Adds asset publishing to dotnet-core blob feed to our builds. Based on
instructions at https://github.com/dotnet/arcade/blob/master/Documentation/DependencyFlowOnboarding.md

