### PR TITLE
Fix issue with blob publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   Build.Repository.Clean: true
   _TeamName: AspNetCore
-  _DotNetPublishToBlobFeed : true
+  _DotNetPublishToBlobFeed : false
   _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
   
   # Variables for public PR builds
@@ -57,6 +57,7 @@ phases:
           _BuildConfig: Debug
         release:
           _BuildConfig: Release
+          _DotNetPublishToBlobFeed: true
     steps:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'official')) }}:
       - task: AzureKeyVault@1


### PR DESCRIPTION
The build is currently failing during publishing to the dotnet-core blob
feed. I think the reason why it's failing is that we're trying to
publish assets for multiple platforms/configurations. 

We only care about publishing windows/release.