### PR TITLE
Add a script for starting Visual Studio with the right environment vars

### DIFF
--- a/src/Razor/startvs.cmd
+++ b/src/Razor/startvs.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+
+%~dp0..\..\startvs.cmd %~dp0Razor.sln

--- a/startvs.cmd
+++ b/startvs.cmd
@@ -1,0 +1,28 @@
+@ECHO OFF
+
+:: This command launches a Visual Studio solution with environment variables required to use a local version of the .NET Core SDK.
+
+:: This tells .NET Core to use .dotnet\dotnet.exe
+SET DOTNET_ROOT=%~dp0.dotnet\
+
+:: This tells .NET Core not to go looking for .NET Core in other places
+SET DOTNET_MULTILEVEL_LOOKUP=0
+
+:: Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
+SET PATH=%DOTNET_ROOT%;%PATH%
+
+SET sln=%1
+
+IF NOT EXIST %DOTNET_ROOT%\dotnet.exe (
+    echo .NET Core has not yet been installed. Run `build.cmd -restore` to install tools
+    exit /b 1
+)
+
+IF "%sln%"=="" (
+    echo Error^: Expected argument ^<SLN_FILE^>
+    echo Usage^: startvs.cmd ^<SLN_FILE^>
+
+    exit /b 1
+)
+
+start %sln%


### PR DESCRIPTION
I got this idea from @nguerrera. You should be able to run "startvs.cmd" in src/Razor (or even double click it) and get an instance of Visual Studio with the right env vars set to use the right .NET Core SDK versions.