### PR TITLE
Update Arcade and remove workaround

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,7 @@
 
   <PropertyGroup Label="Build Settings">
     <LangVersion>7.3</LangVersion>
-    <StrongNameKeyId>MicrosoftAspNet</StrongNameKeyId>
+    <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
   </PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,8 +65,7 @@ phases:
           azureSubscription: 'DotNet-Engineering-Services_KeyVault'
           KeyVaultName: EngKeyVault
           SecretsFilter: 'dotnetfeed-storage-access-key-1,microsoft-symbol-server-pat,symweb-symbol-server-pat'
-    # workaround for dotnet/arcade#1425 (revert to cibuild.cmd once fixed)
-    - script: eng\build-no-publish.cmd 
+    - script: eng\common\cibuild.cmd 
         -configuration $(_BuildConfig)
         -prepareMachine
         $(_SignArgs)
@@ -82,24 +81,6 @@ phases:
       inputs:
         testRunner: xunit
         testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'
-    # workaround for dotnet/arcade#1425 (remove once fixed)
-    - script: eng\publish.cmd
-        -configuration $(_BuildConfig)
-        -msbuildEngine dotnet
-        $(_SignArgs)
-        $(_OfficialBuildIdArgs)
-        $(_PublishArgs)
-      name: Publish
-      displayName: Publish
-      condition: succeeded()
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Packages
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
-        PublishLocation: Container
-        ArtifactName: Packages_$(Agent.Os)_$(Agent.JobName)
-      continueOnError: true
-      condition: eq(variables['_BuildConfig'], 'Release')
     - task: PublishBuildArtifacts@1
       displayName: Publish VSIX Artifacts
       inputs:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,10 +43,6 @@
     </RestoreSources>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <MicrosoftSymbolUploaderBuildTaskVersion>1.0.0-beta-63412-03</MicrosoftSymbolUploaderBuildTaskVersion>
-  </PropertyGroup>
-
   <PropertyGroup Label="Package Versions">
     <BenchmarkDotNetPackageVersion>0.10.13</BenchmarkDotNetPackageVersion>
     <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>3.0.0-preview-181106-14</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>

--- a/eng/build-no-publish.cmd
+++ b/eng/build-no-publish.cmd
@@ -1,4 +1,0 @@
-rem workaround for dotnet/arcade#1425
-@echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0common\Build.ps1""" -restore -build -test -sign -pack -ci %*"
-exit /b %ErrorLevel%

--- a/eng/publish.cmd
+++ b/eng/publish.cmd
@@ -1,4 +1,0 @@
-rem workaround for dotnet/arcade#1425
-@echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0common\Build.ps1""" -publish -ci %*"
-exit /b %ErrorLevel%

--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
       "version": "3.0.100-preview-009750"
     },
     "msbuild-sdks": {
-      "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.18579.9"
+      "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.18605.14"
     }
   }


### PR DESCRIPTION
Removes the workaround we needed to fix symbol publishing when running
on full MSBuild dotnet/arcade#1425
