### PR TITLE
Partially moved tag grouping logic to the parser

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlMarkupParser.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlMarkupParser.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
     {
         private const string ScriptTagName = "script";
 
+        private static readonly SyntaxList<RazorSyntaxNode> EmptySyntaxList = new SyntaxListBuilder<RazorSyntaxNode>(0).ToList();
         private static readonly char[] ValidAfterTypeAttributeNameCharacters = { ' ', '\t', '\r', '\n', '\f', '=' };
         private static readonly SyntaxToken[] nonAllowedHtmlCommentEnding = new[]
         {
@@ -21,10 +22,18 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             SyntaxFactory.Token(SyntaxKind.OpenAngle, "<"),
         };
 
+        private Stack<TagTracker> _tagTracker = new Stack<TagTracker>();
+
         public HtmlMarkupParser(ParserContext context)
             : base(context.ParseLeadingDirectives ? FirstDirectiveHtmlLanguageCharacteristics.Instance : HtmlLanguageCharacteristics.Instance, context)
         {
         }
+
+        private TagTracker CurrentTracker => _tagTracker.Count > 0 ? _tagTracker.Peek() : null;
+
+        private string CurrentStartTagName => CurrentTracker?.TagName;
+
+        private SourceLocation CurrentStartTagLocation => CurrentTracker?.TagLocation ?? SourceLocation.Undefined;
 
         public CSharpCodeParser CodeParser { get; set; }
 
@@ -44,6 +53,16 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 ParseMarkupNodes(builder, ParseMode.Markup);
                 AcceptMarkerTokenIfNecessary();
                 builder.Add(OutputAsMarkupLiteral());
+
+                // If we are still tracking any unclosed start tags, we need to close them.
+                while (_tagTracker.Count > 0)
+                {
+                    var tracker = _tagTracker.Pop();
+                    var element = SyntaxFactory.MarkupElement(tracker.StartTag, builder.ToList(), null);
+                    builder.Clear();
+                    builder.AddRange(tracker.PreviousNodes);
+                    builder.Add(element);
+                }
 
                 var markup = SyntaxFactory.MarkupBlock(builder.ToList());
 
@@ -71,7 +90,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     ParseMarkupText(builder);
                     break;
                 case ParserState.Tag:
-                    ParseMarkupElement(builder);
+                    ParseMarkupElement(builder, mode);
                     break;
                 case ParserState.SpecialTag:
                     ParseSpecialTag(builder);
@@ -111,7 +130,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             AcceptAndMoveNext();
         }
 
-        private void ParseMarkupElement(in SyntaxListBuilder<RazorSyntaxNode> builder)
+        private void ParseMarkupElement(in SyntaxListBuilder<RazorSyntaxNode> builder, ParseMode mode)
         {
             Assert(SyntaxKind.OpenAngle);
 
@@ -121,47 +140,105 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             if (!NextIs(SyntaxKind.ForwardSlash))
             {
                 // Parsing a start tag
+                var tagStart = CurrentStart;
                 var startTag = ParseStartTag(out var tagName, out var tagMode);
-                builder.Add(startTag);
-
                 if (tagMode == MarkupTagMode.Script)
                 {
-                    ParseJavascriptAndEndScriptTag(builder);
+                    ParseJavascriptAndEndScriptTag(builder, startTag);
                     return;
                 }
-                else if (tagMode != MarkupTagMode.Void && tagMode != MarkupTagMode.SelfClosing)
+                else if (tagMode == MarkupTagMode.SelfClosing || tagMode == MarkupTagMode.Invalid)
                 {
-                    var body = ParseTagBody(tagName, out var seenEndTag);
-                    if (body != null)
-                    {
-                        builder.AddRange(body);
-                    }
-
-                    if (seenEndTag)
-                    {
-                        var endTag = ParseEndTag();
-                        builder.Add(endTag);
-                    }
+                    // For cases like <foo /> or invalid cases like |<|<p>
+                    var element = SyntaxFactory.MarkupElement(startTag, EmptySyntaxList, null);
+                    builder.Add(element);
+                    return;
+                }
+                else
+                {
+                    // This is a normal start tag. We need to keep track of it.
+                    var tracker = new TagTracker(tagName, startTag, tagStart, builder);
+                    _tagTracker.Push(tracker);
+                    builder.Clear();
+                    return;
                 }
             }
             else
             {
                 // Parsing an end tag.
-                var endTag = ParseEndTag();
-                builder.Add(endTag);
+                var endTag = ParseEndTag(out var endTagName);
+                if (endTagName != null && string.Equals(CurrentStartTagName, endTagName, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Happy path. Found a matching start tag. Create the element and reset the builder.
+                    var tracker = _tagTracker.Pop();
+                    var element = SyntaxFactory.MarkupElement(tracker.StartTag, builder.ToList(), endTag);
+                    builder.Clear();
+                    builder.AddRange(tracker.PreviousNodes);
+                    builder.Add(element);
+                    return;
+                }
+                else
+                {
+                    // Current tag scope does not match the end tag. Attempt to recover the start tag
+                    // by looking up the previous tag scopes for a matching start tag.
+                    if (!TryRecoverStartTag(builder, endTagName, endTag))
+                    {
+                        // Could not recover.
+                        var element = SyntaxFactory.MarkupElement(null, EmptySyntaxList, endTag);
+                        builder.Add(element);
+                    }
+                }
             }
         }
 
-        private MarkupTagBlockSyntax ParseStartTag(out string tagName, out MarkupTagMode tagMode)
+        private bool TryRecoverStartTag(in SyntaxListBuilder<RazorSyntaxNode> builder, string endTagName, MarkupEndTagSyntax endTag)
+        {
+            var malformedTagCount = 0;
+            foreach (var tag in _tagTracker)
+            {
+                if (string.Equals(tag.TagName, endTagName, StringComparison.OrdinalIgnoreCase))
+                {
+                    break;
+                }
+
+                malformedTagCount++;
+            }
+
+            if (malformedTagCount != _tagTracker.Count)
+            {
+                // This means we found a matching tag.
+                for (var i = 0; i < malformedTagCount; i++)
+                {
+                    var tracker = _tagTracker.Pop();
+                    var malformedElement = SyntaxFactory.MarkupElement(tracker.StartTag, builder.ToList(), null);
+                    builder.Clear();
+                    builder.AddRange(tracker.PreviousNodes);
+                    builder.Add(malformedElement);
+                }
+
+                // Now complete our target tag which is not malformed.
+                var tagTracker = _tagTracker.Pop();
+                var element = SyntaxFactory.MarkupElement(tagTracker.StartTag, builder.ToList(), endTag);
+                builder.Clear();
+                builder.AddRange(tagTracker.PreviousNodes);
+                builder.Add(element);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private MarkupStartTagSyntax ParseStartTag(out string tagName, out MarkupTagMode tagMode)
         {
             tagName = null;
-            tagMode = MarkupTagMode.Normal;
+            tagMode = MarkupTagMode.Invalid;
             using (var pooledResult = Pool.Allocate<RazorSyntaxNode>())
             {
                 var tagBuilder = pooledResult.Builder;
 
                 AcceptAndMoveNext(); // Accept '<'
-                TryParseBangEscape(tagBuilder);
+                var isBangEscape = TryParseBangEscape(tagBuilder);
 
                 if (At(SyntaxKind.Text))
                 {
@@ -170,6 +247,16 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     {
                         // This is a void element.
                         tagMode = MarkupTagMode.Void;
+                    }
+                    else
+                    {
+                        tagMode = MarkupTagMode.Normal;
+                    }
+
+                    if (isBangEscape)
+                    {
+                        // We don't want to group <p> and </!p> together.
+                        tagName = "!" + tagName;
                     }
                 }
                 TryAccept(SyntaxKind.Text);
@@ -189,7 +276,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
                 // End tag block
                 tagBuilder.Add(OutputAsMarkupLiteral());
-                var tagBlock = SyntaxFactory.MarkupTagBlock(tagBuilder.ToList());
+                var tagBlock = SyntaxFactory.MarkupStartTag(tagBuilder.ToList());
                 if (string.Equals(tagName, ScriptTagName, StringComparison.OrdinalIgnoreCase))
                 {
                     // If the script tag expects javascript content then we should do minimal parsing until we reach
@@ -204,10 +291,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
         }
 
-        private MarkupTagBlockSyntax ParseEndTag()
+        private MarkupEndTagSyntax ParseEndTag(out string tagName)
         {
             // This section can accept things like: '</p  >' or '</p>' etc.
             Assert(SyntaxKind.OpenAngle);
+
+            tagName = null;
 
             using (var pooledResult = Pool.Allocate<RazorSyntaxNode>())
             {
@@ -217,14 +306,19 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 TryAccept(SyntaxKind.ForwardSlash);
 
                 // Whitespace here is invalid (according to the spec)
-                TryParseBangEscape(tagBuilder);
-                TryAccept(SyntaxKind.Text);
+                var isBangEscape = TryParseBangEscape(tagBuilder);
+                if (At(SyntaxKind.Text))
+                {
+                    tagName = isBangEscape ? "!" : string.Empty;
+                    tagName += CurrentToken.Content;
+                    AcceptAndMoveNext();
+                }
                 TryAccept(SyntaxKind.Whitespace);
                 TryAccept(SyntaxKind.CloseAngle);
 
                 // End tag block
                 tagBuilder.Add(OutputAsMarkupLiteral());
-                var tagBlock = SyntaxFactory.MarkupTagBlock(tagBuilder.ToList());
+                var tagBlock = SyntaxFactory.MarkupEndTag(tagBuilder.ToList());
                 return tagBlock;
             }
         }
@@ -598,8 +692,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                    token.Kind == SyntaxKind.NewLine;
         }
 
-        private void ParseJavascriptAndEndScriptTag(in SyntaxListBuilder<RazorSyntaxNode> builder, AcceptedCharactersInternal endTagAcceptedCharacters = AcceptedCharactersInternal.Any)
+        private void ParseJavascriptAndEndScriptTag(in SyntaxListBuilder<RazorSyntaxNode> builder, MarkupStartTagSyntax startTag, AcceptedCharactersInternal endTagAcceptedCharacters = AcceptedCharactersInternal.Any)
         {
+            var previousNodes = builder.ToList();
+            builder.Clear();
+
             // Special case for <script>: Skip to end of script tag and parse code
             var seenEndScript = false;
 
@@ -637,6 +734,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 }
             }
 
+            MarkupEndTagSyntax endTag = null;
             if (seenEndScript)
             {
                 var tagStart = CurrentStart;
@@ -660,9 +758,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         Accept(closeAngle);
                     }
                     tagBuilder.Add(OutputAsMarkupLiteral());
-                    builder.Add(SyntaxFactory.MarkupTagBlock(tagBuilder.ToList()));
+                    endTag = SyntaxFactory.MarkupEndTag(tagBuilder.ToList());
                 }
             }
+
+            var element = SyntaxFactory.MarkupElement(startTag, builder.ToList(), endTag);
+            builder.Clear();
+            builder.AddRange(previousNodes);
+            builder.Add(element);
         }
 
         private bool ParseSpecialTag(in SyntaxListBuilder<RazorSyntaxNode> builder)
@@ -878,7 +981,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             AcceptWhile(IsSpacingToken(includeNewLines: true));
         }
 
-        private bool ScriptTagExpectsHtml(MarkupTagBlockSyntax tagBlock)
+        private bool ScriptTagExpectsHtml(MarkupStartTagSyntax tagBlock)
         {
             MarkupAttributeBlockSyntax typeAttribute = null;
             for (var i = 0; i < tagBlock.Children.Count; i++)
@@ -1283,6 +1386,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         private enum ParseMode
         {
             Markup,
+            MarkupInCodeBlock,
             Text,
         }
 
@@ -1291,7 +1395,31 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             Normal,
             Void,
             SelfClosing,
-            Script
+            Script,
+            Invalid,
+        }
+
+        private class TagTracker
+        {
+            public TagTracker(
+                string tagName,
+                MarkupStartTagSyntax startTag,
+                SourceLocation tagLocation,
+                SyntaxListBuilder<RazorSyntaxNode> builder)
+            {
+                TagName = tagName;
+                StartTag = startTag;
+                TagLocation = tagLocation;
+                PreviousNodes = builder.ToList();
+            }
+
+            public string TagName { get; }
+
+            public MarkupStartTagSyntax StartTag { get; }
+
+            public SourceLocation TagLocation { get; }
+
+            public SyntaxList<RazorSyntaxNode> PreviousNodes { get; }
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlMarkupParser.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlMarkupParser.cs
@@ -13,7 +13,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
     {
         private const string ScriptTagName = "script";
 
-        private static readonly SyntaxList<RazorSyntaxNode> EmptySyntaxList = new SyntaxListBuilder<RazorSyntaxNode>(0).ToList();
         private static readonly char[] ValidAfterTypeAttributeNameCharacters = { ' ', '\t', '\r', '\n', '\f', '=' };
         private static readonly SyntaxToken[] nonAllowedHtmlCommentEnding = new[]
         {
@@ -150,7 +149,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 else if (tagMode == MarkupTagMode.SelfClosing || tagMode == MarkupTagMode.Invalid)
                 {
                     // For cases like <foo /> or invalid cases like |<|<p>
-                    var element = SyntaxFactory.MarkupElement(startTag, EmptySyntaxList, null);
+                    var element = SyntaxFactory.MarkupElement(startTag, SyntaxList<RazorSyntaxNode>.Empty, null);
                     builder.Add(element);
                     return;
                 }
@@ -184,7 +183,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     if (!TryRecoverStartTag(builder, endTagName, endTag))
                     {
                         // Could not recover.
-                        var element = SyntaxFactory.MarkupElement(null, EmptySyntaxList, endTag);
+                        var element = SyntaxFactory.MarkupElement(null, SyntaxList<RazorSyntaxNode>.Empty, endTag);
                         builder.Add(element);
                     }
                 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/InternalSyntax/SyntaxListBuilderOfT.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/InternalSyntax/SyntaxListBuilderOfT.cs
@@ -87,6 +87,13 @@ namespace Microsoft.AspNetCore.Razor.Language.Syntax.InternalSyntax
             return _builder.ToList<TNode>();
         }
 
+        public SyntaxList<TNode> Consume()
+        {
+            var list = ToList();
+            Clear();
+            return list;
+        }
+
         public GreenNode ToListNode()
         {
             return _builder.ToListNode();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/InternalSyntax/SyntaxListOfT.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/InternalSyntax/SyntaxListOfT.cs
@@ -9,6 +9,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Syntax.InternalSyntax
     internal struct SyntaxList<TNode> : IEquatable<SyntaxList<TNode>>
         where TNode : GreenNode
     {
+        public static readonly SyntaxList<RazorSyntaxNode> Empty = new SyntaxListBuilder<RazorSyntaxNode>(0).ToList();
         private readonly GreenNode _node;
 
         public SyntaxList(GreenNode node)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/InternalSyntax/SyntaxListOfT.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/InternalSyntax/SyntaxListOfT.cs
@@ -9,7 +9,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Syntax.InternalSyntax
     internal struct SyntaxList<TNode> : IEquatable<SyntaxList<TNode>>
         where TNode : GreenNode
     {
-        public static readonly SyntaxList<RazorSyntaxNode> Empty = new SyntaxListBuilder<RazorSyntaxNode>(0).ToList();
         private readonly GreenNode _node;
 
         public SyntaxList(GreenNode node)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/StackGuard.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/StackGuard.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Razor.Language.Syntax
+{
+    internal static class StackGuard
+    {
+        public const int MaxUncheckedRecursionDepth = 20;
+
+        /// <summary>
+        ///     Ensures that the remaining stack space is large enough to execute
+        ///     the average function.
+        /// </summary>
+        /// <param name="recursionDepth">how many times the calling function has recursed</param>
+        /// <exception cref="InsufficientExecutionStackException">
+        ///     The available stack space is insufficient to execute
+        ///     the average function.
+        /// </exception>
+        public static void EnsureSufficientExecutionStack(int recursionDepth)
+        {
+            if (recursionDepth > MaxUncheckedRecursionDepth)
+            {
+                RuntimeHelpers.EnsureSufficientExecutionStack();
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/SyntaxRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/SyntaxRewriter.cs
@@ -7,6 +7,26 @@ namespace Microsoft.AspNetCore.Razor.Language.Syntax
 {
     internal abstract partial class SyntaxRewriter : SyntaxVisitor<SyntaxNode>
     {
+        private int _recursionDepth;
+
+        public override SyntaxNode Visit(SyntaxNode node)
+        {
+            if (node != null)
+            {
+                _recursionDepth++;
+                StackGuard.EnsureSufficientExecutionStack(_recursionDepth);
+
+                var result = node.Accept(this);
+
+                _recursionDepth--;
+                return result;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         public override SyntaxNode VisitToken(SyntaxToken token)
         {
             // PERF: This is a hot method, so it has been written to minimize the following:

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/SyntaxWalker.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/SyntaxWalker.cs
@@ -9,9 +9,19 @@ namespace Microsoft.AspNetCore.Razor.Language.Syntax
     /// </summary>
     internal abstract class SyntaxWalker : SyntaxVisitor
     {
+        private int _recursionDepth;
+
         public override void Visit(SyntaxNode node)
         {
-            node?.Accept(this);
+            if (node != null)
+            {
+                _recursionDepth++;
+                StackGuard.EnsureSufficientExecutionStack(_recursionDepth);
+
+                node.Accept(this);
+
+                _recursionDepth--;
+            }
         }
 
         public override void DefaultVisit(SyntaxNode node)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/HtmlDocumentTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/HtmlDocumentTest.cs
@@ -199,8 +199,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 new[] { SectionDirective.Directive, });
         }
 
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "We currently don't support 1000 nested elements on MacOS.")]
+        [Fact(Skip = "Skipping temporarily until MarkupElementRewriter is removed")]
         public void ParseBlockCanParse1000NestedElements()
         {
             var content = Nested1000.ReadAllText();


### PR DESCRIPTION
- Added StackGuard (From Roslyn)

With this change, all of grouping logic for ParseDocument cases is now handled directly in the parser.
I am already working on completely deleting `MarkupElementRewriter` but will send that in a separate PR
