### PR TITLE
Attempt to fix symbols and VSIX manifest version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,6 +24,7 @@
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
+    <PublishWindowsPdb>true</PublishWindowsPdb>
   </PropertyGroup>
 
   <PropertyGroup Label="Package and Assembly Metadata">

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -21,6 +21,14 @@
         We are responsible for providing the semicolon for some reason. 
       -->
       <ManifestPublishUrl Condition="'$(ManifestPublishUrl)' == ''">https://vsdrop.corp.microsoft.com/file/v1/Products/$(ManifestTeamProject)/$(ManifestRepositoryName)/$(ManifestBuildBranch)/$(ManifestBuildNumber)%3B</ManifestPublishUrl>
+
+      <!-- 
+        The build-in VSIX manifest support will compute its own version before calling this target.
+        Replace it with our versioning scheme.
+      -->
+      <VsixVersion>16.0</VsixVersion>
+      <VsixVersion Condition="'$(OfficialBuildId)' != ''">$(VsixVersion).$(OfficialBuildId)</VsixVersion>
+      <VsixVersion Condition="'$(OfficialBuildId)' == ''">$(VsixVersion).4242424</VsixVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Attempts to fix a few issues with our VS build and insertion process

First, we're not currently producing Windows pdbs - which we need. I thought I had this turned on, but apparently it was not there.

Secondly, the .vsman file produced by the build doesn't follow our VS versioning scheme. Right now I have to use a hack to fix this, will follow up on a longer term solution later.
