### PR TITLE
Fixing issues with VSIX versioning

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,11 +5,16 @@
 
   <!-- 
     Repeating this here because the Arcade VisualStudio.props runs after our Versions.props and overwrites
-    our VsixVersion
+    our VsixVersion.
+
+    If this is developer build - we need to have a LARGER number than our official builds, which will
+    look like: 16.0.20181207.3
+
+    The current scheme should work until the 43rd century.
   -->
   <PropertyGroup>
     <VsixVersion>16.0</VsixVersion>
     <VsixVersion Condition="'$(OfficialBuildId)' != ''">$(VsixVersion).$(OfficialBuildId)</VsixVersion>
-    <VsixVersion Condition="'$(OfficialBuildId)' == ''">$(VsixVersion).4242424</VsixVersion>
+    <VsixVersion Condition="'$(OfficialBuildId)' == ''">$(VsixVersion).42424242.42</VsixVersion>
   </PropertyGroup>
 </Project>

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -25,10 +25,15 @@
       <!-- 
         The build-in VSIX manifest support will compute its own version before calling this target.
         Replace it with our versioning scheme.
+
+        If this is developer build - we need to have a LARGER number than our official builds, which will
+        look like: 16.0.20181207.3
+
+        The current scheme should work until the 43rd century.
       -->
       <VsixVersion>16.0</VsixVersion>
       <VsixVersion Condition="'$(OfficialBuildId)' != ''">$(VsixVersion).$(OfficialBuildId)</VsixVersion>
-      <VsixVersion Condition="'$(OfficialBuildId)' == ''">$(VsixVersion).4242424</VsixVersion>
+      <VsixVersion Condition="'$(OfficialBuildId)' == ''">$(VsixVersion).42424242.42</VsixVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,12 +21,18 @@
     imported. This OK because we want to just have an obvious salt for a local build.
   -->
   <PropertyGroup>
+    <!-- 
+      If this is developer build - we need to have a LARGER number than our official builds, which will
+      look like: 16.0.20181207.3
+
+      The current scheme should work until the 43rd century.
+    -->
     <VsixVersion>16.0</VsixVersion>
     <VsixVersion Condition="'$(OfficialBuildId)' != ''">$(VsixVersion).$(OfficialBuildId)</VsixVersion>
-    <VsixVersion Condition="'$(OfficialBuildId)' == ''">$(VsixVersion).4242424</VsixVersion>
+    <VsixVersion Condition="'$(OfficialBuildId)' == ''">$(VsixVersion).42424242.42</VsixVersion>
     <AddinVersion>7.5</AddinVersion>
     <AddinVersion Condition="'$(OfficialBuildId)' != ''">$(AddinVersion).$(OfficialBuildId)</AddinVersion>
-    <AddinVersion Condition="'$(OfficialBuildId)' == ''">$(AddinVersion).4242424</AddinVersion>
+    <AddinVersion Condition="'$(OfficialBuildId)' == ''">$(AddinVersion).42424242.42</AddinVersion>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreSources>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -2,12 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
 
-    <!-- 
-      We use the VS release versioning for the VSIX. We also need this to flow into the AssemblyInformationVersionAttribute
-      for the about... dialog
-    -->
-    <InformationalVersion>$(VsixVersion)</InformationalVersion>
-
     <!-- Use the RoslynDev Experimental instance so we can mingle with local builds of Roslyn -->
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
 
@@ -129,5 +123,15 @@ using Microsoft.VisualStudio.Shell;
     <ItemGroup>
       <Analyzer Remove="@(Analyzer)" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="WORKAROUND_SETINFORMATIONVERSION" BeforeTargets="AddSourceRevisionToInformationalVersion">
+    <!-- 
+      We use the VS release versioning for the VSIX. We also need this to flow into the AssemblyInformationVersionAttribute
+      for the about... dialog
+    -->
+    <PropertyGroup>
+      <InformationalVersion>$(VsixVersion)</InformationalVersion>
+    </PropertyGroup>
   </Target>
 </Project>

--- a/src/Razor/src/RazorDeveloperTools/RazorDeveloperTools.csproj
+++ b/src/Razor/src/RazorDeveloperTools/RazorDeveloperTools.csproj
@@ -101,4 +101,14 @@
       <Analyzer Remove="@(Analyzer)" />
     </ItemGroup>
   </Target>
+
+  <Target Name="WORKAROUND_SETINFORMATIONVERSION" BeforeTargets="AddSourceRevisionToInformationalVersion">
+    <!-- 
+      We use the VS release versioning for the VSIX. We also need this to flow into the AssemblyInformationVersionAttribute
+      for the about... dialog
+    -->
+    <PropertyGroup>
+      <InformationalVersion>$(VsixVersion)</InformationalVersion>
+    </PropertyGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
1. Our dev builds have a smaller build number than our official builds
 because they were missing a digit. OOPS

2. The AssemblyInformationVersion was wrong. I'm not sure why this
workaround is required.
