### PR TITLE
Fix racey directive token auto-complete.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectiveTargetExtension.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectiveTargetExtension.cs
@@ -165,10 +165,19 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
         private void WriteMarkerToken(CodeRenderingContext context, DirectiveTokenIntermediateNode node)
         {
-            // We want to map marker tokens to a location in the generated document
-            // that will provide CSharp intellisense.
-            context.AddSourceMappingFor(node);
-            context.CodeWriter.Write(" ");
+            // Marker tokens exist to be filled with other content a user might write. In an end-to-end
+            // scenario markers prep the Razor documents C# projections to have an empty projection that
+            // can be filled with other user content. This content can trigger a multitude of other events,
+            // such as completion. In the case of completion, a completion session can occur when a marker
+            // hasn't been filled and then we will fill it as a user types. The line pragma is necessary
+            // for consistency so when a C# completion session starts, filling user code doesn't result in
+            // a previously non-existent line pragma from being added and destroying the context in which
+            // the completion session was started.
+            using (context.CodeWriter.BuildLinePragma(node.Source))
+            {
+                context.AddSourceMappingFor(node);
+                context.CodeWriter.Write(" ");
+            }
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -16,16 +16,36 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
- }
+#line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
@@ -36,13 +56,28 @@ MyService<TModel> __typeHelper = default(MyService<TModel>);
         }
         ))();
         ((System.Action)(() => {
- }
+#line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 14 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 15 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         }
         #pragma warning restore 219

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -1,40 +1,40 @@
 Source Location: (119:6,6 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (671:18,0 [0] )
+Generated Location: (767:19,0 [0] )
 ||
 
 Source Location: (128:7,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (724:21,0 [0] )
+Generated Location: (957:27,0 [0] )
 ||
 
 Source Location: (139:9,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (777:24,0 [0] )
+Generated Location: (1148:35,0 [0] )
 ||
 
 Source Location: (149:10,8 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (830:27,0 [0] )
+Generated Location: (1339:43,0 [0] )
 ||
 
 Source Location: (159:11,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 |MyService<TModel>|
-Generated Location: (980:31,0 [17] )
+Generated Location: (1530:51,0 [17] )
 |MyService<TModel>|
 
 Source Location: (176:11,25 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1133:38,0 [0] )
+Generated Location: (1780:59,0 [0] )
 ||
 
 Source Location: (190:13,10 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1186:41,0 [0] )
+Generated Location: (1971:67,0 [0] )
 ||
 
 Source Location: (203:14,11 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1239:44,0 [0] )
+Generated Location: (2162:75,0 [0] )
 ||
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -16,16 +16,36 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
- }
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
@@ -36,7 +56,12 @@ MyService<TModel> __typeHelper = default(MyService<TModel>);
         }
         ))();
         ((System.Action)(() => {
- }
+#line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         }
         #pragma warning restore 219

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -1,30 +1,30 @@
 Source Location: (93:2,6 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (680:18,0 [0] )
+Generated Location: (776:19,0 [0] )
 ||
 
 Source Location: (102:3,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (733:21,0 [0] )
+Generated Location: (966:27,0 [0] )
 ||
 
 Source Location: (113:5,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (786:24,0 [0] )
+Generated Location: (1156:35,0 [0] )
 ||
 
 Source Location: (123:6,8 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (839:27,0 [0] )
+Generated Location: (1346:43,0 [0] )
 ||
 
 Source Location: (133:7,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 |MyService<TModel>|
-Generated Location: (988:31,0 [17] )
+Generated Location: (1536:51,0 [17] )
 |MyService<TModel>|
 
 Source Location: (150:7,25 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1141:38,0 [0] )
+Generated Location: (1785:59,0 [0] )
 ||
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -16,16 +16,36 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
- }
+#line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
@@ -36,13 +56,28 @@ MyService<TModel> __typeHelper = default(MyService<TModel>);
         }
         ))();
         ((System.Action)(() => {
- }
+#line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 14 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 15 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         }
         #pragma warning restore 219

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -1,40 +1,40 @@
 Source Location: (119:6,6 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (671:18,0 [0] )
+Generated Location: (767:19,0 [0] )
 ||
 
 Source Location: (128:7,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (724:21,0 [0] )
+Generated Location: (957:27,0 [0] )
 ||
 
 Source Location: (139:9,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (777:24,0 [0] )
+Generated Location: (1148:35,0 [0] )
 ||
 
 Source Location: (149:10,8 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (830:27,0 [0] )
+Generated Location: (1339:43,0 [0] )
 ||
 
 Source Location: (159:11,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 |MyService<TModel>|
-Generated Location: (980:31,0 [17] )
+Generated Location: (1530:51,0 [17] )
 |MyService<TModel>|
 
 Source Location: (176:11,25 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1133:38,0 [0] )
+Generated Location: (1780:59,0 [0] )
 ||
 
 Source Location: (190:13,10 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1186:41,0 [0] )
+Generated Location: (1971:67,0 [0] )
 ||
 
 Source Location: (203:14,11 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1239:44,0 [0] )
+Generated Location: (2162:75,0 [0] )
 ||
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -80,16 +80,36 @@ global::System.Object __typeHelper = ";
         }
         ))();
         ((System.Action)(() => {
- }
+#line 15 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 21 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         ((System.Action)(() => {
- }
+#line 22 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
         ))();
         }
         #pragma warning restore 219

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -45,26 +45,26 @@ Generated Location: (2355:75,37 [1] )
 
 Source Location: (264:14,9 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (2450:82,0 [0] )
+Generated Location: (2547:83,0 [0] )
 ||
 
 Source Location: (276:15,10 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (2503:85,0 [0] )
+Generated Location: (2738:91,0 [0] )
 ||
 
 Source Location: (315:20,8 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (2556:88,0 [0] )
+Generated Location: (2929:99,0 [0] )
 ||
 
 Source Location: (326:21,9 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (2609:91,0 [0] )
+Generated Location: (3120:107,0 [0] )
 ||
 
 Source Location: (354:24,12 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (3025:102,12 [0] )
+Generated Location: (3577:122,12 [0] )
 ||
 


### PR DESCRIPTION
- This happens because a completion session starts when we've rendered a marker directive token (`@inject_`) without a line pragma and then we return our parse results while a completion session is active with C# content that includes a line pragma. This pull request fixes that.
- Updated tests and verified in VS d16.0stg.

AspNetCore#4810