### PR TITLE
Enable BAR publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@ variables:
   _TeamName: AspNetCore
   _DotNetPublishToBlobFeed : false
   _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+  _PublishArgs: ''
   
   # Variables for public PR builds
   ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'github')) }}:
@@ -11,7 +12,6 @@ variables:
     # These are needed to suppress a warning in the cibuild invocation since AzDO leaves the `$(_SignArgs)` in place and it fails to resolve.
     _SignArgs: ''
     _OfficialBuildIdArgs: ''
-    _PublishArgs: ''
 
   # Variables for internal Official builds
   ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'official')) }}:
@@ -22,8 +22,6 @@ variables:
     _OfficialBuildIdArgs: /p:OfficialBuildId=$(Build.BuildNumber) 
       /p:ManifestBuildBranch=$(Build.SourceBranchName)
       /p:ManifestBuildNumber=$(Build.BuildNumber)
-    _PublishArgs: /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-      /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
  
 resources:
   containers:
@@ -57,7 +55,14 @@ phases:
           _BuildConfig: Debug
         release:
           _BuildConfig: Release
-          _DotNetPublishToBlobFeed: false
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'official')) }}:
+            _DotNetPublishToBlobFeed: true
+            _PublishArgs: /p:PublishToSymbolServer=true
+              /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+              /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+              /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+              /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
+              /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
     steps:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'official')) }}:
       - task: AzureKeyVault@1
@@ -80,7 +85,7 @@ phases:
       continueOnError: true
       inputs:
         testRunner: xunit
-        testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'
+        testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml' 
     - task: PublishBuildArtifacts@1
       displayName: Publish VSIX Artifacts
       inputs:

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ProjectToBuild Condition="'$(OS)'=='WINDOWS_NT'" Include="$(MSBuildThisFileDirectory)..\src\Razor\Razor.sln" />
+    <ProjectToBuild Condition="'$(OS)'=='WINDOWS_NT' and '$(SdkTaskProjects)'==''" Include="$(MSBuildThisFileDirectory)..\src\Razor\Razor.sln" />
 
     <!-- Exclude VSIX projects on non-Windows -->
-    <ProjectToBuild Condition="'$(OS)'!='WINDOWS_NT'" Include="$(MSBuildThisFileDirectory)..\src\Razor\Razor.Slim.sln" />
+    <ProjectToBuild Condition="'$(OS)'!='WINDOWS_NT' and '$(SdkTaskProjects)'==''" Include="$(MSBuildThisFileDirectory)..\src\Razor\Razor.Slim.sln" />
   </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,22 +1,30 @@
 
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Opt-in arcade features -->
   <PropertyGroup>
     <UsingToolVSSDK>true</UsingToolVSSDK>
     <MicrosoftVSSDKBuildToolsVersion>15.9.3032</MicrosoftVSSDKBuildToolsVersion>
-    <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <MicrosoftNetFrameworkReferenceAssembliesVersion>1.0.0-alpha-004</MicrosoftNetFrameworkReferenceAssembliesVersion>
+    <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
   </PropertyGroup>
-  <!-- Opt out of certain Arcade features -->
+
+  <!-- Opt out Arcade features -->
   <PropertyGroup>
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>
+
+  <!-- Versioning for assemblies/packages -->
   <PropertyGroup>
     <MajorVersion>3</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
+
   <!-- 
+    Versioning for tooling releases.
+
     Note: Using $(OfficialBuildId) because the other version-related properties are defined yet when this is
     imported. This OK because we want to just have an obvious salt for a local build.
   -->
@@ -34,6 +42,7 @@
     <AddinVersion Condition="'$(OfficialBuildId)' != ''">$(AddinVersion).$(OfficialBuildId)</AddinVersion>
     <AddinVersion Condition="'$(OfficialBuildId)' == ''">$(AddinVersion).42424242.42</AddinVersion>
   </PropertyGroup>
+
   <PropertyGroup>
     <RestoreSources>
       $(RestoreSources);


### PR DESCRIPTION
This change adds a set of workarounds that we need to enable publishing to
BAR from this repo.

1. Workaround the attempt to call the Execute task on every project
2. Force symbol publishing to happen by explicitly passing the option
3. Reenable BAR publishing