### PR TITLE
Flow FileKind from project items -> code document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,5 +128,7 @@ config.ps1
 node_modules/
 
 # Python Compile Outputs
-
 *.pyc
+
+# Rider
+.idea/

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -64,8 +64,8 @@
     <MicrosoftBuildFrameworkPackageVersion>15.8.166</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildPackageVersion>15.8.166</MicrosoftBuildPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.8.166</MicrosoftBuildUtilitiesCorePackageVersion>
-    <MicrosoftCodeAnalysisCommonPackageVersion>2.8.0</MicrosoftCodeAnalysisCommonPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>2.8.0</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCommonPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisCommonPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>2.11.0-beta1-final</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>3.0.0-preview-181106-14</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
     <MicrosoftExtensionsCopyOnWriteDictionarySourcesPackageVersion>3.0.0-preview-181106-14</MicrosoftExtensionsCopyOnWriteDictionarySourcesPackageVersion>
     <MicrosoftExtensionsDependencyModelPackageVersion>3.0.0-preview-27113-06</MicrosoftExtensionsDependencyModelPackageVersion>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentDocumentClassifierPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentDocumentClassifierPass.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         protected override bool IsMatch(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)
         {
-            return codeDocument.GetInputDocumentKind() == InputDocumentKind.Component;
+            return string.Equals(codeDocument.GetFileKind(), FileKinds.Component);
         }
 
         protected override void OnDocumentStructureCreated(RazorCodeDocument codeDocument, NamespaceDeclarationIntermediateNode @namespace, ClassDeclarationIntermediateNode @class, MethodDeclarationIntermediateNode method)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngine.cs
@@ -68,10 +68,10 @@ namespace Microsoft.AspNetCore.Razor.Language
             var importItems = importFeature.GetImports(projectItem);
             var importSourceDocuments = GetImportSourceDocuments(importItems);
 
-            return CreateCodeDocumentCore(sourceDocument, importSourceDocuments, tagHelpers: null);
+            return CreateCodeDocumentCore(sourceDocument, projectItem.FileKind, importSourceDocuments, tagHelpers: null);
         }
 
-        internal override RazorCodeDocument CreateCodeDocumentCore(RazorSourceDocument sourceDocument, IReadOnlyList<RazorSourceDocument> importSourceDocuments, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        internal override RazorCodeDocument CreateCodeDocumentCore(RazorSourceDocument sourceDocument, string fileKind, IReadOnlyList<RazorSourceDocument> importSourceDocuments, IReadOnlyList<TagHelperDescriptor> tagHelpers)
         {
             if (sourceDocument == null)
             {
@@ -83,6 +83,11 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             var codeDocument = RazorCodeDocument.Create(sourceDocument, importSourceDocuments, parserOptions, codeGenerationOptions);
             codeDocument.SetTagHelpers(tagHelpers);
+
+            if (fileKind != null)
+            {
+                codeDocument.SetFileKind(fileKind);
+            }
 
             return codeDocument;
         }
@@ -100,10 +105,10 @@ namespace Microsoft.AspNetCore.Razor.Language
             var importItems = importFeature.GetImports(projectItem);
             var importSourceDocuments = GetImportSourceDocuments(importItems, suppressExceptions: true);
 
-            return CreateCodeDocumentDesignTimeCore(sourceDocument, importSourceDocuments, tagHelpers: null);
+            return CreateCodeDocumentDesignTimeCore(sourceDocument, projectItem.FileKind, importSourceDocuments, tagHelpers: null);
         }
 
-        internal override RazorCodeDocument CreateCodeDocumentDesignTimeCore(RazorSourceDocument sourceDocument, IReadOnlyList<RazorSourceDocument> importSourceDocuments, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        internal override RazorCodeDocument CreateCodeDocumentDesignTimeCore(RazorSourceDocument sourceDocument, string fileKind, IReadOnlyList<RazorSourceDocument> importSourceDocuments, IReadOnlyList<TagHelperDescriptor> tagHelpers)
         {
             if (sourceDocument == null)
             {
@@ -115,6 +120,11 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             var codeDocument = RazorCodeDocument.Create(sourceDocument, importSourceDocuments, parserOptions, codeGenerationOptions);
             codeDocument.SetTagHelpers(tagHelpers);
+
+            if (fileKind != null)
+            {
+                codeDocument.SetFileKind(fileKind);
+            }
 
             return codeDocument;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectFileSystem.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectFileSystem.cs
@@ -34,12 +34,13 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             return directory
                 .EnumerateFiles("*.cshtml", SearchOption.AllDirectories)
+                .Concat(directory.EnumerateFiles("*.razor", SearchOption.AllDirectories))
                 .Select(file =>
                 {
                     var relativePhysicalPath = file.FullName.Substring(absoluteBasePath.Length + 1); // Include leading separator
                     var filePath = "/" + relativePhysicalPath.Replace(Path.DirectorySeparatorChar, '/');
 
-                    return new DefaultRazorProjectItem(basePath, filePath, relativePhysicalPath, file);
+                    return new DefaultRazorProjectItem(basePath, filePath, relativePhysicalPath, fileKind: null, file);
                 });
         }
 
@@ -57,7 +58,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var relativePhysicalPath = file.FullName.Substring(absoluteBasePath.Length + 1); // Include leading separator
             var filePath = "/" + relativePhysicalPath.Replace(Path.DirectorySeparatorChar, '/');
 
-            return new DefaultRazorProjectItem("/", filePath, relativePhysicalPath, new FileInfo(absolutePath));
+            return new DefaultRazorProjectItem("/", filePath, relativePhysicalPath, fileKind: null, new FileInfo(absolutePath));
         }
 
         protected override string NormalizeAndEnsureValidPath(string path)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectItem.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectItem.cs
@@ -7,18 +7,22 @@ namespace Microsoft.AspNetCore.Razor.Language
 {
     internal class DefaultRazorProjectItem : RazorProjectItem
     {
+        private readonly string _fileKind;
+
         /// <summary>
         /// Initializes a new instance of <see cref="DefaultRazorProjectItem"/>.
         /// </summary>
         /// <param name="basePath">The base path.</param>
         /// <param name="relativePhysicalPath">The physical path of the base path.</param>
         /// <param name="filePath">The path.</param>
+        /// <param name="fileKind">The file kind. If null, the document kind will be inferred from the file extension.</param>
         /// <param name="file">The <see cref="FileInfo"/>.</param>
-        public DefaultRazorProjectItem(string basePath, string filePath, string relativePhysicalPath, FileInfo file)
+        public DefaultRazorProjectItem(string basePath, string filePath, string relativePhysicalPath, string fileKind, FileInfo file)
         {
             BasePath = basePath;
             FilePath = filePath;
             RelativePhysicalPath = relativePhysicalPath;
+            _fileKind = fileKind;
             File = file;
         }
 
@@ -33,6 +37,8 @@ namespace Microsoft.AspNetCore.Razor.Language
         public override string PhysicalPath => File.FullName;
 
         public override string RelativePhysicalPath { get; }
+
+        public override string FileKind => _fileKind ?? base.FileKind;
 
         public override Stream Read() => new FileStream(PhysicalPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/FileKinds.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/FileKinds.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.AspNetCore.Razor.Language.Intermediate
+namespace Microsoft.AspNetCore.Razor.Language
 {
-    internal static class InputDocumentKind
+    internal static class FileKinds
     {
         public static readonly string Component = "component";
 
-        public static readonly string MvcFile = "mvc";
+        public static readonly string Legacy = "mvc";
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/RazorCodeDocumentExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/RazorCodeDocumentExtensions.cs
@@ -169,24 +169,24 @@ namespace Microsoft.AspNetCore.Razor.Language
             document.Items[typeof(RazorCodeGenerationOptions)] = codeGenerationOptions;
         }
 
-        public static string GetInputDocumentKind(this RazorCodeDocument document)
+        public static string GetFileKind(this RazorCodeDocument document)
         {
             if (document == null)
             {
                 throw new ArgumentNullException(nameof(document));
             }
 
-            return (string)document.Items[typeof(InputDocumentKind)];
+            return (string)document.Items[typeof(FileKinds)];
         }
 
-        public static void SetInputDocumentKind(this RazorCodeDocument document, string kind)
+        public static void SetFileKind(this RazorCodeDocument document, string fileKind)
         {
             if (document == null)
             {
                 throw new ArgumentNullException(nameof(document));
             }
 
-            document.Items[typeof(InputDocumentKind)] = kind;
+            document.Items[typeof(FileKinds)] = fileKind;
         }
 
         private class ImportSyntaxTreesHolder

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngine.cs
@@ -35,14 +35,14 @@ namespace Microsoft.AspNetCore.Razor.Language
             return codeDocument;
         }
 
-        internal virtual RazorCodeDocument Process(RazorSourceDocument source, IReadOnlyList<RazorSourceDocument> importSources, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        internal virtual RazorCodeDocument Process(RazorSourceDocument source, string fileKind, IReadOnlyList<RazorSourceDocument> importSources, IReadOnlyList<TagHelperDescriptor> tagHelpers)
         {
             if (source == null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            var codeDocument = CreateCodeDocumentCore(source, importSources, tagHelpers);
+            var codeDocument = CreateCodeDocumentCore(source, fileKind, importSources, tagHelpers);
             ProcessCore(codeDocument);
             return codeDocument;
         }
@@ -59,30 +59,40 @@ namespace Microsoft.AspNetCore.Razor.Language
             return codeDocument;
         }
 
-        internal virtual RazorCodeDocument ProcessDesignTime(RazorSourceDocument source, IReadOnlyList<RazorSourceDocument> importSources, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        internal virtual RazorCodeDocument ProcessDesignTime(RazorSourceDocument source, string fileKind, IReadOnlyList<RazorSourceDocument> importSources, IReadOnlyList<TagHelperDescriptor> tagHelpers)
         {
             if (source == null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            var codeDocument = CreateCodeDocumentDesignTimeCore(source, importSources, tagHelpers);
+            var codeDocument = CreateCodeDocumentDesignTimeCore(source, fileKind, importSources, tagHelpers);
             ProcessCore(codeDocument);
             return codeDocument;
         }
 
         protected abstract RazorCodeDocument CreateCodeDocumentCore(RazorProjectItem projectItem);
 
-        internal virtual RazorCodeDocument CreateCodeDocumentCore(RazorSourceDocument source, IReadOnlyList<RazorSourceDocument> importSources, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        internal virtual RazorCodeDocument CreateCodeDocumentCore(RazorSourceDocument source, string fileKind, IReadOnlyList<RazorSourceDocument> importSources, IReadOnlyList<TagHelperDescriptor> tagHelpers)
         {
-            return RazorCodeDocument.Create(source, importSources);
+            var codeDocument = RazorCodeDocument.Create(source, importSources);
+            if (fileKind != null)
+            {
+                codeDocument.SetFileKind(fileKind);
+            }
+            return codeDocument;
         }
 
         protected abstract RazorCodeDocument CreateCodeDocumentDesignTimeCore(RazorProjectItem projectItem);
 
-        internal virtual RazorCodeDocument CreateCodeDocumentDesignTimeCore(RazorSourceDocument source, IReadOnlyList<RazorSourceDocument> importSources, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        internal virtual RazorCodeDocument CreateCodeDocumentDesignTimeCore(RazorSourceDocument source, string fileKind, IReadOnlyList<RazorSourceDocument> importSources, IReadOnlyList<TagHelperDescriptor> tagHelpers)
         {
-            return RazorCodeDocument.Create(source, importSources);
+            var codeDocument = RazorCodeDocument.Create(source, importSources);
+            if (fileKind != null)
+            {
+                codeDocument.SetFileKind(fileKind);
+            }
+            return codeDocument;
         }
 
         protected abstract void ProcessCore(RazorCodeDocument codeDocument);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/RazorProjectItem.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/RazorProjectItem.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using System.IO;
+using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -34,6 +37,28 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// physical path of the <see cref="BasePath"/>.
         /// </summary>
         public virtual string RelativePhysicalPath => null;
+
+        /// <summary>
+        /// Gets the document kind that should be used for the generated document. If possible this will be inferred from the file path. May be null.
+        /// </summary>
+        public virtual string FileKind
+        {
+            get
+            {
+                if (FilePath == null)
+                {
+                    return null;
+                }
+                else if (string.Equals(".razor", Path.GetExtension(FilePath), StringComparison.OrdinalIgnoreCase))
+                {
+                    return FileKinds.Component;
+                }
+                else
+                {
+                    return FileKinds.Legacy;
+                }
+            }
+        }
 
         /// <summary>
         /// Gets the file contents as readonly <see cref="Stream"/>.

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
@@ -381,7 +381,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
                 var projectEngine = project.GetProjectEngine();
 
-                var codeDocument = projectEngine.ProcessDesignTime(documentSource, importSources, tagHelpers);
+                var codeDocument = projectEngine.ProcessDesignTime(documentSource, fileKind: null, importSources, tagHelpers);
                 var csharpDocument = codeDocument.GetCSharpDocument();
 
                 // OK now we've generated the code. Let's check if the output is actually different. This is

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/Components/ComponentDocumentClassifierPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/Components/ComponentDocumentClassifierPassTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         {
             // Arrange
             var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create("some-content", "Test.razor"));
-            codeDocument.SetInputDocumentKind(InputDocumentKind.Component);
+            codeDocument.SetFileKind(FileKinds.Component);
 
             var projectEngine = CreateProjectEngine();
             var irDocument = CreateIRDocument(projectEngine, codeDocument);
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             // Arrange
             var properties = new RazorSourceDocumentProperties(filePath: "/MyApp/Test.razor", relativePath: "Test.razor");
             var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create("some-content", properties));
-            codeDocument.SetInputDocumentKind(InputDocumentKind.Component);
+            codeDocument.SetFileKind(FileKinds.Component);
 
             var projectEngine = CreateProjectEngine();
             var irDocument = CreateIRDocument(projectEngine, codeDocument);
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             // Arrange
             var properties = new RazorSourceDocumentProperties(filePath: "/MyApp/Test.razor", relativePath: "Test.razor");
             var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create("some-content", properties));
-            codeDocument.SetInputDocumentKind(InputDocumentKind.Component);
+            codeDocument.SetFileKind(FileKinds.Component);
 
             var projectEngine = CreateProjectEngine();
             var irDocument = CreateIRDocument(projectEngine, codeDocument);
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             var relativePath = "/Pages/Announcements/Banner.razor";
             var properties = new RazorSourceDocumentProperties(filePath: $"/MyApp{relativePath}", relativePath: relativePath);
             var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create("some-content", properties));
-            codeDocument.SetInputDocumentKind(InputDocumentKind.Component);
+            codeDocument.SetFileKind(FileKinds.Component);
 
             var projectEngine = CreateProjectEngine();
             var irDocument = CreateIRDocument(projectEngine, codeDocument);
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             // Arrange
             var properties = new RazorSourceDocumentProperties(filePath: @"x:\path.with+invalid-chars.razor", relativePath: "path.with+invalid-chars.razor");
             var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create("some-content", properties));
-            codeDocument.SetInputDocumentKind(InputDocumentKind.Component);
+            codeDocument.SetFileKind(FileKinds.Component);
 
             var projectEngine = CreateProjectEngine();
             var irDocument = CreateIRDocument(projectEngine, codeDocument);
@@ -134,7 +134,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         {
             // Arrange
             var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create("some-content", "Test.razor"));
-            codeDocument.SetInputDocumentKind(InputDocumentKind.Component);
+            codeDocument.SetFileKind(FileKinds.Component);
 
             var projectEngine = CreateProjectEngine();
             var irDocument = CreateIRDocument(projectEngine, codeDocument);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineIntegrationTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Moq;
 using Xunit;
 
@@ -110,12 +111,28 @@ namespace Microsoft.AspNetCore.Razor.Language
             var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
 
             // Act
-            var codeDocument = projectEngine.Process(RazorSourceDocument.ReadFrom(projectItem), expectedImports, expectedTagHelpers);
+            var codeDocument = projectEngine.Process(RazorSourceDocument.ReadFrom(projectItem), "test", expectedImports, expectedTagHelpers);
 
             // Assert
             var tagHelpers = codeDocument.GetTagHelpers();
             Assert.Same(expectedTagHelpers, tagHelpers);
             Assert.Equal(expectedImports, codeDocument.Imports);
+        }
+
+        [Fact]
+        public void Process_WithFileKind_SetsOnCodeDocument()
+        {
+            // Arrange
+            var projectItem = new TestRazorProjectItem("Index.cshtml");
+
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
+
+            // Act
+            var codeDocument = projectEngine.Process(RazorSourceDocument.ReadFrom(projectItem), "test", Array.Empty<RazorSourceDocument>(), tagHelpers: null);
+
+            // Assert
+            var actual = codeDocument.GetFileKind();
+            Assert.Equal("test", actual);
         }
 
         [Fact]
@@ -127,7 +144,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
 
             // Act
-            var codeDocument = projectEngine.Process(RazorSourceDocument.ReadFrom(projectItem), Array.Empty<RazorSourceDocument>(), tagHelpers: null);
+            var codeDocument = projectEngine.Process(RazorSourceDocument.ReadFrom(projectItem), "test", Array.Empty<RazorSourceDocument>(), tagHelpers: null);
 
             // Assert
             var tagHelpers = codeDocument.GetTagHelpers();
@@ -151,6 +168,38 @@ namespace Microsoft.AspNetCore.Razor.Language
         }
 
         [Fact]
+        public void Process_SetsInferredFileKindOnCodeDocument_MvcFile()
+        {
+            // Arrange
+            var projectItem = new TestRazorProjectItem("Index.cshtml");
+
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
+
+            // Act
+            var codeDocument = projectEngine.Process(projectItem);
+
+            // Assert
+            var actual = codeDocument.GetFileKind();
+            Assert.Same(FileKinds.Legacy, actual);
+        }
+
+        [Fact]
+        public void Process_SetsInferredFileKindOnCodeDocument_Component()
+        {
+            // Arrange
+            var projectItem = new TestRazorProjectItem("Index.razor");
+
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
+
+            // Act
+            var codeDocument = projectEngine.Process(projectItem);
+
+            // Assert
+            var actual = codeDocument.GetFileKind();
+            Assert.Same(FileKinds.Component, actual);
+        }
+
+        [Fact]
         public void Process_WithNullImports_SetsEmptyListOnCodeDocument()
         {
             // Arrange
@@ -159,7 +208,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
 
             // Act
-            var codeDocument = projectEngine.Process(RazorSourceDocument.ReadFrom(projectItem), importSources: null, tagHelpers: null);
+            var codeDocument = projectEngine.Process(RazorSourceDocument.ReadFrom(projectItem), "test", importSources: null, tagHelpers: null);
 
             // Assert
             Assert.Empty(codeDocument.Imports);
@@ -181,7 +230,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
 
             // Act
-            var codeDocument = projectEngine.ProcessDesignTime(RazorSourceDocument.ReadFrom(projectItem), expectedImports, expectedTagHelpers);
+            var codeDocument = projectEngine.ProcessDesignTime(RazorSourceDocument.ReadFrom(projectItem), "test", expectedImports, expectedTagHelpers);
 
             // Assert
             var tagHelpers = codeDocument.GetTagHelpers();
@@ -198,11 +247,43 @@ namespace Microsoft.AspNetCore.Razor.Language
             var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
 
             // Act
-            var codeDocument = projectEngine.ProcessDesignTime(RazorSourceDocument.ReadFrom(projectItem), Array.Empty<RazorSourceDocument>(), tagHelpers: null);
+            var codeDocument = projectEngine.ProcessDesignTime(RazorSourceDocument.ReadFrom(projectItem), "test", Array.Empty<RazorSourceDocument>(), tagHelpers: null);
 
             // Assert
             var tagHelpers = codeDocument.GetTagHelpers();
             Assert.Null(tagHelpers);
+        }
+
+        [Fact]
+        public void ProcessDesignTime_SetsInferredFileKindOnCodeDocument_MvcFile()
+        {
+            // Arrange
+            var projectItem = new TestRazorProjectItem("Index.cshtml");
+
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
+
+            // Act
+            var codeDocument = projectEngine.ProcessDesignTime(projectItem);
+
+            // Assert
+            var actual = codeDocument.GetFileKind();
+            Assert.Same(FileKinds.Legacy, actual);
+        }
+
+        [Fact]
+        public void ProcessDesignTime_SetsInferredFileKindOnCodeDocument_Component()
+        {
+            // Arrange
+            var projectItem = new TestRazorProjectItem("Index.razor");
+
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
+
+            // Act
+            var codeDocument = projectEngine.ProcessDesignTime(projectItem);
+
+            // Assert
+            var actual = codeDocument.GetFileKind();
+            Assert.Same(FileKinds.Component, actual);
         }
 
         [Fact]
@@ -230,7 +311,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
 
             // Act
-            var codeDocument = projectEngine.ProcessDesignTime(RazorSourceDocument.ReadFrom(projectItem), importSources: null, tagHelpers: null);
+            var codeDocument = projectEngine.ProcessDesignTime(RazorSourceDocument.ReadFrom(projectItem), "test", importSources: null, tagHelpers: null);
 
             // Assert
             Assert.Empty(codeDocument.Imports);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectItemTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectItemTest.cs
@@ -20,15 +20,55 @@ namespace Microsoft.AspNetCore.Razor.Language
             var fileInfo = new FileInfo(Path.Combine(TestFolder, "Home.cshtml"));
 
             // Act
-            var projectItem = new DefaultRazorProjectItem("/", "/Home.cshtml", "Home.cshtml", fileInfo);
+            var projectItem = new DefaultRazorProjectItem("/", "/Home.cshtml", "Home.cshtml", "test", fileInfo);
 
             // Assert
             Assert.Equal("/Home.cshtml", projectItem.FilePath);
             Assert.Equal("/", projectItem.BasePath);
             Assert.True(projectItem.Exists);
             Assert.Equal("Home.cshtml", projectItem.FileName);
+            Assert.Equal("test", projectItem.FileKind);
             Assert.Equal(fileInfo.FullName, projectItem.PhysicalPath);
             Assert.Equal("Home.cshtml", projectItem.RelativePhysicalPath);
+        }
+
+        [Fact]
+        public void DefaultRazorProjectItem_InfersFileKind_Component()
+        {
+            // Arrange
+            var fileInfo = new FileInfo(Path.Combine(TestFolder, "Home.cshtml"));
+
+            // Act
+            var projectItem = new DefaultRazorProjectItem("/", "/Home.razor", "Home.cshtml", fileKind: null, fileInfo);
+
+            // Assert
+            Assert.Equal(FileKinds.Component, projectItem.FileKind);
+        }
+
+        [Fact]
+        public void DefaultRazorProjectItem_InfersFileKind_Legacy()
+        {
+            // Arrange
+            var fileInfo = new FileInfo(Path.Combine(TestFolder, "Home.cshtml"));
+
+            // Act
+            var projectItem = new DefaultRazorProjectItem("/", "/Home.cshtml", "Home.cshtml", fileKind: null, fileInfo);
+
+            // Assert
+            Assert.Equal(FileKinds.Legacy, projectItem.FileKind);
+        }
+
+        [Fact]
+        public void DefaultRazorProjectItem_InfersFileKind_Null()
+        {
+            // Arrange
+            var fileInfo = new FileInfo(Path.Combine(TestFolder, "Home.cshtml"));
+
+            // Act
+            var projectItem = new DefaultRazorProjectItem("/", filePath: null, "Home.cshtml", fileKind: null, fileInfo);
+
+            // Assert
+            Assert.Null(projectItem.FileKind);
         }
 
         [Fact]
@@ -38,7 +78,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var fileInfo = new FileInfo(Path.Combine(TestFolder, "Views", "FileDoesNotExist.cshtml"));
 
             // Act
-            var projectItem = new DefaultRazorProjectItem("/Views", "/FileDoesNotExist.cshtml", Path.Combine("Views", "FileDoesNotExist.cshtml"), fileInfo);
+            var projectItem = new DefaultRazorProjectItem("/Views", "/FileDoesNotExist.cshtml", Path.Combine("Views", "FileDoesNotExist.cshtml"), "test", fileInfo);
 
             // Assert
             Assert.False(projectItem.Exists);
@@ -49,7 +89,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var fileInfo = new FileInfo(Path.Combine(TestFolder, "Home.cshtml"));
-            var projectItem = new DefaultRazorProjectItem("/", "/Home.cshtml", "Home.cshtml", fileInfo);
+            var projectItem = new DefaultRazorProjectItem("/", "/Home.cshtml", "Home.cshtml", "test", fileInfo);
 
             // Act
             var stream = projectItem.Read();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -941,7 +941,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             var imports = GetImports(projectEngine, projectItem);
 
             // Act
-            var codeDocument = projectEngine.Process(RazorSourceDocument.ReadFrom(projectItem), imports, descriptors.ToList());
+            var codeDocument = projectEngine.Process(RazorSourceDocument.ReadFrom(projectItem), FileKinds.Legacy, imports, descriptors.ToList());
 
             // Assert
             AssertDocumentNodeMatchesBaseline(codeDocument.GetDocumentIntermediateNode());
@@ -966,7 +966,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             var imports = GetImports(projectEngine, projectItem);
 
             // Act
-            var codeDocument = projectEngine.ProcessDesignTime(RazorSourceDocument.ReadFrom(projectItem), imports, descriptors.ToList());
+            var codeDocument = projectEngine.ProcessDesignTime(RazorSourceDocument.ReadFrom(projectItem), FileKinds.Legacy, imports, descriptors.ToList());
 
             // Assert
             AssertDocumentNodeMatchesBaseline(codeDocument.GetDocumentIntermediateNode());

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
         internal override bool UseTwoPhaseCompilation => true;
 
         protected ComponentCodeGenerationTestBase()
-            : base(generateBaselines: false)
+            : base(generateBaselines: null)
         {
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/ComponentIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/ComponentIntegrationTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
 
             public void Execute(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)
             {
-                codeDocument.SetInputDocumentKind(InputDocumentKind.Component);
+                codeDocument.SetFileKind(FileKinds.Component);
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/RazorBaselineIntegrationTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/RazorBaselineIntegrationTestBase.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
 #endif
         
         protected string TestProjectRoot { get; }
-
+        
         // For consistent line endings because the character counts are going to be recorded in files.
         internal override string LineEnding => "\r\n";
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/RazorIntegrationTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/RazorIntegrationTestBase.cs
@@ -60,7 +60,6 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             AdditionalSyntaxTrees = new List<SyntaxTree>();
             AdditionalRazorItems = new List<RazorProjectItem>();
 
-
             Configuration = RazorConfiguration.Default;
             FileSystem = new VirtualRazorProjectFileSystem();
             PathSeparator = Path.DirectorySeparatorChar.ToString();
@@ -82,6 +81,12 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
 
         internal virtual bool DesignTime { get; }
 
+        /// <summary>
+        /// Gets a hardcoded document kind to be added to each code document that's created. This can
+        /// be used to generate components.
+        /// </summary>
+        internal virtual string FileKind { get; }
+
         internal virtual VirtualRazorProjectFileSystem FileSystem { get; }
 
         // Used to force a specific style of line-endings for testing. This matters
@@ -98,7 +103,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
 
         internal virtual string WorkingDirectory { get; }
 
-        internal RazorProjectEngine CreateProjectEngine(RazorConfiguration configuration, MetadataReference[] references)
+        // intentionally private - we don't want individual tests messing with the project engine
+        private RazorProjectEngine CreateProjectEngine(RazorConfiguration configuration, MetadataReference[] references)
         {
             return RazorProjectEngine.Create(configuration, FileSystem, b =>
             {
@@ -138,7 +144,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                 filePath: filePath,
                 physicalPath: fullPath,
                 relativePhysicalPath: cshtmlRelativePath,
-                basePath: WorkingDirectory)
+                basePath: WorkingDirectory,
+                fileKind: FileKind)
             {
                 Content = cshtmlContent.TrimStart(),
             };

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/SuppressPrimaryMethodBodyntegrationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/SuppressPrimaryMethodBodyntegrationTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             public void Execute(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)
             {
-                codeDocument.SetInputDocumentKind(InputDocumentKind.Component);
+                codeDocument.SetFileKind(FileKinds.Component);
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestRazorProjectItem.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestRazorProjectItem.cs
@@ -8,19 +8,25 @@ namespace Microsoft.AspNetCore.Razor.Language
 {
     public class TestRazorProjectItem : RazorProjectItem
     {
+        private readonly string _fileKind;
+
         public TestRazorProjectItem(
             string filePath, 
             string physicalPath = null,
             string relativePhysicalPath = null,
-            string basePath = "/")
+            string basePath = "/",
+            string fileKind = null)
         {
             FilePath = filePath;
             PhysicalPath = physicalPath;
             RelativePhysicalPath = relativePhysicalPath;
             BasePath = basePath;
+            _fileKind = fileKind;
         }
 
         public override string BasePath { get; }
+
+        public override string FileKind => _fileKind ?? base.FileKind;
 
         public override string FilePath { get; }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorSyntaxFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorSyntaxFactsServiceTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Xunit;
 
 namespace Microsoft.VisualStudio.Editor.Razor
@@ -94,7 +95,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var sourceDocument = TestRazorSourceDocument.Create(source, normalizeNewLines: true);
             var importDocument = TestRazorSourceDocument.Create("@addTagHelper *, TestAssembly", filePath: "import.cshtml", relativePath: "import.cshtml");
 
-            var codeDocument = engine.ProcessDesignTime(sourceDocument, importSources: new []{ importDocument }, new []{ taghelper });
+            var codeDocument = engine.ProcessDesignTime(sourceDocument, FileKinds.Legacy, importSources: new []{ importDocument }, new []{ taghelper });
 
             return codeDocument;
         }


### PR DESCRIPTION
This is a bit of a rework of how we initially set this up, but with more
forethought to how this will work in the project system. I have not yet
surfaced this through VS.

My immediate next step is to light up the component integration tests
and something like this is on the critical path to get that work since
we need a way to specify in tests that a document should be treated as
a component.

