### PR TITLE
Name Razor's background parser thread.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundParser.cs
@@ -254,7 +254,10 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 _filePath = filePath;
                 _relativeFilePath = GetNormalizedRelativeFilePath(filePath, projectDirectory);
                 _projectDirectory = projectDirectory;
-                _backgroundThread = new Thread(WorkerLoop);
+                _backgroundThread = new Thread(WorkerLoop)
+                {
+                    Name = "Razor Background Document Parser"
+                };
                 SetThreadId(_backgroundThread.ManagedThreadId);
             }
 


### PR DESCRIPTION
- The background thread will eventually go away for Razor once we've moved to only using DocumentSnapshots. Until then, this is a simple stop gap to make identifying threads in Visual Studio easier.

Addresses aspnet/AspNetCore#6171