### PR TITLE
Provide a public entry point for Roslyn features

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Tools/DiscoverCommand.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Tools/DiscoverCommand.cs
@@ -141,12 +141,8 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 b.Features.Add(new DefaultMetadataReferenceFeature() { References = metadataReferences });
                 b.Features.Add(new CompilationTagHelperFeature());
                 b.Features.Add(new DefaultTagHelperDescriptorProvider());
-                b.Features.Add(new ComponentTagHelperDescriptorProvider());
-                b.Features.Add(new BindTagHelperDescriptorProvider());
-                b.Features.Add(new EventHandlerTagHelperDescriptorProvider());
-                b.Features.Add(new RefTagHelperDescriptorProvider());
 
-                b.Features.Add(new DefaultTypeNameFeature());
+                CompilerFeatures.Register(b);
             });
 
             var feature = engine.Engine.Features.OfType<ITagHelperFeature>().Single();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/CompilerFeatures.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/CompilerFeatures.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.CodeAnalysis.Razor
+{
+    /// <summary>
+    /// Provides access to built-in Razor features that require a reference to <c>Microsoft.CodeAnalysis.CSharp</c>.
+    /// </summary>
+    public static class CompilerFeatures
+    {
+        /// <summary>
+        /// Registers built-in Razor features that require a reference to <c>Microsoft.CodeAnalysis.CSharp</c>.
+        /// </summary>
+        /// <param name="builder">The <see cref="RazorProjectEngineBuilder"/>.</param>
+        public static void Register(RazorProjectEngineBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            
+            if (builder.Configuration.LanguageVersion.CompareTo(RazorLanguageVersion.Version_3_0) >= 0)
+            {
+                builder.Features.Add(new BindTagHelperDescriptorProvider());
+                builder.Features.Add(new ComponentTagHelperDescriptorProvider());
+                builder.Features.Add(new EventHandlerTagHelperDescriptorProvider());
+                builder.Features.Add(new RefTagHelperDescriptorProvider());
+
+                builder.Features.Add(new DefaultTypeNameFeature());
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorIntegrationTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorIntegrationTestBase.cs
@@ -126,12 +126,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                     References = references,
                 });
 
-                b.Features.Add(new ComponentTagHelperDescriptorProvider());
-                b.Features.Add(new BindTagHelperDescriptorProvider());
-                b.Features.Add(new EventHandlerTagHelperDescriptorProvider());
-                b.Features.Add(new RefTagHelperDescriptorProvider());
-
-                b.Features.Add(new DefaultTypeNameFeature());
+                CompilerFeatures.Register(b);
             });
         }
 


### PR DESCRIPTION
We need to be able to wire up these features from outside of the Razor
repo. For layering reasons this can't be done in the main Razor
assembly, so it can't be done by default.
