### PR TITLE
Fix lowering of data- with HTML for components

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -1255,6 +1255,27 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             public override void VisitMarkupTextLiteral(MarkupTextLiteralSyntax node)
             {
+                if (_builder.Current is HtmlAttributeIntermediateNode)
+                {
+                    // This can happen inside a data- attribute 
+                    _builder.Push(new HtmlAttributeValueIntermediateNode()
+                    {
+                        Prefix = string.Empty,
+                        Source = BuildSourceSpanFromNode(node),
+                    });
+
+                    _builder.Add(new IntermediateToken()
+                    {
+                        Content = node.GetContent() ?? string.Empty,
+                        Kind = TokenKind.Html,
+                        Source = BuildSourceSpanFromNode(node),
+                    });
+
+                    _builder.Pop();
+
+                    return;
+                }
+
                 var context = node.GetSpanContext();
                 if (context != null && context.ChunkGenerator == SpanChunkGenerator.Null)
                 {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.ir.txt
@@ -22,7 +22,7 @@ Document -
                     IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
                 MarkupElement - (45:3,0 [55] x:\dir\subdir\Test\TestComponent.cshtml) - elem
                     HtmlAttribute - (50:3,5 [25] x:\dir\subdir\Test\TestComponent.cshtml) -  data-abc=" - "
-                        HtmlContent - (61:3,16 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+                        HtmlAttributeValue - (61:3,16 [13] x:\dir\subdir\Test\TestComponent.cshtml) - 
                             IntermediateToken - (61:3,16 [13] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Literal value
                     HtmlAttribute - (75:3,30 [22] x:\dir\subdir\Test\TestComponent.cshtml) -  data-def=" - "
                         CSharpExpressionAttributeValue - (86:3,41 [10] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.ir.txt
@@ -22,7 +22,7 @@ Document -
                     IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
                 MarkupElement - (45:3,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - elem
                     HtmlAttribute - (50:3,5 [25] x:\dir\subdir\Test\TestComponent.cshtml) -  data-abc=" - "
-                        HtmlContent - (61:3,16 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+                        HtmlAttributeValue - (61:3,16 [13] x:\dir\subdir\Test\TestComponent.cshtml) - 
                             IntermediateToken - (61:3,16 [13] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Literal value
                     HtmlAttribute - (75:3,30 [20] x:\dir\subdir\Test\TestComponent.cshtml) -  data-def=" - "
                         CSharpExpressionAttributeValue - (86:3,41 [8] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.codegen.cs
@@ -21,9 +21,8 @@ namespace Test
 #line default
 #line hidden
             builder.OpenElement(0, "elem");
-            builder.AddContent(1, "Literal value");
-            builder.AddAttribute(2, "data-abc", true);
-            builder.AddAttribute(3, "data-def", myValue);
+            builder.AddAttribute(1, "data-abc", "Literal value");
+            builder.AddAttribute(2, "data-def", myValue);
             builder.CloseElement();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.ir.txt
@@ -13,7 +13,7 @@ Document -
                     IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
                 MarkupElement - (45:3,0 [55] x:\dir\subdir\Test\TestComponent.cshtml) - elem
                     HtmlAttribute - (50:3,5 [25] x:\dir\subdir\Test\TestComponent.cshtml) -  data-abc=" - "
-                        HtmlContent - (61:3,16 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+                        HtmlAttributeValue - (61:3,16 [13] x:\dir\subdir\Test\TestComponent.cshtml) - 
                             IntermediateToken - (61:3,16 [13] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Literal value
                     HtmlAttribute - (75:3,30 [22] x:\dir\subdir\Test\TestComponent.cshtml) -  data-def=" - "
                         CSharpExpressionAttributeValue - (86:3,41 [10] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.codegen.cs
@@ -21,9 +21,8 @@ namespace Test
 #line default
 #line hidden
             builder.OpenElement(0, "elem");
-            builder.AddContent(1, "Literal value");
-            builder.AddAttribute(2, "data-abc", true);
-            builder.AddAttribute(3, "data-def", myValue);
+            builder.AddAttribute(1, "data-abc", "Literal value");
+            builder.AddAttribute(2, "data-def", myValue);
             builder.CloseElement();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.ir.txt
@@ -13,7 +13,7 @@ Document -
                     IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
                 MarkupElement - (45:3,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - elem
                     HtmlAttribute - (50:3,5 [25] x:\dir\subdir\Test\TestComponent.cshtml) -  data-abc=" - "
-                        HtmlContent - (61:3,16 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+                        HtmlAttributeValue - (61:3,16 [13] x:\dir\subdir\Test\TestComponent.cshtml) - 
                             IntermediateToken - (61:3,16 [13] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Literal value
                     HtmlAttribute - (75:3,30 [20] x:\dir\subdir\Test\TestComponent.cshtml) -  data-def=" - "
                         CSharpExpressionAttributeValue - (86:3,41 [8] x:\dir\subdir\Test\TestComponent.cshtml) - 


### PR DESCRIPTION
This was missed in the previous attempt to fix data- attributes. HTML
wasn't being translated into the correct IR.
