### PR TITLE
Update xUnit and fix [Foreground(Fact|Theory)]

### DIFF
--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common.csproj
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common.csproj
@@ -10,6 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.core" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.extensibility.core" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.extensibility.execution" Version="$(XUnitVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(VSIX_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
   </ItemGroup>
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/Xunit/ForegroundFactDiscoverer.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/Xunit/ForegroundFactDiscoverer.cs
@@ -1,25 +1,21 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Xunit
 {
-    internal class ForegroundFactDiscoverer : IXunitTestCaseDiscoverer
+    internal class ForegroundFactDiscoverer : FactDiscoverer
     {
-        private readonly FactDiscoverer _inner;
-
         public ForegroundFactDiscoverer(IMessageSink diagnosticMessageSink)
+            : base(diagnosticMessageSink)
         {
-            _inner = new FactDiscoverer(diagnosticMessageSink);
         }
 
-        public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        protected override IXunitTestCase CreateTestCase(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
         {
-            return _inner.Discover(discoveryOptions, testMethod, factAttribute).Select(t => new ForegroundFactTestCase(t));
+            return new ForegroundTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod);
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/Xunit/ForegroundTestCase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/Xunit/ForegroundTestCase.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,52 +11,20 @@ using Xunit.Sdk;
 
 namespace Xunit
 {
-    internal class ForegroundFactTestCase : LongLivedMarshalByRefObject, IXunitTestCase
+    internal class ForegroundTestCase : XunitTestCase
     {
-        private IXunitTestCase _inner;
-
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Called by the de-serializer", error: true)]
-        public ForegroundFactTestCase()
+        public ForegroundTestCase()
         {
         }
 
-        public ForegroundFactTestCase(IXunitTestCase testCase)
+        public ForegroundTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
         {
-            _inner = testCase;
         }
 
-        public string DisplayName => _inner.DisplayName;
-
-        public IMethodInfo Method => _inner.Method;
-
-        public string SkipReason => _inner.SkipReason;
-
-        public ISourceInformation SourceInformation
-        {
-            get => _inner.SourceInformation;
-            set => _inner.SourceInformation = value;
-        }
-
-        public ITestMethod TestMethod => _inner.TestMethod;
-
-        public object[] TestMethodArguments => _inner.TestMethodArguments;
-
-        public Dictionary<string, List<string>> Traits => _inner.Traits;
-
-        public string UniqueID => _inner.UniqueID;
-
-        public void Deserialize(IXunitSerializationInfo info)
-        {
-            _inner = info.GetValue<IXunitTestCase>("InnerTestCase");
-        }
-
-        public void Serialize(IXunitSerializationInfo info)
-        {
-            info.AddValue("InnerTestCase", _inner);
-        }
-
-        public Task<RunSummary> RunAsync(
+        public override Task<RunSummary> RunAsync(
             IMessageSink diagnosticMessageSink,
             IMessageBus messageBus,
             object[] constructorArguments,
@@ -71,7 +38,7 @@ namespace Xunit
                 {
                     SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext());
                     
-                    var worker = _inner.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator, cancellationTokenSource);
+                    var worker = base.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator, cancellationTokenSource);
 
                     Exception caught = null;
                     var frame = new DispatcherFrame();

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/Xunit/ForegroundTheoryDiscoverer.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/Xunit/ForegroundTheoryDiscoverer.cs
@@ -2,24 +2,24 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Xunit
 {
-    internal class ForegroundTheoryDiscoverer : IXunitTestCaseDiscoverer
+    internal class ForegroundTheoryDiscoverer : TheoryDiscoverer
     {
-        private readonly TheoryDiscoverer _inner;
-
         public ForegroundTheoryDiscoverer(IMessageSink diagnosticMessageSink)
+            : base(diagnosticMessageSink)
         {
-            _inner = new TheoryDiscoverer(diagnosticMessageSink);
         }
 
-        public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
         {
-            return _inner.Discover(discoveryOptions, testMethod, factAttribute).Select(t => new ForegroundFactTestCase(t));
+            return new[]
+            {
+                new ForegroundTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, dataRow),
+            };
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/AwaitPeriodInsertionAcceptedProvisionally.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/AwaitPeriodInsertionAcceptedProvisionally.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..20)::20 - [foo @await Html. baz]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..15)::10
                     CSharpCodeBlock - [5..15)::10
-                        CSharpExpressionLiteral - [5..15)::10 - [await Html] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:AnyExceptNewline;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..15)::10 - [await Html] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:AnyExceptNewline;ImplicitExpression[RTD];K21
                             Keyword;[await];
                             Whitespace;[ ];
                             Identifier;[Html];

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprAcceptsDCIInStatementBlock.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprAcceptsDCIInStatementBlock.stree.txt
@@ -19,7 +19,7 @@ RazorDocument - [0..18)::18 - [@{LF    @DateT.LF}]
                                     Transition;[@];
                                 CSharpImplicitExpressionBody - [9..15)::6
                                     CSharpCodeBlock - [9..15)::6
-                                        CSharpExpressionLiteral - [9..15)::6 - [DateT.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[ATD];K20
+                                        CSharpExpressionLiteral - [9..15)::6 - [DateT.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[ATD];K21
                                             Identifier;[DateT];
                                             Dot;[.];
                         CSharpStatementLiteral - [15..17)::2 - [LF] - Gen<Stmt> - SpanEditHandler;Accepts:Any

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprAcceptsDCIInStatementBlock_1.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprAcceptsDCIInStatementBlock_1.stree.txt
@@ -19,7 +19,7 @@ RazorDocument - [0..21)::21 - [@{LF    @DateTime.LF}]
                                     Transition;[@];
                                 CSharpImplicitExpressionBody - [9..18)::9
                                     CSharpCodeBlock - [9..18)::9
-                                        CSharpExpressionLiteral - [9..18)::9 - [DateTime.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[ATD];K20
+                                        CSharpExpressionLiteral - [9..18)::9 - [DateTime.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[ATD];K21
                                             Identifier;[DateTime];
                                             Dot;[.];
                         CSharpStatementLiteral - [18..20)::2 - [LF] - Gen<Stmt> - SpanEditHandler;Accepts:Any

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprAcceptsDCIInStmtBlkAfterIdentifiers.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprAcceptsDCIInStmtBlkAfterIdentifiers.stree.txt
@@ -19,7 +19,7 @@ RazorDocument - [0..21)::21 - [@{LF    @DateTime.LF}]
                                     Transition;[@];
                                 CSharpImplicitExpressionBody - [9..18)::9
                                     CSharpCodeBlock - [9..18)::9
-                                        CSharpExpressionLiteral - [9..18)::9 - [DateTime.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[ATD];K20
+                                        CSharpExpressionLiteral - [9..18)::9 - [DateTime.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[ATD];K21
                                             Identifier;[DateTime];
                                             Dot;[.];
                         CSharpStatementLiteral - [18..20)::2 - [LF] - Gen<Stmt> - SpanEditHandler;Accepts:Any

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprAcceptsDCIInStmtBlkAfterIdentifiers_1.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprAcceptsDCIInStmtBlkAfterIdentifiers_1.stree.txt
@@ -19,7 +19,7 @@ RazorDocument - [0..22)::22 - [@{LF    @DateTime..LF}]
                                     Transition;[@];
                                 CSharpImplicitExpressionBody - [9..19)::10
                                     CSharpCodeBlock - [9..19)::10
-                                        CSharpExpressionLiteral - [9..19)::10 - [DateTime..] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[ATD];K20
+                                        CSharpExpressionLiteral - [9..19)::10 - [DateTime..] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[ATD];K21
                                             Identifier;[DateTime];
                                             Dot;[.];
                                             Dot;[.];

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprAcceptsDCIInStmtBlkAfterIdentifiers_2.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprAcceptsDCIInStmtBlkAfterIdentifiers_2.stree.txt
@@ -19,7 +19,7 @@ RazorDocument - [0..25)::25 - [@{LF    @DateTime.Now.LF}]
                                     Transition;[@];
                                 CSharpImplicitExpressionBody - [9..22)::13
                                     CSharpCodeBlock - [9..22)::13
-                                        CSharpExpressionLiteral - [9..22)::13 - [DateTime.Now.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[ATD];K20
+                                        CSharpExpressionLiteral - [9..22)::13 - [DateTime.Now.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[ATD];K21
                                             Identifier;[DateTime];
                                             Dot;[.];
                                             Identifier;[Now];

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprAcceptsIdentifierTypedAfterDotIfLastChangeProvisional.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprAcceptsIdentifierTypedAfterDotIfLastChangeProvisional.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..14)::14 - [foo @foo.b bar]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..10)::5
                     CSharpCodeBlock - [5..10)::5
-                        CSharpExpressionLiteral - [5..10)::5 - [foo.b] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..10)::5 - [foo.b] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[foo];
                             Dot;[.];
                             Identifier;[b];

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAccCaseInsensitiveDCI_NewRoslynIntegration.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAccCaseInsensitiveDCI_NewRoslynIntegration.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..14)::14 - [foo @date. baz]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..10)::5
                     CSharpCodeBlock - [5..10)::5
-                        CSharpExpressionLiteral - [5..10)::5 - [date.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..10)::5 - [date.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[date];
                             Dot;[.];
         MarkupTextLiteral - [10..14)::4 - [ baz] - Gen<Markup> - SpanEditHandler;Accepts:Any

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAccCaseInsensitiveDCI_NewRoslynIntegration_1.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAccCaseInsensitiveDCI_NewRoslynIntegration_1.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..13)::13 - [foo @date baz]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..9)::4
                     CSharpCodeBlock - [5..9)::4
-                        CSharpExpressionLiteral - [5..9)::4 - [date] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..9)::4 - [date] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[date];
         MarkupTextLiteral - [9..13)::4 - [ baz] - Gen<Markup> - SpanEditHandler;Accepts:Any
             Whitespace;[ ];

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAccCaseInsensitiveDCI_NewRoslynIntegration_2.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAccCaseInsensitiveDCI_NewRoslynIntegration_2.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..17)::17 - [foo @DateTime baz]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..13)::8
                     CSharpCodeBlock - [5..13)::8
-                        CSharpExpressionLiteral - [5..13)::8 - [DateTime] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..13)::8 - [DateTime] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[DateTime];
         MarkupTextLiteral - [13..17)::4 - [ baz] - Gen<Markup> - SpanEditHandler;Accepts:Any
             Whitespace;[ ];

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAccCaseInsensitiveDCI_NewRoslynIntegration_3.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAccCaseInsensitiveDCI_NewRoslynIntegration_3.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..18)::18 - [foo @DateTime. baz]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..14)::9
                     CSharpCodeBlock - [5..14)::9
-                        CSharpExpressionLiteral - [5..14)::9 - [DateTime.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..14)::9 - [DateTime.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[DateTime];
                             Dot;[.];
         MarkupTextLiteral - [14..18)::4 - [ baz] - Gen<Markup> - SpanEditHandler;Accepts:Any

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAccCaseInsensitiveDCI_NewRoslynIntegration_4.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAccCaseInsensitiveDCI_NewRoslynIntegration_4.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..18)::18 - [foo @DateTime. baz]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..13)::8
                     CSharpCodeBlock - [5..13)::8
-                        CSharpExpressionLiteral - [5..13)::8 - [DateTime] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..13)::8 - [DateTime] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[DateTime];
         MarkupTextLiteral - [13..18)::5 - [. baz] - Gen<Markup> - SpanEditHandler;Accepts:Any
             Text;[.];

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCI.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCI.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..15)::15 - [foo @DateT. baz]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..11)::6
                     CSharpCodeBlock - [5..11)::6
-                        CSharpExpressionLiteral - [5..11)::6 - [DateT.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..11)::6 - [DateT.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[DateT];
                             Dot;[.];
         MarkupTextLiteral - [11..15)::4 - [ baz] - Gen<Markup> - SpanEditHandler;Accepts:Any

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCIAfterIdentifiers.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCIAfterIdentifiers.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..18)::18 - [foo @DateTime. baz]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..14)::9
                     CSharpCodeBlock - [5..14)::9
-                        CSharpExpressionLiteral - [5..14)::9 - [DateTime.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..14)::9 - [DateTime.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[DateTime];
                             Dot;[.];
         MarkupTextLiteral - [14..18)::4 - [ baz] - Gen<Markup> - SpanEditHandler;Accepts:Any

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCIAfterIdentifiers_1.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCIAfterIdentifiers_1.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..19)::19 - [foo @DateTime.. baz]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..15)::10
                     CSharpCodeBlock - [5..15)::10
-                        CSharpExpressionLiteral - [5..15)::10 - [DateTime..] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..15)::10 - [DateTime..] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[DateTime];
                             Dot;[.];
                             Dot;[.];

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCIAfterIdentifiers_2.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCIAfterIdentifiers_2.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..22)::22 - [foo @DateTime.Now. baz]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..18)::13
                     CSharpCodeBlock - [5..18)::13
-                        CSharpExpressionLiteral - [5..18)::13 - [DateTime.Now.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..18)::13 - [DateTime.Now.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[DateTime];
                             Dot;[.];
                             Identifier;[Now];

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCIAfterIdentifiers_3.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCIAfterIdentifiers_3.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..22)::22 - [foo @DateTime.Now. baz]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..17)::12
                     CSharpCodeBlock - [5..17)::12
-                        CSharpExpressionLiteral - [5..17)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..17)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[DateTime];
                             Dot;[.];
                             Identifier;[Now];

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCI_1.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCI_1.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..18)::18 - [foo @DateTime. baz]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..14)::9
                     CSharpCodeBlock - [5..14)::9
-                        CSharpExpressionLiteral - [5..14)::9 - [DateTime.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..14)::9 - [DateTime.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[DateTime];
                             Dot;[.];
         MarkupTextLiteral - [14..18)::4 - [ baz] - Gen<Markup> - SpanEditHandler;Accepts:Any

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCI_2.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCI_2.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..18)::18 - [foo @DateTime. baz]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..13)::8
                     CSharpCodeBlock - [5..13)::8
-                        CSharpExpressionLiteral - [5..13)::8 - [DateTime] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..13)::8 - [DateTime] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[DateTime];
         MarkupTextLiteral - [13..18)::5 - [. baz] - Gen<Markup> - SpanEditHandler;Accepts:Any
             Text;[.];

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprRejectsAcceptableChangeIfPrevWasProvisionallyAccepted.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprRejectsAcceptableChangeIfPrevWasProvisionallyAccepted.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..15)::15 - [foo @foo. @barb]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..8)::3
                     CSharpCodeBlock - [5..8)::3
-                        CSharpExpressionLiteral - [5..8)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..8)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[foo];
         MarkupTextLiteral - [8..10)::2 - [. ] - Gen<Markup> - SpanEditHandler;Accepts:Any
             Text;[.];
@@ -20,7 +20,7 @@ RazorDocument - [0..15)::15 - [foo @foo. @barb]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [11..15)::4
                     CSharpCodeBlock - [11..15)::4
-                        CSharpExpressionLiteral - [11..15)::4 - [barb] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [11..15)::4 - [barb] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[barb];
         MarkupTextLiteral - [15..15)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
             Marker;[];

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExpr_AcceptsParenthesisAtEnd_SingleEdit.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExpr_AcceptsParenthesisAtEnd_SingleEdit.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..14)::14 - [foo @foo() bar]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..10)::5
                     CSharpCodeBlock - [5..10)::5
-                        CSharpExpressionLiteral - [5..10)::5 - [foo()] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..10)::5 - [foo()] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[foo];
                             LeftParenthesis;[(];
                             RightParenthesis;[)];

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExpr_AcceptsParenthesisAtEnd_TwoEdits.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExpr_AcceptsParenthesisAtEnd_TwoEdits.stree.txt
@@ -9,7 +9,7 @@ RazorDocument - [0..14)::14 - [foo @foo() bar]
                     Transition;[@];
                 CSharpImplicitExpressionBody - [5..10)::5
                     CSharpCodeBlock - [5..10)::5
-                        CSharpExpressionLiteral - [5..10)::5 - [foo()] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K20
+                        CSharpExpressionLiteral - [5..10)::5 - [foo()] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
                             Identifier;[foo];
                             LeftParenthesis;[(];
                             RightParenthesis;[)];

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorProjectHostTest.cs
@@ -601,9 +601,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             Assert.Equal(expectedLanguageVersion, configuration.LanguageVersion);
             Assert.Equal(expectedConfigurationName, configuration.ConfigurationName);
             Assert.Collection(
-                configuration.Extensions,
-                extension => Assert.Equal(expectedExtension2Name, extension.ExtensionName),
-                extension => Assert.Equal(expectedExtension1Name, extension.ExtensionName));
+                configuration.Extensions.OrderBy(e => e.ExtensionName),
+                extension => Assert.Equal(expectedExtension1Name, extension.ExtensionName),
+                extension => Assert.Equal(expectedExtension2Name, extension.ExtensionName));
         }
 
         [ForegroundFact]
@@ -696,9 +696,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
             Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
             Assert.Collection(
-                snapshot.Configuration.Extensions,
-                e => Assert.Equal("MVC-2.1", e.ExtensionName),
-                e => Assert.Equal("Another-Thing", e.ExtensionName));
+                snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
+                e => Assert.Equal("Another-Thing", e.ExtensionName),
+                e => Assert.Equal("MVC-2.1", e.ExtensionName));
 
             Assert.Collection(
                 snapshot.DocumentFilePaths.OrderBy(d => d),
@@ -792,9 +792,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
             Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
             Assert.Collection(
-                snapshot.Configuration.Extensions,
-                e => Assert.Equal("MVC-2.1", e.ExtensionName),
-                e => Assert.Equal("Another-Thing", e.ExtensionName));
+                snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
+                e => Assert.Equal("Another-Thing", e.ExtensionName),
+                e => Assert.Equal("MVC-2.1", e.ExtensionName));
 
             Assert.Collection(
                 snapshot.DocumentFilePaths.OrderBy(d => d),
@@ -833,7 +833,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             Assert.Equal(RazorLanguageVersion.Version_2_0, snapshot.Configuration.LanguageVersion);
             Assert.Equal("MVC-2.0", snapshot.Configuration.ConfigurationName);
             Assert.Collection(
-                snapshot.Configuration.Extensions,
+                snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
                 e => Assert.Equal("Another-Thing", e.ExtensionName),
                 e => Assert.Equal("MVC-2.0", e.ExtensionName));
 
@@ -897,9 +897,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
             Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
             Assert.Collection(
-                snapshot.Configuration.Extensions,
-                e => Assert.Equal("MVC-2.1", e.ExtensionName),
-                e => Assert.Equal("Another-Thing", e.ExtensionName));
+                snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
+                e => Assert.Equal("Another-Thing", e.ExtensionName),
+                e => Assert.Equal("MVC-2.1", e.ExtensionName));
 
             // Act - 2
             RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "");
@@ -963,9 +963,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
             Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
             Assert.Collection(
-                snapshot.Configuration.Extensions,
-                e => Assert.Equal("MVC-2.1", e.ExtensionName),
-                e => Assert.Equal("Another-Thing", e.ExtensionName));
+                snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
+                e => Assert.Equal("Another-Thing", e.ExtensionName),
+                e => Assert.Equal("MVC-2.1", e.ExtensionName));
 
             // Act - 2
             await Task.Run(async () => await host.DisposeAsync());

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Serialization/ProjectSnapshotHandleSerializationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Serialization/ProjectSnapshotHandleSerializationTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Serialization
             Assert.Equal(snapshot.FilePath, obj.FilePath);
             Assert.Equal(snapshot.Configuration.ConfigurationName, obj.Configuration.ConfigurationName);
             Assert.Collection(
-                snapshot.Configuration.Extensions, 
+                snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName), 
                 e => Assert.Equal("Test-Extension1", e.ExtensionName),
                 e => Assert.Equal("Test-Extension2", e.ExtensionName));
             Assert.Equal(snapshot.Configuration.LanguageVersion, obj.Configuration.LanguageVersion);


### PR DESCRIPTION
xUnit made a breaking change to some extensibility APIs in 2.4.1 that we
use. Since dotnet/Arcade uses this version to run, it was skipping all
of our [Foreground...] tests :(.

The changes to baselines here are expected. We added a new directive as
part of the components work, but these updates were missed because the
tests weren't being run.

Summary of the changes (Less than 80 chars)
 - Detail 1
 - Detail 2

Addresses #bugnumber (in this specific format)
