### PR TITLE
Use Semver 1 for packages

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,6 +17,7 @@
     <MajorVersion>3</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <SemanticVersioningV1>true</SemanticVersioningV1>
   </PropertyGroup>
   <!-- 
     Versioning for tooling releases.


### PR DESCRIPTION
We're deciding to use semver1 for the prerelease version of 3.0 since we
shipped preview1 that way. We don't want to swap to semver2 and have
preview2 show up on nuget.org with a *lower* version than we had in
preview1.

We'll go back to semver2 after 3.0 goes RTM
