### PR TITLE
SDK updates for components tooling

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.DesignTime.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.DesignTime.targets
@@ -59,8 +59,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target 
     Name="RazorGenerateDesignTime" 
-    DependsOnTargets="ResolveRazorGenerateInputs;AssignRazorGenerateTargetPaths;ResolveRazorComponentInputs;AssignRazorComponentTargetPaths" 
-    Returns="@(RazorGenerateWithTargetPath);@(RazorComponentWithTargetPath)">
+    DependsOnTargets="ResolveRazorGenerateInputs;AssignRazorGenerateTargetPaths" 
+    Returns="@(RazorGenerateWithTargetPath)">
+  </Target>
+
+  <Target 
+    Name="RazorGenerateComponentDesignTime" 
+    DependsOnTargets="ResolveRazorComponentInputs;AssignRazorComponentTargetPaths" 
+    Returns="@(RazorComponentWithTargetPath)">
   </Target>
 
 </Project>

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Rules/RazorComponentWithTargetPath.xaml
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Rules/RazorComponentWithTargetPath.xaml
@@ -2,14 +2,14 @@
 <Rule
   Description="Razor Document Properties"
   DisplayName="Razor Document Properties"
-  Name="RazorGenerateWithTargetPath"
+  Name="RazorComponentWithTargetPath"
   PageTemplate="generic"
   xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource
       Persistence="ProjectFile"
       ItemType="RazorComponentWithTargetPath"
-      MSBuildTarget="RazorGenerateDesignTime"
+      MSBuildTarget="RazorGenerateComponentDesignTime"
       HasConfigurationCondition="False"
       SourceOfDefaultValue="AfterContext"
       SourceType="TargetResults" />

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/Rules/RazorComponentWithTargetPath.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/Rules/RazorComponentWithTargetPath.cs
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem.Rules
                         if (System.StringComparer.OrdinalIgnoreCase.Equals(t.Name, SchemaName))
                         {
                             unboundRule = t;
-                            unboundRule.Name = "afc049b55685346f1feb0214edab55c673619e1738da3fd683d5ddabd635876e";
+                            unboundRule.Name = "7bce92b9d442fe435263d738937cc0845b32e8219c968e23697081db5a869f4a";
                             RazorComponentWithTargetPath.deserializedFallbackRule = unboundRule;
                         }
                     }

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/DesignTimeBuildIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/DesignTimeBuildIntegrationTest.cs
@@ -67,11 +67,11 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
         [Fact]
         [InitializeTestProject("ComponentLibrary")]
-        public async Task RazorGenerateDesignTime_ReturnsRazorComponentWithTargetPath()
+        public async Task RazorGenerateComponentDesignTime_ReturnsRazorComponentWithTargetPath()
         {
             TargetFramework = "netstandard2.0";
 
-            var result = await DotnetMSBuild("RazorGenerateDesignTime;_IntrospectRazorComponentWithTargetPath");
+            var result = await DotnetMSBuild("RazorGenerateComponentDesignTime;_IntrospectRazorComponentWithTargetPath");
 
             Assert.BuildPassed(result);
 

--- a/src/Razor/test/testapps/ComponentLibrary/ComponentLibrary.csproj
+++ b/src/Razor/test/testapps/ComponentLibrary/ComponentLibrary.csproj
@@ -42,6 +42,10 @@
       <RazorGenerate Remove="@(RazorGenerate)" />
     </ItemGroup>
   </Target>
+
+  <ItemGroup>
+    <ProjectCapability Include="DotNetCoreRazorConfiguration" />
+  </ItemGroup>
   <!--
     END COMPONENT .cshtml WORKAROUND
   -->


### PR DESCRIPTION
This is a bug fix for the RazorComponentWithTargetPath xaml rule. We
need to have separate targets for components and views.

The other fix here is a change to the set of workarounds we're using for
components currently. We need this project capability for the correct
project host to be used when loading the project.
