### PR TITLE
Wait for parse for directive completion.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorDirectiveCompletionSource.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorDirectiveCompletionSource.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             _completionFactsService = completionFactsService;
         }
 
-        public Task<CompletionContext> GetCompletionContextAsync(
+        public async Task<CompletionContext> GetCompletionContextAsync(
             IAsyncCompletionSession session,
             CompletionTrigger trigger,
             SnapshotPoint triggerLocation,
@@ -70,7 +70,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             _foregroundDispatcher.AssertBackgroundThread();
 
-            var syntaxTree = _parser.CodeDocument?.GetSyntaxTree();
+            var codeDocument = await _parser.GetLatestCodeDocumentAsync();
+            var syntaxTree = codeDocument?.GetSyntaxTree();
             var location = new SourceSpan(applicableSpan.Start.Position, applicableSpan.Length);
             var razorCompletionItems = _completionFactsService.GetCompletionItems(syntaxTree, location);
 
@@ -97,7 +98,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 completionItems.Add(completionItem);
             }
             var context = new CompletionContext(completionItems.ToImmutableArray());
-            return Task.FromResult(context);
+            return context;
         }
 
         public Task<object> GetDescriptionAsync(IAsyncCompletionSession session, CompletionItem item, CancellationToken token)

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioRazorParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioRazorParser.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.VisualStudio.Text;
 
@@ -22,5 +23,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
         public abstract bool HasPendingChanges { get; }
 
         public abstract void QueueReparse();
+
+        public virtual Task<RazorCodeDocument> GetLatestCodeDocumentAsync() => throw new NotImplementedException();
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorDirectiveCompletionSourceTest.cs
@@ -33,8 +33,10 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             // Arrange
             var text = "@validCompletion";
-            var parser = Mock.Of<VisualStudioRazorParser>(); // CodeDocument will be null faking a parser without a parse.
-            var completionSource = new RazorDirectiveCompletionSource(Dispatcher, parser, CompletionFactsService);
+            var parser = new Mock<VisualStudioRazorParser>();
+            parser.Setup(p => p.GetLatestCodeDocumentAsync())
+                .Returns(Task.FromResult<RazorCodeDocument>(null)); // CodeDocument will be null faking a parser without a parse.
+            var completionSource = new RazorDirectiveCompletionSource(Dispatcher, parser.Object, CompletionFactsService);
             var documentSnapshot = new StringTextSnapshot(text);
             var triggerLocation = new SnapshotPoint(documentSnapshot, 4);
             var applicableSpan = new SnapshotSpan(documentSnapshot, new Span(1, text.Length - 1 /* validCompletion */));
@@ -153,9 +155,11 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var syntaxTree = CreateSyntaxTree(text, directives);
             var codeDocument = TestRazorCodeDocument.Create(text);
             codeDocument.SetSyntaxTree(syntaxTree);
-            var parser = Mock.Of<VisualStudioRazorParser>(p => p.CodeDocument == codeDocument);
+            var parser = new Mock<VisualStudioRazorParser>();
+            parser.Setup(p => p.GetLatestCodeDocumentAsync())
+                .Returns(Task.FromResult(codeDocument));
 
-            return parser;
+            return parser.Object;
         }
 
         private static RazorSyntaxTree CreateSyntaxTree(string text, params DirectiveDescriptor[] directives)


### PR DESCRIPTION
- Prior to this parses would take the currently available syntax tree and make decisions on if a cursor location was valid to provide directive completions. In the case that you were typing the page directive and you typed `@pa` there were times when the latest code document known was the one for the `@` symbol and a parse was being processed for the `pa` inclusion. Because of this our directive completion would be asked for completions after the `pa` at which point we wouldn't find a valid owner because the syntax tree would be out of date. These changes introduce `GetLatestCodeDocumentAsync` to work around this issue.
- `GetLatestCodeDocumentAsync`uses task completion sources and the already-existing HasPendingChanges flags to ensure that a caller gets the latest code document.
- Added tests to validate `GetLatestCodeDocumentAsync` works as expected.
- Updated directive completion tests to expect the new behavior.

#6408

/cc @ToddGrun