### PR TITLE
Reenable skipped test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,7 @@ resources:
   containers:
   - container: LinuxContainer
     image: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
+    options: --init # This ensures all the stray defunct processes are reaped.
 
 trigger:
 - master

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerIntegrationTest.cs
@@ -141,9 +141,8 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         }
 
         // Skipping on MacOS because of https://github.com/dotnet/corefx/issues/33141.
-        // Skipping on Linux because of https://github.com/aspnet/Razor/issues/2525.
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         [InitializeTestProject("SimpleMvc")]
         public async Task ManualServerShutdown_NoPipeName_ShutsDownServer()
         {


### PR DESCRIPTION
~Just testing if this still fails.~

Looks like we needed to pass `--init` to the docker run command which spins up a PID 1 process that takes care of ending defunct processes in the container.