### PR TITLE
Exclude RazorComponent items from RazorGenerate item group

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -367,7 +367,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <ItemGroup Condition="'$(EnableDefaultRazorGenerateItems)'=='true'">
-      <RazorGenerate Include="@(Content)" Condition="'%(Content.Extension)'=='.cshtml'" />
+      <RazorGenerate
+        Include="@(Content)"
+        Exclude="@(RazorComponent)"
+        Condition="'%(Content.Extension)'=='.cshtml'" />
     </ItemGroup>
 
     <!--

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/Assert.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/Assert.cs
@@ -397,25 +397,24 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 throw new ArgumentNullException(nameof(result));
             }
 
+            assemblyPath = Path.Combine(result.Project.DirectoryPath, Path.Combine(assemblyPath));
+
             var typeNames = GetDeclaredTypeNames(assemblyPath);
             Assert.DoesNotContain(fullTypeName, typeNames);
         }
 
         private static IEnumerable<string> GetDeclaredTypeNames(string assemblyPath)
         {
-            IEnumerable<string> typeNames;
             using (var file = File.OpenRead(assemblyPath))
             {
                 var peReader = new PEReader(file);
                 var metadataReader = peReader.GetMetadataReader();
-                typeNames = metadataReader.TypeDefinitions.Where(t => !t.IsNil).Select(t =>
+                return metadataReader.TypeDefinitions.Where(t => !t.IsNil).Select(t =>
                 {
                     var type = metadataReader.GetTypeDefinition(t);
                     return metadataReader.GetString(type.Namespace) + "." + metadataReader.GetString(type.Name);
-                });
+                }).ToArray();
             }
-
-            return typeNames;
         }
 
         private abstract class MSBuildXunitException : Xunit.Sdk.XunitException

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/Assert.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/Assert.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -384,18 +385,37 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             }
 
             assemblyPath = Path.Combine(result.Project.DirectoryPath, Path.Combine(assemblyPath));
+
+            var typeNames = GetDeclaredTypeNames(assemblyPath);
+            Assert.Contains(fullTypeName, typeNames);
+        }
+
+        public static void AssemblyDoesNotContainType(MSBuildResult result, string assemblyPath, string fullTypeName)
+        {
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
+            var typeNames = GetDeclaredTypeNames(assemblyPath);
+            Assert.DoesNotContain(fullTypeName, typeNames);
+        }
+
+        private static IEnumerable<string> GetDeclaredTypeNames(string assemblyPath)
+        {
+            IEnumerable<string> typeNames;
             using (var file = File.OpenRead(assemblyPath))
             {
                 var peReader = new PEReader(file);
                 var metadataReader = peReader.GetMetadataReader();
-                var typeNames = metadataReader.TypeDefinitions.Where(t => !t.IsNil).Select(t =>
+                typeNames = metadataReader.TypeDefinitions.Where(t => !t.IsNil).Select(t =>
                 {
                     var type = metadataReader.GetTypeDefinition(t);
                     return metadataReader.GetString(type.Namespace) + "." + metadataReader.GetString(type.Name);
                 });
-
-                Assert.Contains(fullTypeName, typeNames);
             }
+
+            return typeNames;
         }
 
         private abstract class MSBuildXunitException : Xunit.Sdk.XunitException

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildWithComponentsIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildWithComponentsIntegrationTest.cs
@@ -36,8 +36,16 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
             Assert.AssemblyContainsType(result, Path.Combine(OutputPath, "MvcWithComponents.dll"), "MvcWithComponents.TestComponent");
             Assert.AssemblyContainsType(result, Path.Combine(OutputPath, "MvcWithComponents.dll"), "MvcWithComponents.Views.Shared.NavMenu");
+
+            // This is a component file with a .cshtml extension. It should appear in the main assembly, but not in the views dll.
             Assert.AssemblyContainsType(result, Path.Combine(OutputPath, "MvcWithComponents.dll"), "MvcWithComponents.Components.Counter");
-            Assert.AssemblyDoesNotContainType(result, Path.Combine(OutputPath, "MvcWithComponents.dll"), "MvcWithComponents.Views.Home.Index");
+            Assert.AssemblyDoesNotContainType(result, Path.Combine(OutputPath, "MvcWithComponents.Views.dll"), "MvcWithComponents.Components.Counter");
+            Assert.AssemblyDoesNotContainType(result, Path.Combine(OutputPath, "MvcWithComponents.Views.dll"), "AspNetCore.Components_Counter");
+
+            // Verify a regular View appears in the views dll, but not in the main assembly.
+            Assert.AssemblyDoesNotContainType(result, Path.Combine(OutputPath, "MvcWithComponents.dll"), "AspNetCore.Views.Home.Index");
+            Assert.AssemblyDoesNotContainType(result, Path.Combine(OutputPath, "MvcWithComponents.dll"), "AspNetCore.Views_Home_Index");
+            Assert.AssemblyContainsType(result, Path.Combine(OutputPath, "MvcWithComponents.Views.dll"), "AspNetCore.Views_Home_Index");
         }
     }
 }

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildWithComponentsIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildWithComponentsIntegrationTest.cs
@@ -36,6 +36,8 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
             Assert.AssemblyContainsType(result, Path.Combine(OutputPath, "MvcWithComponents.dll"), "MvcWithComponents.TestComponent");
             Assert.AssemblyContainsType(result, Path.Combine(OutputPath, "MvcWithComponents.dll"), "MvcWithComponents.Views.Shared.NavMenu");
+            Assert.AssemblyContainsType(result, Path.Combine(OutputPath, "MvcWithComponents.dll"), "MvcWithComponents.Components.Counter");
+            Assert.AssemblyDoesNotContainType(result, Path.Combine(OutputPath, "MvcWithComponents.dll"), "MvcWithComponents.Views.Home.Index");
         }
     }
 }

--- a/src/Razor/test/testapps/ComponentLibrary/ComponentLibrary.csproj
+++ b/src/Razor/test/testapps/ComponentLibrary/ComponentLibrary.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <RazorComponent Include="@(Content->WithMetadataValue('Extension', '.cshtml'))" />
+    <RazorComponent Include="**/*.cshtml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/test/testapps/ComponentLibrary/ComponentLibrary.csproj
+++ b/src/Razor/test/testapps/ComponentLibrary/ComponentLibrary.csproj
@@ -27,28 +27,13 @@
     <Reference Include="$(BinariesRoot)\Microsoft.AspNetCore.Razor.Test.ComponentShim.dll"/>
   </ItemGroup>
 
-  <!-- 
-    BEGIN COMPONENT .cshtml WORKAROUND
-
-    This is the current workaround used by the components codebase to treat .cshtml files as components
-    so that we can have tooling support. Testing it here so it won't break.
-  -->
   <ItemGroup>
     <RazorComponent Include="@(Content->WithMetadataValue('Extension', '.cshtml'))" />
   </ItemGroup>
 
-  <Target Name="_RemoveFilesFromRazorGenerate" AfterTargets="ResolveRazorGenerateInputs">
-    <ItemGroup>
-      <RazorGenerate Remove="@(RazorGenerate)" />
-    </ItemGroup>
-  </Target>
-
   <ItemGroup>
     <ProjectCapability Include="DotNetCoreRazorConfiguration" />
   </ItemGroup>
-  <!--
-    END COMPONENT .cshtml WORKAROUND
-  -->
 
   <!-- Test Placeholder -->
 

--- a/src/Razor/test/testapps/MvcWithComponents/Components/Counter.cshtml
+++ b/src/Razor/test/testapps/MvcWithComponents/Components/Counter.cshtml
@@ -1,0 +1,1 @@
+This file should produce a component

--- a/src/Razor/test/testapps/MvcWithComponents/MvcWithComponents.csproj
+++ b/src/Razor/test/testapps/MvcWithComponents/MvcWithComponents.csproj
@@ -29,6 +29,10 @@
     <Reference Include="$(BinariesRoot)\Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib.dll"/>
   </ItemGroup>
 
+  <ItemGroup>
+    <RazorComponent Include="Components/**/*.cshtml" />
+  </ItemGroup>
+
   <!-- Test Placeholder -->
 
 </Project>


### PR DESCRIPTION
Interim solution to allow components to share the .cshtml extension. When declared in
the project file, the SDK will prevent RazorComponent items from being included
in the RazorGenerate itemgroup.
