### PR TITLE
Remove workarounds for missing 3.0 support

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Configuration.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Configuration.targets
@@ -54,12 +54,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup Condition="'$(RazorLangVersion)'==''">
     <RazorLangVersion Condition="'$(_TargetingNETCoreApp30OrLater)' == 'true'">3.0</RazorLangVersion>
-
-    <!--
-      For dev16 the Razor toolings bits don't currently understand 3.0 projects. Therefore, we default to 2.1 which is currently
-      functionally equivalent. This will be undone in the near future.
-    -->
-    <RazorLangVersion Condition="'$(_TargetingNETCoreApp30OrLater)' == 'true' AND '$(DesignTimeBuild)' == 'true'">2.1</RazorLangVersion>
   </PropertyGroup>
 
   <!--
@@ -67,12 +61,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <PropertyGroup Condition="'$(RazorDefaultConfiguration)'==''">
     <RazorDefaultConfiguration Condition="'$(_TargetingNETCoreApp30OrLater)' == 'true'">MVC-3.0</RazorDefaultConfiguration>
-
-    <!--
-      For dev16 the Razor toolings bits don't currently understand 3.0 projects. Therefore, we default to 2.1 which is currently
-      functionally equivalent. This will be undone in the near future.
-    -->
-    <RazorDefaultConfiguration Condition="'$(_TargetingNETCoreApp30OrLater)' == 'true' AND '$(DesignTimeBuild)' == 'true'">MVC-2.1</RazorDefaultConfiguration>
   </PropertyGroup>
 
   <ItemGroup>
@@ -81,32 +69,15 @@ Copyright (c) .NET Foundation. All rights reserved.
       it here. The IDE is hardcoded to inject 2.0 support when needed. The settings flowing through MSBuild should reflect
       the project's runtime.
     -->
-    <RazorConfiguration Include="MVC-3.0" Condition="'$(DesignTimeBuild)' != 'true'">
+    <RazorConfiguration Include="MVC-3.0">
       <Extensions>MVC-3.0;$(CustomRazorExtension)</Extensions>
-    </RazorConfiguration>
-
-    <!--
-      For dev16 the Razor toolings bits don't currently understand 3.0 projects. Therefore, we default to 2.1 which is currently
-      functionally equivalent. This will be undone in the near future.
-    -->
-    <RazorConfiguration Include="MVC-2.1" Condition="'$(DesignTimeBuild)' == 'true'">
-      <Extensions>MVC-2.1;$(CustomRazorExtension)</Extensions>
     </RazorConfiguration>
   </ItemGroup>
 
   <ItemGroup>
-    <RazorExtension Include="MVC-3.0" Condition="'$(DesignTimeBuild)' != 'true'">
+    <RazorExtension Include="MVC-3.0">
       <AssemblyName>Microsoft.AspNetCore.Mvc.Razor.Extensions</AssemblyName>
       <AssemblyFilePath>$(RazorSdkDirectoryRoot)extensions\mvc-3-0\Microsoft.AspNetCore.Mvc.Razor.Extensions.dll</AssemblyFilePath>
-    </RazorExtension>
-
-    <!--
-      For dev16 the Razor toolings bits don't currently understand 3.0 projects. Therefore, we default to 2.1 which is currently
-      functionally equivalent. This will be undone in the near future.
-    -->
-    <RazorExtension Include="MVC-2.1" Condition="'$(DesignTimeBuild)' == 'true'">
-      <AssemblyName>Microsoft.AspNetCore.Mvc.Razor.Extensions</AssemblyName>
-      <AssemblyFilePath>$(RazorSdkDirectoryRoot)extensions\mvc-2-1\Microsoft.AspNetCore.Mvc.Razor.Extensions.dll</AssemblyFilePath>
     </RazorExtension>
   </ItemGroup>
 


### PR DESCRIPTION
Leading up the release of VS 16.0p1 we added workarounds to the SDK to
make Razor fall back to the 2.1 configuration for design-time. Since
we're adding the 3.0 language support to preview2 we can remove these
workarounds. These features have been available in internal builds for
some time.
