### PR TITLE
Fix null ref in the parser

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlMarkupParser.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlMarkupParser.cs
@@ -1591,6 +1591,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 var node = tagBlock.Attributes[i];
 
                 if (node is MarkupAttributeBlockSyntax attributeBlock &&
+                    attributeBlock.Value != null &&
                     attributeBlock.Value.Children.Count > 0 &&
                     IsTypeAttribute(attributeBlock))
                 {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/HtmlTagsTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/HtmlTagsTest.cs
@@ -109,6 +109,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
+        public void ScriptTag_Incomplete()
+        {
+            ParseDocumentTest("<script type=");
+        }
+
+        [Fact]
         public void VoidElementFollowedByContent()
         {
             // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlTagsTest/ScriptTag_Incomplete.cspans.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlTagsTest/ScriptTag_Incomplete.cspans.txt
@@ -1,0 +1,2 @@
+Markup span at (0:0,0 [7] ) (Accepts:Any) - Parent: Tag block at (0:0,0 [13] )
+Markup span at (7:0,7 [6] ) (Accepts:Any) - Parent: Markup block at (7:0,7 [6] )

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlTagsTest/ScriptTag_Incomplete.stree.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlTagsTest/ScriptTag_Incomplete.stree.txt
@@ -1,0 +1,13 @@
+RazorDocument - [0..13)::13 - [<script type=]
+    MarkupBlock - [0..13)::13
+        MarkupElement - [0..13)::13
+            MarkupStartTag - [0..13)::13 - [<script type=] - Gen<None> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[script];
+                MarkupAttributeBlock - [7..13)::6 - [ type=]
+                    MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [8..12)::4 - [type] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[type];
+                    Equals;[=];
+                CloseAngle;[<Missing>];


### PR DESCRIPTION
This happens whenever a script tag is seen without any value for the attribute `type`.