### PR TITLE
Fixed exception with non taghelper start/end void tags

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
@@ -144,8 +144,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         // Non-TagHelper tag.
                         ValidateParentAllowsPlainStartTag(startTag);
 
-                        if (!startTag.IsSelfClosing() && !startTag.IsVoidElement())
+                        if (node.EndTag != null || (!startTag.IsSelfClosing() && !startTag.IsVoidElement()))
                         {
+                            // Ideally we don't want to keep track of self-closing or void tags.
+                            // But if a matching end tag exists, keep track of the start tag no matter what.
+                            // We will just assume the parser had a good reason to do this.
                             var tracker = new TagTracker(tagName, isTagHelper: false);
                             _trackerStack.Push(tracker);
                         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperParseTreeRewriterTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperParseTreeRewriterTest.cs
@@ -1874,5 +1874,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         {
             RunParseTreeRewriterTest("<div>@{</div>}");
         }
+
+        [Fact]
+        public void HandlesNonTagHelperStartAndEndVoidTags_Correctly()
+        {
+            RunParseTreeRewriterTest("<input>Foo</input>");
+        }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/HandlesNonTagHelperStartAndEndVoidTags_Correctly.cspans.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/HandlesNonTagHelperStartAndEndVoidTags_Correctly.cspans.txt
@@ -1,0 +1,3 @@
+Markup span at (0:0,0 [7] ) (Accepts:Any) - Parent: Tag block at (0:0,0 [7] )
+Markup span at (7:0,7 [3] ) (Accepts:Any) - Parent: Markup block at (0:0,0 [18] )
+Markup span at (10:0,10 [8] ) (Accepts:Any) - Parent: Tag block at (10:0,10 [8] )

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/HandlesNonTagHelperStartAndEndVoidTags_Correctly.stree.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/HandlesNonTagHelperStartAndEndVoidTags_Correctly.stree.txt
@@ -1,0 +1,14 @@
+RazorDocument - [0..18)::18 - [<input>Foo</input>]
+    MarkupBlock - [0..18)::18
+        MarkupElement - [0..18)::18
+            MarkupStartTag - [0..7)::7 - [<input>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[input];
+                CloseAngle;[>];
+            MarkupTextLiteral - [7..10)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Foo];
+            MarkupEndTag - [10..18)::8 - [</input>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[input];
+                CloseAngle;[>];


### PR DESCRIPTION
This happens if you type `<input>Foo</input>`. We fail to keep track of the start tag because it is a void tag.