### PR TITLE
Fix: Missing void end tag when targeted by TH with WithoutEndTag structure

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
@@ -111,18 +111,18 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         {
                             var tagHelperElement = SyntaxFactory.MarkupTagHelperElement(tagHelperStart, body: new SyntaxList<RazorSyntaxNode>(), endTag: null);
                             var rewrittenTagHelper = tagHelperElement.WithTagHelperInfo(tagHelperInfo);
-                            if (node.Body.Count == 0)
+                            if (node.Body.Count == 0 && node.EndTag == null)
                             {
                                 return rewrittenTagHelper;
                             }
 
-                            // This tag contains a body which needs to be moved to the parent.
+                            // This tag contains a body and/or an end tag which needs to be moved to the parent.
                             var rewrittenNodes = SyntaxListBuilder<RazorSyntaxNode>.Create();
                             rewrittenNodes.Add(rewrittenTagHelper);
                             var rewrittenBody = VisitList(node.Body);
                             rewrittenNodes.AddRange(rewrittenBody);
 
-                            return SyntaxFactory.MarkupElement(startTag: null, body: rewrittenNodes.ToList(), endTag: null);
+                            return SyntaxFactory.MarkupElement(startTag: null, body: rewrittenNodes.ToList(), endTag: node.EndTag);
                         }
                         else if (node.EndTag == null)
                         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperBlockRewriterTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperBlockRewriterTest.cs
@@ -223,6 +223,16 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
+        public void AllowsCompatibleTagStructures8()
+        {
+            // Arrange
+            var descriptors = GetTagStructureCompatibilityDescriptors(TagStructure.WithoutEndTag, TagStructure.Unspecified);
+
+            // Act & Assert
+            EvaluateData(descriptors, "<input></input>");
+        }
+
+        [Fact]
         public void CreatesErrorForMalformedTagHelpersWithAttributes1()
         {
             RunParseTreeRewriterTest("<p class='", "strong", "p");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperBlockRewriterTest/AllowsCompatibleTagStructures8.cspans.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperBlockRewriterTest/AllowsCompatibleTagStructures8.cspans.txt
@@ -1,0 +1,1 @@
+Markup span at (7:0,7 [8] ) (Accepts:Any) - Parent: Tag block at (7:0,7 [8] )

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperBlockRewriterTest/AllowsCompatibleTagStructures8.stree.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperBlockRewriterTest/AllowsCompatibleTagStructures8.stree.txt
@@ -1,0 +1,15 @@
+RazorDocument - [0..15)::15 - [<input></input>]
+    MarkupBlock - [0..15)::15
+        MarkupElement - [0..15)::15
+            MarkupTagHelperElement - [0..7)::7 - input[StartTagOnly] - InputTagHelper1 - InputTagHelper2
+                MarkupTagHelperStartTag - [0..7)::7
+                    MarkupTextLiteral - [0..6)::6 - [<input] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[input];
+                    MarkupTextLiteral - [6..7)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        CloseAngle;[>];
+            MarkupEndTag - [7..15)::8 - [</input>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[input];
+                CloseAngle;[>];

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperBlockRewriterTest/AllowsCompatibleTagStructures8.tspans.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperBlockRewriterTest/AllowsCompatibleTagStructures8.tspans.txt
@@ -1,0 +1,1 @@
+TagHelper span at (0:0,0 [7] ) - InputTagHelper1 - InputTagHelper2


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/6469

This does not cause a crash. I noticed this when investigating the crashing issue.
