### PR TITLE
Set ParserContext.StartOfLine to true when parsing starts

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/ParserContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/ParserContext.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         public bool InTemplateContext { get; set; }
 
-        public bool StartOfLine { get; set; }
+        public bool StartOfLine { get; set; } = true;
 
         public AcceptedCharactersInternal LastAcceptedCharacters { get; set; } = AcceptedCharactersInternal.None;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -38,8 +38,8 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
-                    IntermediateToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (85:1,0 [2] IncompleteDirectives.cshtml)
+                    IntermediateToken - (85:1,0 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (94:3,0 [8] IncompleteDirectives.cshtml) - page
                 MalformedDirective - (102:4,0 [6] IncompleteDirectives.cshtml) - page
                 HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
@@ -18,7 +18,7 @@ namespace AspNetCore
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n\r\n");
+            WriteLiteral("\r\n");
             WriteLiteral("\"\r\n\r\n");
             WriteLiteral("\r\n");
             WriteLiteral("\r\n\r\n");

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -11,8 +11,8 @@ Document -
         RazorSourceChecksumAttribute - 
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives - global::Microsoft.AspNetCore.Mvc.RazorPages.Page - 
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
-                    IntermediateToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (85:1,0 [2] IncompleteDirectives.cshtml)
+                    IntermediateToken - (85:1,0 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (94:3,0 [8] IncompleteDirectives.cshtml) - page
                 MalformedDirective - (102:4,0 [6] IncompleteDirectives.cshtml) - page
                 HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -34,8 +34,8 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
-                    IntermediateToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (85:1,0 [2] IncompleteDirectives.cshtml)
+                    IntermediateToken - (85:1,0 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (87:2,0 [6] IncompleteDirectives.cshtml) - model
                     DirectiveToken - (93:2,6 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (93:2,6 [2] IncompleteDirectives.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -38,8 +38,8 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
-                    IntermediateToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (85:1,0 [2] IncompleteDirectives.cshtml)
+                    IntermediateToken - (85:1,0 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (94:3,0 [8] IncompleteDirectives.cshtml) - page
                 MalformedDirective - (102:4,0 [6] IncompleteDirectives.cshtml) - page
                 HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
@@ -19,8 +19,8 @@ namespace AspNetCore
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
-            BeginContext(83, 4, true);
-            WriteLiteral("\r\n\r\n");
+            BeginContext(85, 2, true);
+            WriteLiteral("\r\n");
             EndContext();
             BeginContext(108, 5, true);
             WriteLiteral("\"\r\n\r\n");

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -14,9 +14,9 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives - global::Microsoft.AspNetCore.Mvc.RazorPages.Page - 
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - 
-                    IntermediateToken -  - CSharp - BeginContext(83, 4, true);
-                HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
-                    IntermediateToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                    IntermediateToken -  - CSharp - BeginContext(85, 2, true);
+                HtmlContent - (85:1,0 [2] IncompleteDirectives.cshtml)
+                    IntermediateToken - (85:1,0 [2] IncompleteDirectives.cshtml) - Html - \n
                 CSharpCode - 
                     IntermediateToken -  - CSharp - EndContext();
                 MalformedDirective - (94:3,0 [8] IncompleteDirectives.cshtml) - page

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -22,8 +22,8 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
-                    IntermediateToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (85:1,0 [2] IncompleteDirectives.cshtml)
+                    IntermediateToken - (85:1,0 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (100:2,13 [0] IncompleteDirectives.cshtml) - addTagHelper
                     DirectiveToken - (100:2,13 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (100:2,13 [2] IncompleteDirectives.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n\r\n");
+            WriteLiteral("\r\n");
             WriteLiteral("\r\n");
             WriteLiteral("\r\n");
             WriteLiteral("\r\n");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -4,8 +4,8 @@ Document -
         RazorSourceChecksumAttribute - 
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_Runtime -  - 
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
-                    IntermediateToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (85:1,0 [2] IncompleteDirectives.cshtml)
+                    IntermediateToken - (85:1,0 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (100:2,13 [2] IncompleteDirectives.cshtml) - addTagHelper
                     DirectiveToken - (100:2,13 [2] IncompleteDirectives.cshtml) - 
                 MalformedDirective - (116:3,14 [2] IncompleteDirectives.cshtml) - addTagHelper

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.ir.txt
@@ -9,8 +9,7 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (36:0,36 [17] RazorComments.cshtml)
-                    IntermediateToken - (36:0,36 [2] RazorComments.cshtml) - Html - \n
+                HtmlContent - (38:1,0 [15] RazorComments.cshtml)
                     IntermediateToken - (38:1,0 [2] RazorComments.cshtml) - Html - <p
                     IntermediateToken - (40:1,2 [1] RazorComments.cshtml) - Html - >
                     IntermediateToken - (41:1,3 [12] RazorComments.cshtml) - Html - This should 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_Runtime.codegen.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n<p>This should ");
+            WriteLiteral("<p>This should ");
             WriteLiteral(" be shown</p>\r\n\r\n");
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml"
                                        

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_Runtime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_Runtime.ir.txt
@@ -4,8 +4,7 @@ Document -
         RazorSourceChecksumAttribute - 
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RazorComments_Runtime -  - 
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (36:0,36 [17] RazorComments.cshtml)
-                    IntermediateToken - (36:0,36 [2] RazorComments.cshtml) - Html - \n
+                HtmlContent - (38:1,0 [15] RazorComments.cshtml)
                     IntermediateToken - (38:1,0 [2] RazorComments.cshtml) - Html - <p
                     IntermediateToken - (40:1,2 [1] RazorComments.cshtml) - Html - >
                     IntermediateToken - (41:1,3 [12] RazorComments.cshtml) - Html - This should 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/RazorDirectivesTest/DirectiveDescriptor_FileScoped_CanBeBeneathOtherWhiteSpaceCommentsAndDirectives.stree.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/RazorDirectivesTest/DirectiveDescriptor_FileScoped_CanBeBeneathOtherWhiteSpaceCommentsAndDirectives.stree.txt
@@ -8,7 +8,7 @@ RazorDocument - [0..130)::130 - [@* There are two directives beneath this *@LF@c
             RazorCommentLiteral;[ There are two directives beneath this ];
             RazorCommentStar;[*];
             RazorCommentTransition;[@];
-        MarkupTextLiteral - [43..45)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        MarkupEphemeralTextLiteral - [43..45)::2 - [LF] - Gen<None> - SpanEditHandler;Accepts:Any
             NewLine;[LF];
         CSharpCodeBlock - [45..89)::44
             RazorDirective - [45..89)::44 - Directive:{custom;SingleLine;FileScopedSinglyOccurring}


### PR DESCRIPTION
Found this when investigating https://github.com/aspnet/AspNetCore/issues/6206.

Note: This issue has existed even in the old parser. This is not a regression.

The correct value for `StartOfLine` is `true` when the parsing starts. Before this change cases like a Razor comment at the top of file,
```
@* Some comment *@
<div></div>
```
will output a newline at the start of the document. This fixes it.

This might require us to update the `HtmlGenerationTest` baselines in Mvc. I'll check and send a PR there if necessary.