### PR TITLE
Correctly handle whitespace that precedes a Razor directive

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentWhitespacePass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentWhitespacePass.cs
@@ -77,11 +77,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
                         break;
 
                     case CSharpCodeIntermediateNode codeIntermediateNode:
-                        // A C# code node could be empty. We can't remove them, but we can skip them. 
                         shouldRemoveNode = false;
-                        shouldContinueIteration = 
-                            IsEmpty(codeIntermediateNode) || 
-                            ComponentDocumentClassifierPass.IsBuildRenderTreeBaseCall(codeIntermediateNode);
+                        shouldContinueIteration = ComponentDocumentClassifierPass.IsBuildRenderTreeBaseCall(codeIntermediateNode);
                         break;
 
                     default:
@@ -112,19 +109,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         {
             Forwards,
             Backwards
-        }
-
-        private static bool IsEmpty(CSharpCodeIntermediateNode node)
-        {
-            for (var i = 0; i < node.Children.Count; i++)
-            {
-                if (!(node.Children[i] is IntermediateToken token && string.IsNullOrWhiteSpace(token.Content)))
-                {
-                    return false;
-                }
-            }
-
-            return true;
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_Runtime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_Runtime.ir.txt
@@ -6,7 +6,5 @@ Document -
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [4] FunctionsBlockMinimal.cshtml)
                     IntermediateToken - (0:0,0 [4] FunctionsBlockMinimal.cshtml) - Html - \n\n
-                CSharpCode - (4:2,0 [1] FunctionsBlockMinimal.cshtml)
-                    IntermediateToken - (4:2,0 [1] FunctionsBlockMinimal.cshtml) - CSharp - 	
             CSharpCode - (16:2,12 [55] FunctionsBlockMinimal.cshtml)
                 IntermediateToken - (16:2,12 [55] FunctionsBlockMinimal.cshtml) - CSharp - \nstring foo(string input) {\n	return input + "!";\n}\n

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.ir.txt
@@ -13,7 +13,5 @@ Document -
                     HtmlAttribute - (5:0,5 [10] x:\dir\subdir\Test\TestComponent.cshtml) -  attr= - 
                         CSharpExpressionAttributeValue - (11:0,11 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 
                             IntermediateToken - (12:0,12 [3] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Foo
-                CSharpCode - (20:1,0 [4] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (20:1,0 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -     
             CSharpCode - (36:1,16 [29] x:\dir\subdir\Test\TestComponent.cshtml)
                 IntermediateToken - (36:1,16 [29] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n        int Foo = 18;\n    

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/RazorDirectivesTest/BuiltInDirectiveDoesNotErorrIfNotAtStartOfLineBecauseOfWhitespace.stree.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/RazorDirectivesTest/BuiltInDirectiveDoesNotErorrIfNotAtStartOfLineBecauseOfWhitespace.stree.txt
@@ -3,7 +3,7 @@ RazorDocument - [0..26)::26 - [LF  @addTagHelper "*, Foo"]
         MarkupTextLiteral - [0..2)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
             NewLine;[LF];
         CSharpCodeBlock - [2..26)::24
-            CSharpStatementLiteral - [2..4)::2 - [  ] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+            CSharpEphemeralTextLiteral - [2..4)::2 - [  ] - Gen<Stmt> - SpanEditHandler;Accepts:Any
                 Whitespace;[  ];
             RazorDirective - [4..26)::22
                 CSharpTransition - [4..5)::1 - Gen<None> - SpanEditHandler;Accepts:None

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/RazorDirectivesTest/ExtensibleDirectiveDoesNotErorrIfNotAtStartOfLineBecauseOfWhitespace.stree.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/RazorDirectivesTest/ExtensibleDirectiveDoesNotErorrIfNotAtStartOfLineBecauseOfWhitespace.stree.txt
@@ -3,7 +3,7 @@ RazorDocument - [0..46)::46 - [LF  @custom System.Text.Encoding.ASCIIEncoding]
         MarkupTextLiteral - [0..2)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
             NewLine;[LF];
         CSharpCodeBlock - [2..46)::44
-            CSharpStatementLiteral - [2..4)::2 - [  ] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+            CSharpEphemeralTextLiteral - [2..4)::2 - [  ] - Gen<Stmt> - SpanEditHandler;Accepts:Any
                 Whitespace;[  ];
             RazorDirective - [4..46)::42 - Directive:{custom;SingleLine;Unrestricted}
                 CSharpTransition - [4..5)::1 - Gen<None> - SpanEditHandler;Accepts:None


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/6206

Basically when we have whitespace preceding any csharp transition,
```
|    |@if (true) {

}
```
We classify this whitespace as `CSharpStatementLiteral` in runtime which is fine and is the expected behavior. We want it to be generated in the output.

Whereas for a directive,
```
|    |@functions {

}
```
it doesn't make sense for that whitespace to appear in the output. But I was incorrectly classifying it as `CSharpStatementLiteral`. This change special cases directives to correctly classify it.

Note: In design time, in both cases the whitespace will be classified as markup resulting in correct markup intellisense.