### PR TITLE
Fix A VS issue

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.DesignTime.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.DesignTime.targets
@@ -74,16 +74,26 @@ Copyright (c) .NET Foundation. All rights reserved.
     Returns="@(RazorGenerateWithTargetPath)">
   </Target>
 
+  <!--
+    Using DependsOnTargets here because real dependencies of this target aren't defined in
+    a downlevel (pre-3.0) SDK.
+  -->
   <Target 
     Name="RazorGenerateComponentDesignTime" 
-    DependsOnTargets="ResolveRazorComponentInputs;AssignRazorComponentTargetPaths" 
+    DependsOnTargets="$(_RazorGenerateComponentDesignTimeDependsOn)" 
     Returns="@(RazorComponentWithTargetPath)">
   </Target>
 
-  <!-- Called by the project system to update generated declaration files -->
+
+  <!--
+    Using DependsOnTargets here because real dependencies of this target aren't defined in
+    a downlevel (pre-3.0) SDK.
+
+    Called by the project system to update generated declaration files
+  -->
   <Target 
     Name="RazorGenerateComponentDeclarationDesignTime" 
-    DependsOnTargets="ResolveRazorConfiguration;ResolveRazorComponentInputs;AssignRazorComponentTargetPaths;RazorGenerateComponentDeclaration">
+    DependsOnTargets="$(_RazorGenerateComponentDeclarationDesignTimeDependsOn)">
   </Target>
 
 </Project>

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
@@ -78,4 +78,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <None Remove="**\*.razor" />
   </ItemGroup>
 
+  <!-- 
+    Wire-ups for design-time build targets. These have to be here because the design time targetes need to exist
+    on a downlevel SDK which doesn't have components support.
+  -->
+  <PropertyGroup>
+    <_RazorGenerateComponentDeclarationDesignTimeDependsOn>ResolveRazorConfiguration;ResolveRazorComponentInputs;AssignRazorComponentTargetPaths;RazorGenerateComponentDeclaration</_RazorGenerateComponentDeclarationDesignTimeDependsOn>
+    <_RazorGenerateComponentDesignTimeDependsOn>ResolveRazorComponentInputs;AssignRazorComponentTargetPaths</_RazorGenerateComponentDesignTimeDependsOn>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
The issue here is that the downlevel SDK (2.1/2.2) don't define the
component-related targets needed for the component design time build.
Depending on the ordering of targets, this can break all features in VS
that depend on the design-time build.

Since we want this to noop in those cases, the best fix is to make our
targets depend on a target property that will be empty in the downlevel
SDKS, but will contain our targets in the 3.0 SDK.

(cherry picked from commit b88b32c73ac823febf2319690e5b7ff9f23e9e28)
