### PR TITLE
Add attribute only bindings and fix #6373

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperBlockRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperBlockRewriter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
             foreach (var descriptor in bindingResult.Descriptors)
             {
-                var boundRules = bindingResult.GetBoundRules(descriptor);
+                var boundRules = bindingResult.Mappings[descriptor];
                 var nonDefaultRule = boundRules.FirstOrDefault(rule => rule.TagStructure != TagStructure.Unspecified);
 
                 if (nonDefaultRule?.TagStructure == TagStructure.WithoutEndTag)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
@@ -336,7 +336,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
                     foreach (var descriptor in tagHelperBinding.Descriptors)
                     {
-                        var boundRules = tagHelperBinding.GetBoundRules(descriptor);
+                        var boundRules = tagHelperBinding.Mappings[descriptor];
                         var invalidRule = boundRules.FirstOrDefault(rule => rule.TagStructure == TagStructure.WithoutEndTag);
 
                         if (invalidRule != null)
@@ -456,7 +456,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 TagStructure? baseStructure = null;
                 foreach (var descriptor in bindingResult.Descriptors)
                 {
-                    var boundRules = bindingResult.GetBoundRules(descriptor);
+                    var boundRules = bindingResult.Mappings[descriptor];
                     foreach (var rule in boundRules)
                     {
                         if (rule.TagStructure != TagStructure.Unspecified)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/TagHelperMetadata.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/TagHelperMetadata.cs
@@ -10,6 +10,8 @@ namespace Microsoft.AspNetCore.Razor.Language
             public static readonly string PropertyName = "Common.PropertyName";
 
             public static readonly string TypeName = "Common.TypeName";
+
+            public static readonly string ClassifyAttributesOnly = "Common.ClassifyAttributesOnly";
         }
 
         public static class Runtime

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/BindTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/BindTagHelperDescriptorProvider.cs
@@ -121,6 +121,7 @@ namespace Microsoft.CodeAnalysis.Razor
             builder.Documentation = ComponentResources.BindTagHelper_Fallback_Documentation;
 
             builder.Metadata.Add(BlazorMetadata.SpecialKindKey, BlazorMetadata.Bind.TagHelperKind);
+            builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
             builder.Metadata[TagHelperMetadata.Runtime.Name] = BlazorMetadata.Bind.RuntimeName;
             builder.Metadata[BlazorMetadata.Bind.FallbackKey] = bool.TrueString;
 
@@ -257,6 +258,7 @@ namespace Microsoft.CodeAnalysis.Razor
                     entry.ChangeAttribute);
 
                 builder.Metadata.Add(BlazorMetadata.SpecialKindKey, BlazorMetadata.Bind.TagHelperKind);
+                builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
                 builder.Metadata[TagHelperMetadata.Runtime.Name] = BlazorMetadata.Bind.RuntimeName;
                 builder.Metadata[BlazorMetadata.Bind.ValueAttribute] = entry.ValueAttribute;
                 builder.Metadata[BlazorMetadata.Bind.ChangeAttribute] = entry.ChangeAttribute;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/EventHandlerTagHelperDescriptorProvider.cs
@@ -35,7 +35,6 @@ namespace Microsoft.CodeAnalysis.Razor
                 return;
             }
 
-
             var eventHandlerData = GetEventHandlerData(compilation);
 
             foreach (var tagHelper in CreateEventHandlerTagHelpers(eventHandlerData))
@@ -112,6 +111,7 @@ namespace Microsoft.CodeAnalysis.Razor
 
                 builder.Metadata.Add(BlazorMetadata.SpecialKindKey, BlazorMetadata.EventHandler.TagHelperKind);
                 builder.Metadata.Add(BlazorMetadata.EventHandler.EventArgsType, entry.EventArgsType.ToDisplayString());
+                builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
                 builder.Metadata[TagHelperMetadata.Runtime.Name] = BlazorMetadata.EventHandler.RuntimeName;
 
                 // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/RefTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/RefTagHelperDescriptorProvider.cs
@@ -21,6 +21,20 @@ namespace Microsoft.CodeAnalysis.Razor
                 throw new ArgumentNullException(nameof(context));
             }
 
+            var compilation = context.GetCompilation();
+            if (compilation == null)
+            {
+                return;
+            }
+
+            var elementRef = compilation.GetTypeByMetadataName(ComponentsApi.ElementRef.FullTypeName);
+            if (elementRef == null)
+            {
+                // If we can't find ElementRef, then just bail. We won't be able to compile the
+                // generated code anyway.
+                return;
+            }
+
             context.Results.Add(CreateRefTagHelper());
         }
 
@@ -30,6 +44,7 @@ namespace Microsoft.CodeAnalysis.Razor
             builder.Documentation = ComponentResources.RefTagHelper_Documentation;
 
             builder.Metadata.Add(BlazorMetadata.SpecialKindKey, BlazorMetadata.Ref.TagHelperKind);
+            builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
             builder.Metadata[TagHelperMetadata.Runtime.Name] = BlazorMetadata.Ref.RuntimeName;
 
             // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorTagHelperBinderPhaseTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorTagHelperBinderPhaseTest.cs
@@ -342,7 +342,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             var formTagHelper = Assert.Single(tagHelperNodes);
             Assert.Equal("form", formTagHelper.TagHelperInfo.TagName);
-            Assert.Equal(2, formTagHelper.TagHelperInfo.BindingResult.GetBoundRules(descriptor).Count());
+            Assert.Equal(2, formTagHelper.TagHelperInfo.BindingResult.Mappings[descriptor].Count());
         }
 
         [Fact]
@@ -396,7 +396,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             var formTagHelper = Assert.Single(tagHelperNodes);
             Assert.Equal("form", formTagHelper.TagHelperInfo.TagName);
-            Assert.Equal(2, formTagHelper.TagHelperInfo.BindingResult.GetBoundRules(descriptor).Count());
+            Assert.Equal(2, formTagHelper.TagHelperInfo.BindingResult.Mappings[descriptor].Count());
         }
 
         [Fact]

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/BindTagHelperDescriptorProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/BindTagHelperDescriptorProviderTest.cs
@@ -207,6 +207,7 @@ namespace Test
             Assert.Empty(bind.Diagnostics);
             Assert.False(bind.HasErrors);
             Assert.Equal(BlazorMetadata.Bind.TagHelperKind, bind.Kind);
+            Assert.Equal(bool.TrueString, bind.Metadata[TagHelperMetadata.Common.ClassifyAttributesOnly]);
             Assert.Equal(BlazorMetadata.Bind.RuntimeName, bind.Metadata[TagHelperMetadata.Runtime.Name]);
             Assert.False(bind.IsDefaultKind());
             Assert.False(bind.KindUsesDefaultTagHelperRuntime());
@@ -571,6 +572,7 @@ namespace Test
             Assert.Empty(bind.Diagnostics);
             Assert.False(bind.HasErrors);
             Assert.Equal(BlazorMetadata.Bind.TagHelperKind, bind.Kind);
+            Assert.Equal(bool.TrueString, bind.Metadata[TagHelperMetadata.Common.ClassifyAttributesOnly]);
             Assert.Equal(BlazorMetadata.Bind.RuntimeName, bind.Metadata[TagHelperMetadata.Runtime.Name]);
             Assert.False(bind.IsDefaultKind());
             Assert.False(bind.KindUsesDefaultTagHelperRuntime());

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/EventHandlerTagHelperDescriptorProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/EventHandlerTagHelperDescriptorProviderTest.cs
@@ -4,10 +4,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.Razor;
+using Microsoft.AspNetCore.Razor.Language.Components;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Razor.Language.Components
+namespace Microsoft.CodeAnalysis.Razor
 {
     public class EventHandlerTagHelperDescriptorProviderTest : BaseTagHelperDescriptorProviderTest
     {
@@ -52,6 +52,7 @@ namespace Test
             Assert.Empty(item.Diagnostics);
             Assert.False(item.HasErrors);
             Assert.Equal(BlazorMetadata.EventHandler.TagHelperKind, item.Kind);
+            Assert.Equal(bool.TrueString, item.Metadata[TagHelperMetadata.Common.ClassifyAttributesOnly]);
             Assert.Equal(BlazorMetadata.EventHandler.RuntimeName, item.Metadata[TagHelperMetadata.Runtime.Name]);
             Assert.False(item.IsDefaultKind());
             Assert.False(item.KindUsesDefaultTagHelperRuntime());

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/RefTagHelperDescriptorProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/RefTagHelperDescriptorProviderTest.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis.Razor
         {
             // Arrange
             var context = TagHelperDescriptorProviderContext.Create();
+            context.SetCompilation(BaseCompilation);
+
             var provider = new RefTagHelperDescriptorProvider();
 
             // Act
@@ -29,6 +31,7 @@ namespace Microsoft.CodeAnalysis.Razor
             Assert.Empty(item.Diagnostics);
             Assert.False(item.HasErrors);
             Assert.Equal(BlazorMetadata.Ref.TagHelperKind, item.Kind);
+            Assert.Equal(bool.TrueString, item.Metadata[TagHelperMetadata.Common.ClassifyAttributesOnly]);
             Assert.Equal(BlazorMetadata.Ref.RuntimeName, item.Metadata[TagHelperMetadata.Runtime.Name]);
             Assert.False(item.IsDefaultKind());
             Assert.False(item.KindUsesDefaultTagHelperRuntime());

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultTagHelperFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultTagHelperFactsServiceTest.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             // Assert
             var descriptor = Assert.Single(binding.Descriptors);
             Assert.Equal(documentDescriptors[0], descriptor, TagHelperDescriptorComparer.CaseSensitive);
-            var boundRule = Assert.Single(binding.GetBoundRules(descriptor));
+            var boundRule = Assert.Single(binding.Mappings[descriptor]);
             Assert.Equal(documentDescriptors[0].TagMatchingRules.First(), boundRule, TagMatchingRuleDescriptorComparer.CaseSensitive);
         }
 


### PR DESCRIPTION
Adds a new API for WTE to call given a TagHelperBinding to determine if
the binding should colorize/classify only the attributes of the HTML
element in source code. This is driven by a new metadata item that the
Components 'directive attributes' all set. There's no way for a user to
access this feature via tag helpers currently, but it could be added
easily in the future.

Also fixing aspnet/AspNetCore#6376 while I'm in there. :+1:
