### PR TITLE
Prioritize local dotnet when running SDK Razor tests.

### DIFF
--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/MSBuildProcessManager.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/MSBuildProcessManager.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.CommandLineUtils;
 
 namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 {
@@ -38,7 +39,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             }
             else
             {
-                processStartInfo.FileName = "dotnet";
+                processStartInfo.FileName = DotNetMuxer.MuxerPathOrDefault();
                 processStartInfo.Arguments = $"msbuild {arguments}";
             }
 


### PR DESCRIPTION
- The SDK tests were occasionally failing with access denied due to the test using the machines dotnet.exe (instead of the local projects dotnet.exe).

aspnet/AspNetCore#1667
