### PR TITLE
Allow VSIX project to be built on its own.

### DIFF
--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -16,6 +16,15 @@
       <VsixVersion Condition="'$(OfficialBuildId)' != ''">$(VsixVersion).$(OfficialBuildId)</VsixVersion>
       <VsixVersion Condition="'$(OfficialBuildId)' == ''">$(VsixVersion).42424242.42</VsixVersion>
     </PropertyGroup>
+  </Target>
 
+  <Target Name="_EnsureVSIXWasGenerated" AfterTargets="GenerateVisualStudioInsertionManifests" Condition="'$(OS)'=='WINDOWS_NT'">
+    <PropertyGroup>
+      <VSSetupDir>$(ArtifactsDir)VSSetup\</VSSetupDir>
+      <RazorExtensionVSIXName>Microsoft.VisualStudio.RazorExtension.vsix</RazorExtensionVSIXName>
+    </PropertyGroup>
+    <Error 
+      Text="$(RazorExtensionVSIXName) was not generated."
+      Condition="!Exists('$(VSSetupDir)$(Configuration)\$(RazorExtensionVSIXName)')" />
   </Target>
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -17,6 +17,8 @@
     <!-- Don't automatically include dependencies -->
     <IncludePackageReferencesInVSIXContainer>false</IncludePackageReferencesInVSIXContainer>
 
+    <!-- Update the VSToolsPath to ensure VSIX builds -->
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
- Prior to this, rebuilding the VSIX project would not result it in re-deploying to the experiemental hive.
- Added an AfterSigning target that ensures a VSIX is always built
