### PR TITLE
Ensure updates to Razor components trigger design time build

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.DesignTime.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.DesignTime.targets
@@ -34,9 +34,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     to trigger a workspace update for the declaration files when they change.
   -->
   <ItemGroup>
-    <Content Update="@(RazorComponent)">
+    <Content Update="**\*.razor">
       <Generator>MSBuild:RazorGenerateComponentDeclarationDesignTime</Generator>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </Content>
+
+    <Content Update="$(_RazorComponentInclude)">
+      <Generator>MSBuild:RazorGenerateComponentDeclarationDesignTime</Generator>
     </Content>
   </ItemGroup>
 

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -92,8 +92,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       _RazorAddDebugSymbolsProjectOutputGroupOutput
     </DebugSymbolsProjectOutputGroupDependsOn>
 
-    <CoreCompileDependsOn>
+    <CoreCompileDependsOn Condition="'$(DesignTimeBuild)'!='true'">
       RazorComponentGenerate;
+      $(CoreCompileDependsOn)
+    </CoreCompileDependsOn>
+
+    <CoreCompileDependsOn Condition="'$(DesignTimeBuild)'=='true'">
+      RazorGenerateComponentDeclarationDesignTime;
       $(CoreCompileDependsOn)
     </CoreCompileDependsOn>
 
@@ -408,7 +413,21 @@ Copyright (c) .NET Foundation. All rights reserved.
       <RazorComponent Include="@(Content)" Condition="'%(Content.Extension)'=='.razor'" />
       <RazorComponent Include="$(_RazorComponentInclude)" />
     </ItemGroup>
+
+    <ItemGroup>
+      <Content Condition="'%(Content.Extension)'=='.razor'" CopyToPublishDirectory="Never" />
+    </ItemGroup>
   </Target>
+
+  <!--
+    Temporarary workaround for https://github.com/aspnet/AspNetCore/issues/6859. This can be removed after a VS insertion with a newer copy of the DesignTime targets.
+  -->
+  <ItemGroup>
+    <Content Update="$(_RazorComponentInclude)">
+      <Generator>MSBuild:RazorGenerateComponentDeclarationDesignTime</Generator>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
 
   <Target Name="AssignRazorComponentTargetPaths" Condition="'@(RazorComponent)' != ''">
     <AssignTargetPath Files="@(RazorComponent)" RootFolder="$(MSBuildProjectDirectory)">


### PR DESCRIPTION
* Use _RazorComponentInclude to determine the set of files to set Generator property for
* Run RazorGenerateComponentDeclarationDesignTime instead of RazorComponentGenerate during design time builds
* Update design time targets to set Generator for content files with .razor extension.

Fixes https://github.com/aspnet/AspNetCore/issues/6859
Fixes https://github.com/aspnet/AspNetCore/issues/6860

