### PR TITLE
Update Razor parser state on background thread.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorSyntaxTreePartialParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorSyntaxTreePartialParser.cs
@@ -30,14 +30,23 @@ namespace Microsoft.VisualStudio.Editor.Razor
         // Internal for testing
         internal SyntaxNode ModifiedSyntaxTreeRoot { get; private set; }
 
-        public PartialParseResultInternal Parse(SourceChange change)
+        /// <summary>
+        /// Partially parses the provided <paramref name="change"/>.
+        /// </summary>
+        /// <param name="change">The <see cref="SourceChange"/> that should be partially parsed.</param>
+        /// <returns>The <see cref="PartialParseResultInternal"/> and <see cref="RazorSyntaxTree"/> of the partial parse.</returns>
+        /// <remarks>
+        /// The returned <see cref="RazorSyntaxTree"/> has the <see cref="OriginalSyntaxTree"/>'s <see cref="RazorSyntaxTree.Source"/> and <see cref="RazorSyntaxTree.Diagnostics"/>.
+        /// </remarks>
+        public (PartialParseResultInternal, RazorSyntaxTree) Parse(SourceChange change)
         {
             var result = GetPartialParseResult(change);
 
             // Remember if this was provisionally accepted for next partial parse.
             _lastResultProvisional = (result & PartialParseResultInternal.Provisional) == PartialParseResultInternal.Provisional;
+            var newSyntaxTree = RazorSyntaxTree.Create(ModifiedSyntaxTreeRoot, OriginalSyntaxTree.Source, OriginalSyntaxTree.Diagnostics, OriginalSyntaxTree.Options);
 
-            return result;
+            return (result, newSyntaxTree);
         }
 
         private PartialParseResultInternal GetPartialParseResult(SourceChange change)

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioRazorParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioRazorParser.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.VisualStudio.Text;
@@ -24,6 +25,6 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         public abstract void QueueReparse();
 
-        public virtual Task<RazorCodeDocument> GetLatestCodeDocumentAsync() => throw new NotImplementedException();
+        public virtual Task<RazorSyntaxTree> GetLatestSyntaxTreeAsync(ITextSnapshot atOrNewerSnapshot, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
@@ -15,7 +15,13 @@ namespace Microsoft.VisualStudio.Text
     {
         private readonly List<ITextSnapshotLine> _lines;
 
-        public StringTextSnapshot(string content)
+        public static readonly StringTextSnapshot Empty = new StringTextSnapshot(string.Empty);
+
+        public StringTextSnapshot(string content) : this(content, versionNumber: 0)
+        {
+        }
+
+        public StringTextSnapshot(string content, int versionNumber)
         {
             Content = content;
             _lines = new List<ITextSnapshotLine>();
@@ -39,6 +45,8 @@ namespace Microsoft.VisualStudio.Text
                 _lines.Add(new SnapshotLine(lineText, start, this));
 
                 start = nextLineStartIndex;
+
+                Version = new TextVersion(versionNumber);
             }
         }
 
@@ -46,7 +54,7 @@ namespace Microsoft.VisualStudio.Text
 
         public char this[int position] => Content[position];
 
-        public ITextVersion Version { get; } = new TextVersion();
+        public ITextVersion Version { get; }
 
         public int Length => Content.Length;
 
@@ -120,15 +128,20 @@ namespace Microsoft.VisualStudio.Text
 
         private class TextVersion : ITextVersion
         {
+            public TextVersion(int versionNumber)
+            {
+                VersionNumber = versionNumber;
+            }
+
             public INormalizedTextChangeCollection Changes { get; } = new TextChangeCollection();
+
+            public int VersionNumber { get; }
 
             public ITextVersion Next => throw new NotImplementedException();
 
             public int Length => throw new NotImplementedException();
 
             public ITextBuffer TextBuffer => throw new NotImplementedException();
-
-            public int VersionNumber => throw new NotImplementedException();
 
             public int ReiteratedVersionNumber => throw new NotImplementedException();
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorDirectiveCompletionSourceTest.cs
@@ -34,8 +34,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
             // Arrange
             var text = "@validCompletion";
             var parser = new Mock<VisualStudioRazorParser>();
-            parser.Setup(p => p.GetLatestCodeDocumentAsync())
-                .Returns(Task.FromResult<RazorCodeDocument>(null)); // CodeDocument will be null faking a parser without a parse.
+            parser.Setup(p => p.GetLatestSyntaxTreeAsync(It.IsAny<ITextSnapshot>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<RazorSyntaxTree>(null)); // CodeDocument will be null faking a parser without a parse.
             var completionSource = new RazorDirectiveCompletionSource(Dispatcher, parser.Object, CompletionFactsService);
             var documentSnapshot = new StringTextSnapshot(text);
             var triggerLocation = new SnapshotPoint(documentSnapshot, 4);
@@ -153,11 +153,9 @@ namespace Microsoft.VisualStudio.Editor.Razor
         private static VisualStudioRazorParser CreateParser(string text, params DirectiveDescriptor[] directives)
         {
             var syntaxTree = CreateSyntaxTree(text, directives);
-            var codeDocument = TestRazorCodeDocument.Create(text);
-            codeDocument.SetSyntaxTree(syntaxTree);
             var parser = new Mock<VisualStudioRazorParser>();
-            parser.Setup(p => p.GetLatestCodeDocumentAsync())
-                .Returns(Task.FromResult(codeDocument));
+            parser.Setup(p => p.GetLatestSyntaxTreeAsync(It.IsAny<ITextSnapshot>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(syntaxTree));
 
             return parser.Object;
         }

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorSyntaxTreePartialParserTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorSyntaxTreePartialParserTest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var parser = new RazorSyntaxTreePartialParser(syntaxTree);
 
             // Act
-            var result = parser.Parse(edit.Change);
+            var (result, _) = parser.Parse(edit.Change);
 
             // Assert
             Assert.Equal(PartialParseResultInternal.Rejected, result);
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var parser = new RazorSyntaxTreePartialParser(syntaxTree);
 
             // Act
-            var result = parser.Parse(edit.Change);
+            var (result, _) = parser.Parse(edit.Change);
 
             // Assert
             Assert.Equal(partialParseResult, result);
@@ -357,7 +357,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var syntaxTree = document.GetSyntaxTree();
             var parser = new RazorSyntaxTreePartialParser(syntaxTree);
 
-            var result = parser.Parse(edit.Change);
+            var (result, _) = parser.Parse(edit.Change);
             Assert.Equal(PartialParseResultInternal.Rejected | additionalFlags, result);
         }
 
@@ -369,7 +369,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var syntaxTree = document.GetSyntaxTree();
             var parser = new RazorSyntaxTreePartialParser(syntaxTree);
 
-            var result = parser.Parse(edit.Change);
+            var (result, _) = parser.Parse(edit.Change);
             Assert.Equal(PartialParseResultInternal.Accepted | additionalFlags, result);
 
             var newSource = TestRazorSourceDocument.Create(edit.NewSnapshot.GetText());

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCIAfterIdentifiers_CompletesSyntaxTreeRequest.cspans.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCIAfterIdentifiers_CompletesSyntaxTreeRequest.cspans.txt
@@ -1,0 +1,4 @@
+Markup span at (0:0,0 [4] test.cshtml) (Accepts:Any) - Parent: Markup block at (0:0,0 [18] test.cshtml)
+Transition span at (4:0,4 [1] test.cshtml) (Accepts:None) - Parent: Expression block at (4:0,4 [10] test.cshtml)
+Code span at (5:0,5 [9] test.cshtml) (Accepts:NonWhitespace) - Parent: Expression block at (4:0,4 [10] test.cshtml)
+Markup span at (14:0,14 [4] test.cshtml) (Accepts:Any) - Parent: Markup block at (0:0,0 [18] test.cshtml)

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCIAfterIdentifiers_CompletesSyntaxTreeRequest.stree.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TestFiles/ParserTests/DefaultVisualStudioRazorParserIntegrationTest/ImpExprProvisionallyAcceptsDCIAfterIdentifiers_CompletesSyntaxTreeRequest.stree.txt
@@ -1,0 +1,17 @@
+RazorDocument - [0..18)::18 - [foo @DateTime. baz]
+    MarkupBlock - [0..18)::18
+        MarkupTextLiteral - [0..4)::4 - [foo ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Text;[foo];
+            Whitespace;[ ];
+        CSharpCodeBlock - [4..14)::10
+            CSharpImplicitExpression - [4..14)::10
+                CSharpTransition - [4..5)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpImplicitExpressionBody - [5..14)::9
+                    CSharpCodeBlock - [5..14)::9
+                        CSharpExpressionLiteral - [5..14)::9 - [DateTime.] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K21
+                            Identifier;[DateTime];
+                            Dot;[.];
+        MarkupTextLiteral - [14..18)::4 - [ baz] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Whitespace;[ ];
+            Text;[baz];


### PR DESCRIPTION
- This change enables our parser to return a background completable task instead of waiting for the document structure notifications on the foreground thread.
- When changing the system to resolve all data on the background thread I ran into several races which triggered severe delays/timeouts/deadlocks when running through completion scenarios. To fix these issues I had to tie into our current partial parsing and snapshot tracking systems to properly complete tasks without crashing VS.
- Had to make a slight hack of returning the latest partially parsed syntax tree which maintains its original diagnostics/source document.
- There were some unrelated issues that result in a completion request aborting mid-flight, because of this changed the API to properly consume a cancellation token.
