### PR TITLE
Ensure TagHelpers from the current project are discovered for projects targeting 2.x

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.CodeGeneration.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.CodeGeneration.targets
@@ -70,14 +70,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <Target
+   <!-- Force a Compile to happen if we are not doing a components build. This keeps parity with 2.x CodeGeneration targets -->
+   <Target
     Name="_RazorEnsureCompiled"
-    Condition="!Exists('$(_RazorGenerateTargetReferenceAssembly)')"
+    Condition="'$(_RazorComponentDeclarationAssemblyFullPath)' == ''"
     DependsOnTargets="Compile" />
 
   <Target
     Name="ResolveTagHelperRazorGenerateInputs"
-    Inputs="$(MSBuildAllProjects);@(RazorReferencePath);$(_RazorGenerateTargetReferenceAssembly)"
+    Inputs="$(MSBuildAllProjects);@(RazorReferencePath)"
     DependsOnTargets="_RazorEnsureCompiled"
     Outputs="$(_RazorTagHelperInputCache)"
     Condition="'@(RazorGenerateWithTargetPath)' != ''">
@@ -105,7 +106,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       Version="$(RazorLangVersion)"
       Configuration="@(ResolvedRazorConfiguration)"
       Extensions="@(ResolvedRazorExtension)"
-      Assemblies="@(RazorReferencePath);$(_RazorGenerateTargetReferenceAssembly)"
+      Assemblies="@(RazorReferencePath)"
       ProjectRoot="$(MSBuildProjectDirectory)"
       TagHelperManifest="$(_RazorTagHelperOutputCache)">
       <Output

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Compilation.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Compilation.targets
@@ -54,7 +54,6 @@ Copyright (c) .NET Foundation. All rights reserved.
           Inputs="$(MSBuildAllProjects);
                   @(RazorCompile);
                   $(AssemblyOriginatorKeyFile);
-                  $(_RazorCompileTargetReferenceAssembly);
                   @(RazorReferencePath);
                   @(CompiledLicenseFile);
                   @(LinkResource);
@@ -148,7 +147,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          Prefer32Bit="$(Prefer32Bit)"
          PreferredUILang="$(PreferredUILang)"
          ProvideCommandLineArgs="$(ProvideCommandLineArgs)"
-         References="@(RazorReferencePath);$(_RazorCompileTargetReferenceAssembly)"
+         References="@(RazorReferencePath)"
          ReportAnalyzer="$(ReportAnalyzer)"
          Resources="@(_RazorCoreCompileResourceInputs);@(CompiledLicenseFile)"
          ResponseFiles="$(CompilerResponseFile)"

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Component.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Component.targets
@@ -253,7 +253,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Point to the declaration assembly to perform taghelper discovery -->
     <PropertyGroup>
-      <_RazorGenerateTargetReferenceAssembly>@(_RazorComponentDeclarationAssembly->Metadata('FullPath'))</_RazorGenerateTargetReferenceAssembly>
+      <_RazorComponentDeclarationAssemblyFullPath>@(_RazorComponentDeclarationAssembly->Metadata('FullPath'))</_RazorComponentDeclarationAssemblyFullPath>
     </PropertyGroup>
   </Target>
 

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -74,7 +74,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PrepareForRazorCompileDependsOn>
 
     <ResolveRazorCompileInputsDependsOn>
-      ResolveRazorEmbeddedResources
+      ResolveRazorEmbeddedResources;
+      _FixupRazorReferencePathForRazorCompile;
     </ResolveRazorCompileInputsDependsOn>
 
     <RazorCompileDependsOn>
@@ -471,22 +472,33 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target
     Name="ResolveAssemblyReferenceRazorGenerateInputs"
     DependsOnTargets="ResolveReferences">
+
     <ItemGroup>
       <RazorReferencePath Include="@(ReferencePath)"/>
-    </ItemGroup>
 
-    <PropertyGroup>
       <!--
-        Assembly of the project used as input in RazorGenerate. This property is overwritten to point to the definition assembly when components are present.
+      RazorReferencePath must include the closure of assemblies required for tag helper discovery to keep parity with the 2.1 Razor.Design package.
+      Use the component declaration assembly, if available or the IntermediateAssembly if no components are involved in the build.
       -->
-      <_RazorGenerateTargetReferenceAssembly Condition="'$(_RazorGenerateTargetReferenceAssembly)'==''">
-        @(IntermediateAssembly->Metadata('FullPath'))
-      </_RazorGenerateTargetReferenceAssembly>
+      <RazorReferencePath
+        Include="$(_RazorComponentDeclarationAssemblyFullPath)"
+        Condition="'$(_RazorComponentDeclarationAssemblyFullPath)' != ''" />
 
-      <_RazorCompileTargetReferenceAssembly Condition="'$(_RazorCompileTargetReferenceAssembly)'==''">
-        @(IntermediateAssembly->Metadata('FullPath'))
-      </_RazorCompileTargetReferenceAssembly>
-    </PropertyGroup>
+      <RazorReferencePath
+        Include="@(IntermediateAssembly->Metadata('FullPath'))"
+        Condition="'$(_RazorComponentDeclarationAssemblyFullPath)' == ''" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_FixupRazorReferencePathForRazorCompile" Condition="'$(_RazorComponentDeclarationAssemblyFullPath)' != ''">
+    <!--
+      ResolveAssemblyReferenceRazorGenerateInputs may have added the component declaration assembly to RazorReferencePath to perform tag helper discovery.
+      However, we want to compile the Razor assembly against the actual output of the project build i.e. the IntermediateAssembly.
+    -->
+    <ItemGroup>
+      <RazorReferencePath Remove="$(_RazorComponentDeclarationAssemblyFullPath)" />
+      <RazorReferencePath Include="@(IntermediateAssembly->Metadata('FullPath'))" />
+    </ItemGroup>
   </Target>
 
   <!--

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntegrationTest21.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntegrationTest21.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.IO;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -27,6 +28,14 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileExists(result, OutputPath, "SimpleMvc21.pdb");
             Assert.FileExists(result, OutputPath, "SimpleMvc21.Views.dll");
             Assert.FileExists(result, OutputPath, "SimpleMvc21.Views.pdb");
+
+            // Verify RazorTagHelper works
+            Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc21.TagHelpers.input.cache");
+            Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc21.TagHelpers.output.cache");
+            Assert.FileContains(
+                result,
+                Path.Combine(IntermediateOutputPath, "SimpleMvc21.TagHelpers.output.cache"),
+                @"""Name"":""SimpleMvc.SimpleTagHelper""");
         }
     }
 }

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntegrationTest22.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntegrationTest22.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.IO;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -27,6 +28,14 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileExists(result, OutputPath, "SimpleMvc22.pdb");
             Assert.FileExists(result, OutputPath, "SimpleMvc22.Views.dll");
             Assert.FileExists(result, OutputPath, "SimpleMvc22.Views.pdb");
+
+            // Verify RazorTagHelper works
+            Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc22.TagHelpers.input.cache");
+            Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc22.TagHelpers.output.cache");
+            Assert.FileContains(
+                result,
+                Path.Combine(IntermediateOutputPath, "SimpleMvc22.TagHelpers.output.cache"),
+                @"""Name"":""SimpleMvc.SimpleTagHelper""");
         }
     }
 }

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerIntegrationTest.cs
@@ -254,6 +254,11 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 result,
                 tagHelperOutputCacheFile,
                 @"""Name"":""MvcWithComponents.Views.Shared.NavMenu""");
+
+            Assert.FileContains(
+                result,
+                tagHelperOutputCacheFile,
+                @"""Name"":""MvcWithComponents.SimpleTagHelper""");
         }
 
         private class TestProjectDirectory : ProjectDirectory

--- a/src/Razor/test/testapps/MvcWithComponents/SimpleTagHelper.cs
+++ b/src/Razor/test/testapps/MvcWithComponents/SimpleTagHelper.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace MvcWithComponents
+{
+    public class SimpleTagHelper : TagHelper
+    {
+    }
+}

--- a/src/Razor/test/testapps/SimpleMvc21/SimpleTagHelper.cs
+++ b/src/Razor/test/testapps/SimpleMvc21/SimpleTagHelper.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace SimpleMvc
+{
+    public class SimpleTagHelper : TagHelper
+    {
+    }
+}

--- a/src/Razor/test/testapps/SimpleMvc22/SimpleTagHelper.cs
+++ b/src/Razor/test/testapps/SimpleMvc22/SimpleTagHelper.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace SimpleMvc
+{
+    public class SimpleTagHelper : TagHelper
+    {
+    }
+}


### PR DESCRIPTION
As part of migrating the CodeGeneration targets in to the Razor.Sdk,
the SDK broke the contract that RazorReferencePaths includes the full closure
of assemblies during tag helper discovery.

This change restores the behavior to be compatible with the 2.x Razor.Design
package and adds tests to verify TagHelper discovery works in a range of projects.

Fixes https://github.com/aspnet/AspNetCore/issues/6825

