### PR TITLE
Use new PreserveCompilationReferences in Razor Sdk

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,9 +37,9 @@ jobs:
       pool:
         # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
         ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-          name: dotnet-external-temp
+          name: dotnet-external-temp-vs2019
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          name: dotnet-internal-temp
+          name: dotnet-internal-temp-vs2019
       strategy:
         matrix:
           debug:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview-009812",
+    "dotnet": "3.0.100-preview-010184",
     "vs": {
       "version": "15.9",
       "components": [
@@ -9,7 +9,7 @@
     }
   },
   "sdk": {
-    "version": "3.0.100-preview-009812"
+    "version": "3.0.100-preview-010184"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19108.1"

--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "tools": {
     "dotnet": "3.0.100-preview-010184",
     "vs": {
-      "version": "15.9",
+      "version": "16.0",
       "components": [
         "Microsoft.VisualStudio.Component.VSSDK"
       ]

--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "tools": {
     "dotnet": "3.0.100-preview-010184",
     "vs": {
-      "version": "16.0",
+      "version": "15.9",
       "components": [
         "Microsoft.VisualStudio.Component.VSSDK"
       ]

--- a/src/Razor/Razor.Slim.sln
+++ b/src/Razor/Razor.Slim.sln
@@ -2,7 +2,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28410.60
-MinimumVisualStudioVersion = 15.0.26730.03
+MinimumVisualStudioVersion = 16.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{3C0D6505-79B3-49D0-B4C3-176F0F1836ED}"
 	ProjectSection(SolutionItems) = preProject
 		src\Directory.Build.props = src\Directory.Build.props

--- a/src/Razor/Razor.sln
+++ b/src/Razor/Razor.sln
@@ -2,7 +2,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28410.60
-MinimumVisualStudioVersion = 15.0.26730.03
+MinimumVisualStudioVersion = 16.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{3C0D6505-79B3-49D0-B4C3-176F0F1836ED}"
 	ProjectSection(SolutionItems) = preProject
 		src\Directory.Build.props = src\Directory.Build.props

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
@@ -43,14 +43,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CopyRazorGenerateFilesToPublishDirectory Condition="'$(CopyRazorGenerateFilesToPublishDirectory)'==''">false</CopyRazorGenerateFilesToPublishDirectory>
 
     <!--
-      Set to true to copy reference assembly items to the publish directory.
-
-      Typically reference assemblies are not needed for a published application if Razor compilation occurs at build-time
-      or publish-time. By default, the Razor SDK will suppress the copying of reference assemblies to the publish directory.
-    -->
-    <CopyRefAssembliesToPublishDirectory Condition="'$(CopyRefAssembliesToPublishDirectory)'==''">false</CopyRefAssembliesToPublishDirectory>
-
-    <!--
     Determines the toolset to use to compile Razor (.cshtml) files. Defaults to 'Implicit' to let the Razor Sdk determine the toolset to use.
     Valid values include 'Implicit', 'RazorSdk', and 'PrecompilationTool'.
     -->
@@ -68,7 +60,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
     <RazorGenerateOutputFileExtension>.g.cs</RazorGenerateOutputFileExtension>
 
+    <!-- Determines if the deps file includes complication context -->
     <PreserveCompilationContext>true</PreserveCompilationContext>
+
+    <!-- Determines if the refs folder is produced as part of build \ publish -->
+    <PreserveCompilationReferences>false</PreserveCompilationReferences>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true'">

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -174,8 +174,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CopyRazorGenerateFilesToPublishDirectory Condition="'$(MvcRazorExcludeViewFilesFromPublish)'=='true'">false</CopyRazorGenerateFilesToPublishDirectory>
     <CopyRazorGenerateFilesToPublishDirectory Condition="'$(MvcRazorExcludeViewFilesFromPublish)'=='false'">true</CopyRazorGenerateFilesToPublishDirectory>
 
-    <CopyRefAssembliesToPublishDirectory Condition="'$(MvcRazorExcludeRefAssembliesFromPublish)'=='true'">false</CopyRefAssembliesToPublishDirectory>
-    <CopyRefAssembliesToPublishDirectory Condition="'$(MvcRazorExcludeRefAssembliesFromPublish)'=='false'">true</CopyRefAssembliesToPublishDirectory>
+    <!--
+    In 2.x, setting CopyRefAssembliesToPublishDirectory controlled copying of the refs directory to the publish directory.
+    If explicitly specified, use it to override PreserveCompilationReferences.
+    -->
+    <PreserveCompilationReferences Condition="'$(CopyRefAssembliesToPublishDirectory)'!=''">$(CopyRefAssembliesToPublishDirectory)</PreserveCompilationReferences>
+
+    <PreserveCompilationReferences Condition="'$(MvcRazorExcludeRefAssembliesFromPublish)'=='true'">false</PreserveCompilationReferences>
+    <PreserveCompilationReferences Condition="'$(MvcRazorExcludeRefAssembliesFromPublish)'=='false'">true</PreserveCompilationReferences>
 
     <!-- 
       We can't set the actual default value here due to evaluation order (depends on $(OutDir)).
@@ -226,6 +232,16 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Previous versions of the precompilation tool still depends on the msbuild property 'MvcRazorCompileOnPublish'. Hence, setting it to the old default value -->
     <MvcRazorCompileOnPublish Condition="'$(MvcRazorCompileOnPublish)' == ''">true</MvcRazorCompileOnPublish>
+  </PropertyGroup>
+
+  <!-- Back-compat for PrecompilationTool -->
+  <PropertyGroup>
+    <!--
+      For 2.x desktop targeting projects using MvcPrecompilation, ref assemblies are required to compile the PrecompiledViews.dll,
+      but are removed by the tool once done. Set PreserveCompilationReferences = true, ignoring any value configured in the project,
+      if the project is using the precompilation tool.
+    -->
+    <PreserveCompilationReferences Condition="'$(ResolvedRazorCompileToolset)'=='PrecompilationTool'">true</PreserveCompilationReferences>
   </PropertyGroup>
 
   <!--
@@ -708,21 +724,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
     <ItemGroup Condition="'$(CopyRazorGenerateFilesToPublishDirectory)'=='false'">
       <ResolvedFileToPublish Remove="%(RazorGenerate.FullPath)"/>
-    </ItemGroup>
-  </Target>
-
-  <Target
-    Name="_RazorRemoveRefAssembliesFromPublish"
-    AfterTargets="ComputeRefAssembliesToPublish"
-    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnPublish)'=='true' and '$(CopyRefAssembliesToPublishDirectory)'=='false'">
-    <!--
-      The ref assemblies are published whenever PreserveCompilationContext is true, which we expect to be true for
-      most usages of Razor. There's no setting that excludes just the ref assemblies, so we do it ourselves. 
-    -->
-    <ItemGroup>
-      <ResolvedFileToPublish
-        Remove="%(ResolvedFileToPublish.Identity)"
-        Condition="'%(ResolvedFileToPublish.RelativePath)'=='$(RefAssembliesFolderName)\%(Filename)%(Extension)'"/>
     </ItemGroup>
   </Target>
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.csproj
@@ -4,7 +4,7 @@
     <!-- To generate baselines, run tests with /p:GenerateBaselines=true -->
     <DefineConstants Condition="'$(GenerateBaselines)'=='true'">$(DefineConstants);GENERATE_BASELINES</DefineConstants>
     <DefineConstants>$(DefineConstants);__RemoveThisBitTo__GENERATE_BASELINES</DefineConstants>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/TestCompilation.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/TestCompilation.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis
 
         private static IEnumerable<string> ResolvePaths(CompilationLibrary library)
         {
+#if NETFRAMEWORK
             var assemblies = AppDomain.CurrentDomain.GetAssemblies();
             for (var i = 0; i < assemblies.Length; i++)
             {
@@ -40,6 +41,7 @@ namespace Microsoft.CodeAnalysis
                     return new[] { assemblies[i].Location };
                 }
             }
+#endif
 
             try
             {

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntegrationTest.cs
@@ -235,7 +235,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
         [Fact]
         [InitializeTestProject("SimpleMvc")]
-        public async Task Build_WithViews_ProducesDepsFileWithCompilationContext()
+        public async Task Build_WithViews_ProducesDepsFileWithCompilationContext_ButNoReferences()
         {
             var customDefine = "RazorSdkTest";
             var result = await DotnetMSBuild("Build", $"/p:DefineConstants={customDefine}");
@@ -247,13 +247,16 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             var dependencyContext = ReadDependencyContext(depsFilePath);
 
             // Pick a couple of libraries and ensure they have some compile references
-            var packageReference = dependencyContext.CompileLibraries.First(l => l.Name == "Microsoft.NETCore.App");
+            var packageReference = dependencyContext.CompileLibraries.First(l => l.Name == "System.Diagnostics.DiagnosticSource");
             Assert.NotEmpty(packageReference.Assemblies);
 
             var projectReference = dependencyContext.CompileLibraries.First(l => l.Name == "SimpleMvc");
             Assert.NotEmpty(projectReference.Assemblies);
 
             Assert.Contains(customDefine, dependencyContext.CompilationOptions.Defines);
+
+            // Verify no refs folder is produced
+            Assert.FileCountEquals(result, 0, Path.Combine(PublishOutputPath, "refs"), "*.dll");
         }
 
         [Fact]

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntegrationTest21.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntegrationTest21.cs
@@ -37,5 +37,25 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 Path.Combine(IntermediateOutputPath, "SimpleMvc21.TagHelpers.output.cache"),
                 @"""Name"":""SimpleMvc.SimpleTagHelper""");
         }
+
+        [Fact]
+        [InitializeTestProject("SimpleMvc21")]
+        public async Task Publish_NETCoreApp21TargetingProject()
+        {
+            TargetFramework = "netcoreapp2.1";
+
+            var result = await DotnetMSBuild("Publish");
+
+            Assert.BuildPassed(result);
+
+            Assert.FileExists(result, PublishOutputPath, "SimpleMvc21.dll");
+            Assert.FileExists(result, PublishOutputPath, "SimpleMvc21.pdb");
+            Assert.FileExists(result, PublishOutputPath, "SimpleMvc21.Views.dll");
+            Assert.FileExists(result, PublishOutputPath, "SimpleMvc21.Views.pdb");
+
+            // By default refs and .cshtml files will not be copied on publish
+            Assert.FileCountEquals(result, 0, Path.Combine(PublishOutputPath, "refs"), "*.dll");
+            Assert.FileCountEquals(result, 0, Path.Combine(PublishOutputPath, "Views"), "*.cshtml");
+        }
     }
 }

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/PublishIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/PublishIntegrationTest.cs
@@ -247,6 +247,30 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileCountEquals(result, 8, Path.Combine(PublishOutputPath, "Views"), "*.cshtml");
         }
 
+        [Fact]
+        [InitializeTestProject("SimpleMvc")]
+        public async Task Publish_WithCopySettingsInProjectFile_CopiesFiles()
+        {
+            AddProjectFileContent(@"
+            <PropertyGroup>
+                <CopyRefAssembliesToPublishDirectory>true</CopyRefAssembliesToPublishDirectory>
+                <CopyRazorGenerateFilesToPublishDirectory>true</CopyRazorGenerateFilesToPublishDirectory>
+            </PropertyGroup>");
+
+            var result = await DotnetMSBuild("Publish");
+
+            Assert.BuildPassed(result);
+
+            Assert.FileExists(result, PublishOutputPath, "SimpleMvc.dll");
+            Assert.FileExists(result, PublishOutputPath, "SimpleMvc.pdb");
+            Assert.FileExists(result, PublishOutputPath, "SimpleMvc.Views.dll");
+            Assert.FileExists(result, PublishOutputPath, "SimpleMvc.Views.pdb");
+
+            // By default refs and .cshtml files will not be copied on publish
+            Assert.FileExists(result, PublishOutputPath, "refs", "mscorlib.dll");
+            Assert.FileCountEquals(result, 8, Path.Combine(PublishOutputPath, "Views"), "*.cshtml");
+        }
+
         [Fact] // Tests old MvcPrecompilation behavior that we support for compat.
         [InitializeTestProject("SimpleMvc")]
         public async Task Publish_MvcRazorExcludeFilesFromPublish_False_CopiesFiles()

--- a/src/Razor/test/testapps/AppWithP2PReference/AppWithP2PReference.csproj
+++ b/src/Razor/test/testapps/AppWithP2PReference/AppWithP2PReference.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Razor/test/testapps/AppWithP2PReference/AppWithP2PReference.csproj
+++ b/src/Razor/test/testapps/AppWithP2PReference/AppWithP2PReference.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -17,7 +18,7 @@
   <!-- Test Placeholder -->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App" IsImplicitlyDefined="true" />
+    <FrameworkReference Include="Microsoft.NETCore.App" />
     <ProjectReference Include="..\ClassLibrary\ClassLibrary.csproj"/>
   </ItemGroup>
 

--- a/src/Razor/test/testapps/LargeProject/LargeProject.csproj
+++ b/src/Razor/test/testapps/LargeProject/LargeProject.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -15,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App" IsImplicitlyDefined="true" />
+    <FrameworkReference Include="Microsoft.NETCore.App" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BinariesRoot)'==''">

--- a/src/Razor/test/testapps/LargeProject/LargeProject.csproj
+++ b/src/Razor/test/testapps/LargeProject/LargeProject.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Razor/test/testapps/MvcWithComponents/MvcWithComponents.csproj
+++ b/src/Razor/test/testapps/MvcWithComponents/MvcWithComponents.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <UseAppHost>false</UseAppHost>
     <_RazorComponentInclude>Components\**\*.cshtml</_RazorComponentInclude>
   </PropertyGroup>
 
@@ -16,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App" IsImplicitlyDefined="true" />
+    <FrameworkReference Include="Microsoft.NETCore.App" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BinariesRoot)'==''">

--- a/src/Razor/test/testapps/MvcWithComponents/MvcWithComponents.csproj
+++ b/src/Razor/test/testapps/MvcWithComponents/MvcWithComponents.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <UseAppHost>false</UseAppHost>
     <_RazorComponentInclude>Components\**\*.cshtml</_RazorComponentInclude>
   </PropertyGroup>
 

--- a/src/Razor/test/testapps/SimpleMvc/SimpleMvc.csproj
+++ b/src/Razor/test/testapps/SimpleMvc/SimpleMvc.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -15,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App" IsImplicitlyDefined="true" />
+    <FrameworkReference Include="Microsoft.NETCore.App" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BinariesRoot)'==''">

--- a/src/Razor/test/testapps/SimpleMvc/SimpleMvc.csproj
+++ b/src/Razor/test/testapps/SimpleMvc/SimpleMvc.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Razor/test/testapps/SimpleMvcFSharp/SimpleMvcFSharp.fsproj
+++ b/src/Razor/test/testapps/SimpleMvcFSharp/SimpleMvcFSharp.fsproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Razor/test/testapps/SimpleMvcFSharp/SimpleMvcFSharp.fsproj
+++ b/src/Razor/test/testapps/SimpleMvcFSharp/SimpleMvcFSharp.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -20,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App" IsImplicitlyDefined="true" />
+    <FrameworkReference Include="Microsoft.NETCore.App" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BinariesRoot)'==''">

--- a/src/Razor/test/testapps/SimplePages/SimplePages.csproj
+++ b/src/Razor/test/testapps/SimplePages/SimplePages.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -15,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App" IsImplicitlyDefined="true" />
+    <FrameworkReference Include="Microsoft.NETCore.App" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BinariesRoot)'==''">

--- a/src/Razor/test/testapps/SimplePages/SimplePages.csproj
+++ b/src/Razor/test/testapps/SimplePages/SimplePages.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/6512


* Verified compatibility with 2.2 projects with runtime compilation using `CopyRefAssembliesToPublishDirectory` flag
* Verified compatibility with 2.1 projects with precompilation 