### PR TITLE
Fix global LiveShare session access timing issue.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Guest/DefaultProxyAccessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Guest/DefaultProxyAccessor.cs
@@ -14,7 +14,6 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
     {
         private readonly LiveShareSessionAccessor _liveShareSessionAccessor;
         private readonly JoinableTaskFactory _joinableTaskFactory;
-        private IProjectSnapshotManagerProxy _projectSnapshotManagerProxy;
         private IProjectHierarchyProxy _projectHierarchyProxy;
 
         [ImportingConstructor]
@@ -39,16 +38,6 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
         // Testing constructor
         private protected DefaultProxyAccessor()
         {
-        }
-
-        public override IProjectSnapshotManagerProxy GetProjectSnapshotManagerProxy()
-        {
-            if (_projectSnapshotManagerProxy == null)
-            {
-                _projectSnapshotManagerProxy = CreateServiceProxy<IProjectSnapshotManagerProxy>();
-            }
-
-            return _projectSnapshotManagerProxy;
         }
 
         public override IProjectHierarchyProxy GetProjectHierarchyProxy()

--- a/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Guest/GuestProjectPathProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Guest/GuestProjectPathProvider.cs
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
         [MethodImpl(MethodImplOptions.NoInlining)]
         private string ResolveGuestPath(Uri hostProjectPath)
         {
-            return _liveShareSessionAccessor.Session?.ConvertSharedUriToLocalPath(hostProjectPath);
+            return _liveShareSessionAccessor.Session.ConvertSharedUriToLocalPath(hostProjectPath);
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Guest/ProjectSnapshotSynchronizationServiceFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Guest/ProjectSnapshotSynchronizationServiceFactory.cs
@@ -66,10 +66,11 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
             var languageServices = _workspace.Services.GetLanguageServices(RazorLanguage.Name);
             var projectManager = (ProjectSnapshotManagerBase)languageServices.GetRequiredService<ProjectSnapshotManager>();
 
+            var projectSnapshotManagerProxy = await sessionContext.GetRemoteServiceAsync<IProjectSnapshotManagerProxy>(typeof(IProjectSnapshotManagerProxy).Name, cancellationToken);
             var synchronizationService = new ProjectSnapshotSynchronizationService(
                 _joinableTaskContext.Factory,
                 _liveShareSessionAccessor,
-                _proxyAccessor.GetProjectSnapshotManagerProxy(),
+                projectSnapshotManagerProxy,
                 projectManager);
 
             await synchronizationService.InitializeAsync(cancellationToken);

--- a/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Guest/ProxyAccessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Guest/ProxyAccessor.cs
@@ -5,8 +5,6 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
 {
     public abstract class ProxyAccessor
     {
-        public abstract IProjectSnapshotManagerProxy GetProjectSnapshotManagerProxy();
-
         public abstract IProjectHierarchyProxy GetProjectHierarchyProxy();
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LiveShare.Razor.Test/Guest/DefaultProxyAccessorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LiveShare.Razor.Test/Guest/DefaultProxyAccessorTest.cs
@@ -10,21 +10,6 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
     public class DefaultProxyAccessorTest
     {
         [Fact]
-        public void GetProjectSnapshotManagerProxy_Caches()
-        {
-            // Arrange
-            var proxy = Mock.Of<IProjectSnapshotManagerProxy>();
-            var proxyAccessor = new TestProxyAccessor<IProjectSnapshotManagerProxy>(proxy);
-
-            // Act
-            var proxy1 = proxyAccessor.GetProjectSnapshotManagerProxy();
-            var proxy2 = proxyAccessor.GetProjectSnapshotManagerProxy();
-
-            // Assert
-            Assert.Same(proxy1, proxy2);
-        }
-
-        [Fact]
         public void GetProjectHierarchyProxy_Caches()
         {
             // Arrange


### PR DESCRIPTION
- Because we need to expose a LiveShare session globally to multiple services there was a situation where if the `GuestInitializationService` was instantiated after the snapshot synchronization service then we wouldn't have access to the current collaboration service via the `LiveShareSessionAccessor`. This is ok though, because in our synchronization service we're already passed the session context which we can just use directly.
- `GuestProjectPathProvider`can't actually return a null guest path if it's asked, so also removed the null coalescing on the `LiveShareSessionAccessor`'s `Session`.
- Fixed tests.