### PR TITLE
Restore packages as part of build to avoid restore timeouts as part of running tests

### DIFF
--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/Microsoft.NET.Sdk.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/Microsoft.NET.Sdk.Razor.Test.csproj
@@ -32,15 +32,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- We don't need anything in this assembly, we just want to make sure it's built -->
-    <ProjectReference Include="..\..\src\Microsoft.NET.Sdk.Razor\Microsoft.NET.Sdk.Razor.csproj">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Mvc.Razor.Extensions\Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Razor.Tools\Microsoft.AspNetCore.Razor.Tools.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib\Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib.csproj" />
+
+    <!-- We don't need anything in this assembly, we just want to make sure it's built -->
+    <ProjectReference Include="..\..\src\Microsoft.NET.Sdk.Razor\Microsoft.NET.Sdk.Razor.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Mvc.Razor.Extensions\Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\testapps\RestoreTestProjects\RestoreTestProjects.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Razor/test/testapps/RestoreTestProjects/RestoreTestProjects.csproj
+++ b/src/Razor/test/testapps/RestoreTestProjects/RestoreTestProjects.csproj
@@ -1,0 +1,20 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AppWithP2PReference\AppWithP2PReference.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ClassLibrary\ClassLibrary.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ClassLibrary2\ClassLibrary2.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ClassLibraryMvc21\ClassLibraryMvc21.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ComponentLibrary\ComponentLibrary.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\LargeProject\LargeProject.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\SimpleMvcFSharp\SimpleMvcFSharp.fsproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\SimpleMvc\SimpleMvc.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\SimpleMvc11\SimpleMvc11.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\SimpleMvc21\SimpleMvc21.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\SimpleMvc22\SimpleMvc22.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\SimplePages\SimplePages.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/1701

The `dotnet build /restore` that runs as part of running tests makes the tests flaky \ time out when network conditions are poor. This forces a restore as part of build that would download packages required for the restore to later succeed without network I/O.