### PR TITLE
Update package branding to use SemVer v2 and set version to 3.0.0-preview3

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,8 +16,8 @@
   <PropertyGroup>
     <MajorVersion>3</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <SemanticVersioningV1>true</SemanticVersioningV1>
+    <PatchVersion>0</PatchVersion>
+    <PreReleaseVersionLabel>preview3</PreReleaseVersionLabel>
   </PropertyGroup>
   <!-- 
     Versioning for tooling releases.


### PR DESCRIPTION
Two changes:

* Update packages to 3.0.0-preview3.$(buildnumber) per latest 3.0 plan from the PMs
* Update packages to use SemVerV2 like most other repos are doing. Preview 1 of the packages in this repo were released with SemVer v1 "3.0.0-preview-18579-0056". We didn't update to SemVer v2 like everyone else because semver v2 would have sorted as "older" than 3.0.0-preview-18579-0056. But, now that we're updating the prerelease label to "preview3", semverv2 packages should appear as newer than 3.0.0-preview-18579-0056.