### PR TITLE
Fix LiveShare VS crash.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Guest/ProjectSnapshotSynchronizationService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Guest/ProjectSnapshotSynchronizationService.cs
@@ -14,13 +14,13 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
     internal class ProjectSnapshotSynchronizationService : ICollaborationService, IAsyncDisposable
     {
         private readonly JoinableTaskFactory _joinableTaskFactory;
-        private readonly LiveShareSessionAccessor _liveShareSessionAccessor;
+        private readonly CollaborationSession _sessionContext;
         private readonly IProjectSnapshotManagerProxy _hostProjectManagerProxy;
         private readonly ProjectSnapshotManagerBase _projectSnapshotManager;
 
         public ProjectSnapshotSynchronizationService(
             JoinableTaskFactory joinableTaskFactory,
-            LiveShareSessionAccessor liveShareSessionAccessor,
+            CollaborationSession sessionContext,
             IProjectSnapshotManagerProxy hostProjectManagerProxy,
             ProjectSnapshotManagerBase projectSnapshotManager)
         {
@@ -29,9 +29,9 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
                 throw new ArgumentNullException(nameof(joinableTaskFactory));
             }
 
-            if (liveShareSessionAccessor == null)
+            if (sessionContext == null)
             {
-                throw new ArgumentNullException(nameof(liveShareSessionAccessor));
+                throw new ArgumentNullException(nameof(sessionContext));
             }
 
             if (hostProjectManagerProxy == null)
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
             }
 
             _joinableTaskFactory = joinableTaskFactory;
-            _liveShareSessionAccessor = liveShareSessionAccessor;
+            _sessionContext = sessionContext;
             _hostProjectManagerProxy = hostProjectManagerProxy;
             _projectSnapshotManager = projectSnapshotManager;
         }
@@ -159,7 +159,7 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
 
         private string ResolveGuestPath(Uri filePath)
         {
-            return _liveShareSessionAccessor.Session?.ConvertSharedUriToLocalPath(filePath);
+            return _sessionContext.ConvertSharedUriToLocalPath(filePath);
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Guest/ProjectSnapshotSynchronizationServiceFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Guest/ProjectSnapshotSynchronizationServiceFactory.cs
@@ -20,14 +20,12 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
     {
         private readonly ProxyAccessor _proxyAccessor;
         private readonly JoinableTaskContext _joinableTaskContext;
-        private readonly LiveShareSessionAccessor _liveShareSessionAccessor;
         private readonly Workspace _workspace;
 
         [ImportingConstructor]
         public ProjectSnapshotSynchronizationServiceFactory(
             ProxyAccessor proxyAccessor,
             JoinableTaskContext joinableTaskContext,
-            LiveShareSessionAccessor liveShareSessionAccessor,
             [Import(typeof(VisualStudioWorkspace))] Workspace workspace)
         {
             if (proxyAccessor == null)
@@ -40,11 +38,6 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
                 throw new ArgumentNullException(nameof(joinableTaskContext));
             }
 
-            if (liveShareSessionAccessor == null)
-            {
-                throw new ArgumentNullException(nameof(liveShareSessionAccessor));
-            }
-
             if (workspace == null)
             {
                 throw new ArgumentNullException(nameof(workspace));
@@ -52,7 +45,6 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
 
             _proxyAccessor = proxyAccessor;
             _joinableTaskContext = joinableTaskContext;
-            _liveShareSessionAccessor = liveShareSessionAccessor;
             _workspace = workspace;
         }
 
@@ -69,7 +61,7 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
             var projectSnapshotManagerProxy = await sessionContext.GetRemoteServiceAsync<IProjectSnapshotManagerProxy>(typeof(IProjectSnapshotManagerProxy).Name, cancellationToken);
             var synchronizationService = new ProjectSnapshotSynchronizationService(
                 _joinableTaskContext.Factory,
-                _liveShareSessionAccessor,
+                sessionContext,
                 projectSnapshotManagerProxy,
                 projectManager);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LiveShare.Razor.Test/Guest/ProjectSnapshotSynchronizationServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LiveShare.Razor.Test/Guest/ProjectSnapshotSynchronizationServiceTest.cs
@@ -22,8 +22,7 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
             var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
             JoinableTaskFactory = new JoinableTaskFactory(joinableTaskContext.Context);
 
-            var collabSession = new TestCollaborationSession(isHost: false);
-            SessionAccessor = Mock.Of<LiveShareSessionAccessor>(accessor => accessor.IsGuestSessionActive == true && accessor.Session == collabSession);
+            SessionContext = new TestCollaborationSession(isHost: false);
 
             ProjectSnapshotManager = new TestProjectSnapshotManager(Workspace);
 
@@ -35,7 +34,7 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
 
         private JoinableTaskFactory JoinableTaskFactory { get; }
 
-        private LiveShareSessionAccessor SessionAccessor { get; }
+        private CollaborationSession SessionContext { get; }
 
         private TestProjectSnapshotManager ProjectSnapshotManager { get; }
 
@@ -54,7 +53,7 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
                 proxy => proxy.GetProjectManagerStateAsync(It.IsAny<CancellationToken>()) == Task.FromResult(state));
             var synchronizationService = new ProjectSnapshotSynchronizationService(
                 JoinableTaskFactory,
-                SessionAccessor,
+                SessionContext,
                 hostProjectManagerProxy,
                 ProjectSnapshotManager);
 
@@ -78,7 +77,7 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
                 ProjectWorkspaceStateWithTagHelpers);
             var synchronizationService = new ProjectSnapshotSynchronizationService(
                 JoinableTaskFactory,
-                SessionAccessor,
+                SessionContext,
                 Mock.Of<IProjectSnapshotManagerProxy>(),
                 ProjectSnapshotManager);
             var args = new ProjectChangeEventProxyArgs(older: null, newHandle, ProjectProxyChangeKind.ProjectAdded);
@@ -103,7 +102,7 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
                 projectWorkspaceState: null);
             var synchronizationService = new ProjectSnapshotSynchronizationService(
                 JoinableTaskFactory,
-                SessionAccessor,
+                SessionContext,
                 Mock.Of<IProjectSnapshotManagerProxy>(),
                 ProjectSnapshotManager);
             var hostProject = new HostProject("/guest/path/project.csproj", RazorConfiguration.Default);
@@ -132,7 +131,7 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
                 oldHandle.ProjectWorkspaceState);
             var synchronizationService = new ProjectSnapshotSynchronizationService(
                 JoinableTaskFactory,
-                SessionAccessor,
+                SessionContext,
                 Mock.Of<IProjectSnapshotManagerProxy>(),
                 ProjectSnapshotManager);
             var hostProject = new HostProject("/guest/path/project.csproj", RazorConfiguration.Default);
@@ -165,7 +164,7 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
                 newProjectWorkspaceState);
             var synchronizationService = new ProjectSnapshotSynchronizationService(
                 JoinableTaskFactory,
-                SessionAccessor,
+                SessionContext,
                 Mock.Of<IProjectSnapshotManagerProxy>(),
                 ProjectSnapshotManager);
             var hostProject = new HostProject("/guest/path/project.csproj", RazorConfiguration.Default);


### PR DESCRIPTION
- Collaboration services aren't guaranteed to be invoked in a particular order. If the guest initialization service was not invoked prior to the snapshot synchronization service then the synchronization service would null ref when resolving guest paths because the `LiveShareSessionAccessor.Session` would not be set yet.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/786078