### PR TITLE
Fix an assumption in ComponentBindLoweringPass that crashes VS

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentBindLoweringPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentBindLoweringPass.cs
@@ -507,15 +507,19 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
                 return GetToken(node);
             }
 
-            // In error cases we won't have a single token, but we still want to generate the code.
             IntermediateToken GetToken(IntermediateNode parent)
             {
-                return
-                    parent.Children.Count == 1 ? (IntermediateToken)parent.Children[0] : new IntermediateToken()
-                    {
-                        Kind = TokenKind.CSharp,
-                        Content = string.Join(string.Empty, parent.Children.OfType<IntermediateToken>().Select(t => t.Content)),
-                    };
+                if (parent.Children.Count == 1 && parent.Children[0] is IntermediateToken token)
+                {
+                    return token;
+                }
+
+                // In error cases we won't have a single token, but we still want to generate the code.
+                return new IntermediateToken()
+                {
+                    Kind = TokenKind.CSharp,
+                    Content = string.Join(string.Empty, parent.Children.OfType<IntermediateToken>().Select(t => t.Content)),
+                };
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/ComponentBindIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/ComponentBindIntegrationTest.cs
@@ -79,5 +79,22 @@ namespace Test
             var diagnostic = Assert.Single(generated.Diagnostics);
             Assert.Equal("BL9991", diagnostic.Id);
         }
+
+        [Fact]
+        public void Bind_InvalidUseOfDirective_DoesNotThrow()
+        {
+            var generated = CompileToCSharp(@"
+@addTagHelper *, TestAssembly
+<input type=""text"" bind=""@page"" />
+@functions {
+    public string page { get; set; } = ""text"";
+}");
+
+            // Assert
+            Assert.Collection(
+                generated.Diagnostics,
+                d => Assert.Equal("RZ2005", d.Id),
+                d => Assert.Equal("RZ1011", d.Id));
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/7384

We should also not register some of the directives that are no supported by components. But that can be a separate issue/PR.