### PR TITLE
Make TagHelper & Razor comments locatable at design time.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/LegacySyntaxNodeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/LegacySyntaxNodeExtensions.cs
@@ -23,6 +23,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         private static readonly SyntaxKind[] CommentSpanKinds = new SyntaxKind[]
         {
+            SyntaxKind.RazorCommentTransition,
+            SyntaxKind.RazorCommentStar,
             SyntaxKind.RazorCommentLiteral,
         };
 
@@ -100,7 +102,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
 
             SyntaxNode owner = null;
-            IEnumerable<SyntaxNode> children = null;
+            IEnumerable<SyntaxNode> children;
             if (node is MarkupStartTagSyntax startTag)
             {
                 children = startTag.Children;
@@ -108,6 +110,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             else if (node is MarkupEndTagSyntax endTag)
             {
                 children = endTag.Children;
+            }
+            else if (node is MarkupTagHelperStartTagSyntax startTagHelper)
+            {
+                children = startTagHelper.Children;
+            }
+            else if (node is MarkupTagHelperEndTagSyntax endTagHelper)
+            {
+                children = endTagHelper.Children;
             }
             else
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/MarkupTagHelperEndTagSyntax.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/MarkupTagHelperEndTagSyntax.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+
+namespace Microsoft.AspNetCore.Razor.Language.Syntax
+{
+    internal partial class MarkupTagHelperEndTagSyntax
+    {
+        // Copied directly from MarkupEndTagSyntax Children & GetLegacyChildren.
+        public SyntaxList<RazorSyntaxNode> Children => GetLegacyChildren();
+
+        private SyntaxList<RazorSyntaxNode> GetLegacyChildren()
+        {
+            // This method returns the children of this end tag in legacy format.
+            // This is needed to generate the same classified spans as the legacy syntax tree.
+            var builder = new SyntaxListBuilder(3);
+            var tokens = SyntaxListBuilder<SyntaxToken>.Create();
+            var context = this.GetSpanContext();
+            if (!OpenAngle.IsMissing)
+            {
+                tokens.Add(OpenAngle);
+            }
+            if (!ForwardSlash.IsMissing)
+            {
+                tokens.Add(ForwardSlash);
+            }
+            if (Bang != null)
+            {
+                // The prefix of an end tag(E.g '|</|!foo>') will have 'Any' accepted characters if a bang exists.
+                var acceptsAnyContext = new SpanContext(context.ChunkGenerator, SpanEditHandler.CreateDefault());
+                acceptsAnyContext.EditHandler.AcceptedCharacters = AcceptedCharactersInternal.Any;
+                builder.Add(SyntaxFactory.MarkupTextLiteral(tokens.Consume()).WithSpanContext(acceptsAnyContext));
+
+                tokens.Add(Bang);
+                var acceptsNoneContext = new SpanContext(context.ChunkGenerator, SpanEditHandler.CreateDefault());
+                acceptsNoneContext.EditHandler.AcceptedCharacters = AcceptedCharactersInternal.None;
+                builder.Add(SyntaxFactory.RazorMetaCode(tokens.Consume()).WithSpanContext(acceptsNoneContext));
+            }
+            if (!Name.IsMissing)
+            {
+                tokens.Add(Name);
+            }
+            if (MiscAttributeContent?.Children != null && MiscAttributeContent.Children.Count > 0)
+            {
+                foreach (var content in MiscAttributeContent.Children)
+                {
+                    tokens.AddRange(((MarkupTextLiteralSyntax)content).LiteralTokens);
+                }
+            }
+            if (!CloseAngle.IsMissing)
+            {
+                tokens.Add(CloseAngle);
+            }
+            builder.Add(SyntaxFactory.MarkupTextLiteral(tokens.Consume()).WithSpanContext(context));
+
+            return new SyntaxList<RazorSyntaxNode>(builder.ToListNode().CreateRed(this, Position));
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/MarkupTagHelperStartTagSyntax.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/MarkupTagHelperStartTagSyntax.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+
+namespace Microsoft.AspNetCore.Razor.Language.Syntax
+{
+    internal partial class MarkupTagHelperStartTagSyntax
+    {
+        // Copied directly from MarkupStartTagSyntax Children & GetLegacyChildren.
+
+        public SyntaxList<RazorSyntaxNode> Children => GetLegacyChildren();
+
+        private SyntaxList<RazorSyntaxNode> GetLegacyChildren()
+        {
+            // This method returns the children of this start tag in legacy format.
+            // This is needed to generate the same classified spans as the legacy syntax tree.
+            var builder = new SyntaxListBuilder(5);
+            var tokens = SyntaxListBuilder<SyntaxToken>.Create();
+            var context = this.GetSpanContext();
+
+            // We want to know if this tag contains non-whitespace attribute content to set the appropriate AcceptedCharacters.
+            // The prefix of a start tag(E.g '|<foo| attr>') will have 'Any' accepted characters if non-whitespace attribute content exists.
+            var acceptsAnyContext = new SpanContext(context.ChunkGenerator, SpanEditHandler.CreateDefault());
+            acceptsAnyContext.EditHandler.AcceptedCharacters = AcceptedCharactersInternal.Any;
+            var containsAttributesContent = false;
+            foreach (var attribute in Attributes)
+            {
+                if (!string.IsNullOrWhiteSpace(attribute.GetContent()))
+                {
+                    containsAttributesContent = true;
+                    break;
+                }
+            }
+
+            if (!OpenAngle.IsMissing)
+            {
+                tokens.Add(OpenAngle);
+            }
+            if (Bang != null)
+            {
+                builder.Add(SyntaxFactory.MarkupTextLiteral(tokens.Consume()).WithSpanContext(acceptsAnyContext));
+
+                tokens.Add(Bang);
+                var acceptsNoneContext = new SpanContext(context.ChunkGenerator, SpanEditHandler.CreateDefault());
+                acceptsNoneContext.EditHandler.AcceptedCharacters = AcceptedCharactersInternal.None;
+                builder.Add(SyntaxFactory.RazorMetaCode(tokens.Consume()).WithSpanContext(acceptsNoneContext));
+            }
+            if (!Name.IsMissing)
+            {
+                tokens.Add(Name);
+            }
+
+            builder.Add(SyntaxFactory.MarkupTextLiteral(tokens.Consume()).WithSpanContext(containsAttributesContent ? acceptsAnyContext : context));
+
+            builder.AddRange(Attributes);
+
+            if (ForwardSlash != null)
+            {
+                tokens.Add(ForwardSlash);
+            }
+            if (!CloseAngle.IsMissing)
+            {
+                tokens.Add(CloseAngle);
+            }
+
+            if (tokens.Count > 0)
+            {
+                builder.Add(SyntaxFactory.MarkupTextLiteral(tokens.Consume()).WithSpanContext(context));
+            }
+
+            return new SyntaxList<RazorSyntaxNode>(builder.ToListNode().CreateRed(this, Position));
+        }
+    }
+}


### PR DESCRIPTION
- Added a step to full fidelity verification that does a `LocateOwner` at every source location. If we find a `null` owner we build a snippet with a detailed response to enable us to diagnose the problem.

How the error looks when things are broken:

![image](https://user-images.githubusercontent.com/2008729/53044116-f4baa480-343e-11e9-92e8-1430d0c67f6b.png)

Addresses aspnet/AspNetCore#7718

