### PR TITLE
Fixed an assumption in ComponentLoweringPass

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentLoweringPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentLoweringPass.cs
@@ -304,36 +304,42 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
                 {
                     if (attribute.Children[i] is HtmlAttributeValueIntermediateNode htmlValue)
                     {
-                        attribute.Children[i] = new HtmlContentIntermediateNode()
+                        var newNode = new HtmlContentIntermediateNode()
                         {
-                            Children =
-                            {
-                                htmlValue.Children.Single(),
-                            },
                             Source = htmlValue.Source,
                         };
+                        for (var j = 0; j < htmlValue.Children.Count; j++)
+                        {
+                            newNode.Children.Add(htmlValue.Children[j]);
+                        }
+
+                        attribute.Children[i] = newNode;
                     }
                     else if (attribute.Children[i] is CSharpExpressionAttributeValueIntermediateNode expressionValue)
                     {
-                        attribute.Children[i] = new CSharpExpressionIntermediateNode()
+                        var newNode = new CSharpExpressionIntermediateNode()
                         {
-                            Children =
-                            {
-                                expressionValue.Children.Single(),
-                            },
                             Source = expressionValue.Source,
                         };
+                        for (var j = 0; j < expressionValue.Children.Count; j++)
+                        {
+                            newNode.Children.Add(expressionValue.Children[j]);
+                        }
+
+                        attribute.Children[i] = newNode;
                     }
                     else if (attribute.Children[i] is CSharpCodeAttributeValueIntermediateNode codeValue)
                     {
-                        attribute.Children[i] = new CSharpExpressionIntermediateNode()
+                        var newNode = new CSharpExpressionIntermediateNode()
                         {
-                            Children =
-                            {
-                                codeValue.Children.Single(),
-                            },
                             Source = codeValue.Source,
                         };
+                        for (var j = 0; j < codeValue.Children.Count; j++)
+                        {
+                            newNode.Children.Add(codeValue.Children[j]);
+                        }
+
+                        attribute.Children[i] = newNode;
                     }
                 }
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorIntegrationTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorIntegrationTestBase.cs
@@ -158,12 +158,12 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             };
         }
 
-        protected CompileToCSharpResult CompileToCSharp(string cshtmlContent)
+        protected CompileToCSharpResult CompileToCSharp(string cshtmlContent, bool throwOnFailure=true)
         {
-            return CompileToCSharp(DefaultFileName, cshtmlContent);
+            return CompileToCSharp(DefaultFileName, cshtmlContent, throwOnFailure);
         }
 
-        protected CompileToCSharpResult CompileToCSharp(string cshtmlRelativePath, string cshtmlContent)
+        protected CompileToCSharpResult CompileToCSharp(string cshtmlRelativePath, string cshtmlContent, bool throwOnFailure = true)
         {
             if (DeclarationOnly && DesignTime)
             {
@@ -204,7 +204,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                 };
 
                 // Result of doing 'temp' compilation
-                var tempAssembly = CompileToAssembly(declaration);
+                var tempAssembly = CompileToAssembly(declaration, throwOnFailure);
 
                 // Add the 'temp' compilation as a metadata reference 
                 var references = BaseCompilation.References.Concat(new[] { tempAssembly.Compilation.ToMetadataReference() }).ToArray();
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
 
         protected CompileToAssemblyResult CompileToAssembly(CompileToCSharpResult cSharpResult, bool throwOnFailure = true)
         {
-            if (cSharpResult.Diagnostics.Any())
+            if (cSharpResult.Diagnostics.Any() && throwOnFailure)
             {
                 var diagnosticsLog = string.Join(Environment.NewLine, cSharpResult.Diagnostics.Select(d => d.ToString()).ToArray());
                 throw new InvalidOperationException($"Aborting compilation to assembly because RazorCompiler returned nonempty diagnostics: {diagnosticsLog}");


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore/issues/7384
In some malformed cases, when a component attribute contains more than just an expression, we were throwing an exception at place we do `.Single()`.
- Added a test for that scenario.