### PR TITLE
Update CI to build with VS2019 Preview 3 and require vs >= 16.0 for command line builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,9 +29,9 @@ jobs:
       pool:
         # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
         ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-          name: dotnet-external-temp-vs2019
+          name: dotnet-external-vs2019-preview
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          name: dotnet-internal-temp-vs2019
+          name: dotnet-internal-vs2019-preview
       steps:
       - powershell: ./restore.cmd -ci; ./eng/scripts/CodeCheck.ps1 -ci
         displayName: Run eng/scripts/CodeCheck.ps1
@@ -54,9 +54,9 @@ jobs:
       pool:
         # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
         ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-          name: dotnet-external-temp-vs2019
+          name: dotnet-external-vs2019-preview
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          name: dotnet-internal-temp-vs2019
+          name: dotnet-internal-vs2019-preview
       strategy:
         matrix:
           debug:

--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "tools": {
     "dotnet": "3.0.100-preview3-010280",
     "vs": {
-      "version": "15.9",
+      "version": "16.0",
       "components": [
         "Microsoft.VisualStudio.Component.VSSDK"
       ]


### PR DESCRIPTION
Part of https://github.com/aspnet/AspNetCore-Internal/issues/1624