### PR TITLE
Unskip test

### DIFF
--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerIntegrationTest.cs
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileDoesNotExist(result, IntermediateOutputPath, "SimpleMvc.Views.dll");
         }
 
-        [Fact(Skip = "https://github.com/aspnet/Razor/issues/2723")]
+        [Fact]
         [InitializeTestProject("SimpleMvc")]
         public async Task Build_ServerConnectionMutexCreationFails_FallsBackToInProcessRzc()
         {

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerIntegrationTest.cs
@@ -114,8 +114,8 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         [InitializeTestProject("SimpleMvc")]
         public async Task Build_ServerConnectionMutexCreationFails_FallsBackToInProcessRzc()
         {
-            // Use a pipe name longer that 260 characters to make the Mutex constructor throw.
-            var pipeName = new string('P', 261);
+            // Use an invalid pipe name to make the Mutex constructor throw.
+            var pipeName = "Invalid\\name";
             var result = await DotnetMSBuild(
                 "Build",
                 "/p:_RazorForceBuildServer=true",


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/5104

~The current mutex behavior looks like what we expect. I suspect this was failing earlier in November due to some bug which has since been fixed but we never unskipped the test.~

Modified the test to use a more reliable invalid pipe name.
