### PR TITLE
Update TagHelper completion to understand dictionary attributes.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperCompletionService.cs
@@ -88,11 +88,25 @@ namespace Microsoft.VisualStudio.Editor.Razor
                     foreach (var attributeDescriptor in descriptor.BoundAttributes)
                     {
                         UpdateCompletions(attributeDescriptor.Name, attributeDescriptor);
+
+                        if (!string.IsNullOrEmpty(attributeDescriptor.IndexerNamePrefix))
+                        {
+                            UpdateCompletions(attributeDescriptor.IndexerNamePrefix + "...", attributeDescriptor);
+                        }
                     }
                 }
                 else
                 {
-                    var htmlNameToBoundAttribute = descriptor.BoundAttributes.ToDictionary(attribute => attribute.Name, StringComparer.OrdinalIgnoreCase);
+                    var htmlNameToBoundAttribute = new Dictionary<string, BoundAttributeDescriptor>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var attributeDescriptor in descriptor.BoundAttributes)
+                    {
+                        htmlNameToBoundAttribute[attributeDescriptor.Name] = attributeDescriptor;
+
+                        if (!string.IsNullOrEmpty(attributeDescriptor.IndexerNamePrefix))
+                        {
+                            htmlNameToBoundAttribute[attributeDescriptor.IndexerNamePrefix] = attributeDescriptor;
+                        }
+                    }
 
                     foreach (var rule in descriptor.TagMatchingRules)
                     {
@@ -100,11 +114,11 @@ namespace Microsoft.VisualStudio.Editor.Razor
                         {
                             if (htmlNameToBoundAttribute.TryGetValue(requiredAttribute.Name, out var attributeDescriptor))
                             {
-                                UpdateCompletions(requiredAttribute.Name, attributeDescriptor);
+                                UpdateCompletions(requiredAttribute.DisplayName, attributeDescriptor);
                             }
                             else
                             {
-                                UpdateCompletions(requiredAttribute.Name, possibleDescriptor: null);
+                                UpdateCompletions(requiredAttribute.DisplayName, possibleDescriptor: null);
                             }
                         }
                     }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/RazorExcerptServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/RazorExcerptServiceTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Razor
             services.Add(new TestTagHelperResolver());
         }
 
-        [Fact]
+        [Fact(Skip = "This test is flakey due to https://github.com/dotnet/roslyn/issues/31548. Skipping until the blocking issue is resolved.")]
         public async Task TryGetExcerptInternalAsync_SingleLine_CanClassifyCSharp()
         {
             // Arrange
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Razor
                 });
         }
 
-        [Fact]
+        [Fact(Skip = "This test is flakey due to https://github.com/dotnet/roslyn/issues/31548. Skipping until the blocking issue is resolved.")]
         public async Task TryGetExcerptInternalAsync_SingleLine_CanClassifyCSharp_ImplicitExpression()
         {
             // Arrange
@@ -393,7 +393,7 @@ namespace Microsoft.CodeAnalysis.Razor
                 });
         }
 
-        [Fact(Skip = "This test is flakey due to https://github.com/dotnet/roslyn/issues/31548. Skipping until the blocking issue is resovled.")]
+        [Fact(Skip = "This test is flakey due to https://github.com/dotnet/roslyn/issues/31548. Skipping until the blocking issue is resolved.")]
         public async Task TryGetExcerptInternalAsync_MultiLine_Boundaries_CanClassifyCSharp()
         {
             // Arrange


### PR DESCRIPTION
- Since dictionaries fill `TagHelperDescriptor`s with two ways to bind to a `TagHelper` (prefix or full match) we need to take into account their indexer name prefix when providing attribute completions.
- Added tests to ensure that bound and unbound scenarios work as expected.

This results in both `asp-all-route-data` and `asp-route-...` showing up in completion:
![image](https://user-images.githubusercontent.com/2008729/53124222-a923fb80-350f-11e9-94fb-3815d015930c.png)

Prior to this only `asp-all-route-data` would show up.

#7759
