### PR TITLE
Update dependencies and workaround dotnet/sdk#2976

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <PropertyGroup>
-    <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
-  </PropertyGroup>
-
   <!--
     We don't follow their conventions for project naming. 
   -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,4 +2,9 @@
 <Project>
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="eng\MPack.targets" />
+
+  <ItemGroup>
+    <!-- Workaround https://github.com/dotnet/sdk/issues/2976 -->
+    <PackageReference Update="Microsoft.NETCore.Platforms" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,4 +7,9 @@
     <!-- Workaround https://github.com/dotnet/sdk/issues/2976 -->
     <PackageReference Update="Microsoft.NETCore.Platforms" PrivateAssets="All" />
   </ItemGroup>
+
+  <!-- Workaround https://github.com/dotnet/cli/issues/10528 -->
+  <PropertyGroup>
+    <BundledNETCorePlatformsPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
+  </PropertyGroup>
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -31,6 +31,11 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
+    <!-- Listed as a dependency to workaround https://github.com/dotnet/cli/issues/10528 -->
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.0-preview3.19115.9">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>b07bc5efcad439d5157f65df176e08f26ccb4b88</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="3.0.0-preview3.19120.3">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>924015e98bc443023a6b0eea2c0016b876e4051f</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,43 +1,43 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Extensions.CommandLineUtils.Sources" Version="3.0.0-preview.19078.2">
+    <Dependency Name="Microsoft.Extensions.CommandLineUtils.Sources" Version="3.0.0-preview3.19120.3">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>a58a80bdf5ad971167f73e501661131c3e34a901</Sha>
+      <Sha>924015e98bc443023a6b0eea2c0016b876e4051f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.HashCodeCombiner.Sources" Version="3.0.0-preview.19078.2">
+    <Dependency Name="Microsoft.Extensions.HashCodeCombiner.Sources" Version="3.0.0-preview3.19120.3">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>a58a80bdf5ad971167f73e501661131c3e34a901</Sha>
+      <Sha>924015e98bc443023a6b0eea2c0016b876e4051f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.NonCapturingTimer.Sources" Version="3.0.0-preview.19078.2">
+    <Dependency Name="Microsoft.Extensions.NonCapturingTimer.Sources" Version="3.0.0-preview3.19120.3">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>a58a80bdf5ad971167f73e501661131c3e34a901</Sha>
+      <Sha>924015e98bc443023a6b0eea2c0016b876e4051f</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview.19109.6">
+    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview3.19115.9">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>0abec4390b30fdda97dc496594f9b1f9c9b20e17</Sha>
+      <Sha>b07bc5efcad439d5157f65df176e08f26ccb4b88</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="4.6.0-preview.19109.6">
+    <Dependency Name="System.Text.Encodings.Web" Version="4.6.0-preview3.19115.9">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>0abec4390b30fdda97dc496594f9b1f9c9b20e17</Sha>
+      <Sha>b07bc5efcad439d5157f65df176e08f26ccb4b88</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="3.0.0-preview3-27415-4">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="3.0.0-preview3-27419-3">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>0dfcccec1a9fdf391fe4544ed354ac15390d9205</Sha>
+      <Sha>84174943d9ea6cf34ade0dbab8e7f0319378f0ab</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview3-27415-4">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview3-27419-3">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>0dfcccec1a9fdf391fe4544ed354ac15390d9205</Sha>
+      <Sha>84174943d9ea6cf34ade0dbab8e7f0319378f0ab</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="3.0.0-preview.19078.2">
+    <Dependency Name="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="3.0.0-preview3.19120.3">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>a58a80bdf5ad971167f73e501661131c3e34a901</Sha>
+      <Sha>924015e98bc443023a6b0eea2c0016b876e4051f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Testing" Version="3.0.0-preview.19078.2">
+    <Dependency Name="Microsoft.AspNetCore.Testing" Version="3.0.0-preview3.19120.3">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>a58a80bdf5ad971167f73e501661131c3e34a901</Sha>
+      <Sha>924015e98bc443023a6b0eea2c0016b876e4051f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19119.2">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,4 +1,4 @@
-
+﻿
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Opt-in arcade features -->
   <PropertyGroup>
@@ -55,15 +55,15 @@
 
   -->
   <PropertyGroup Label="Automated">
-    <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>3.0.0-preview.19078.2</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
-    <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-preview.19078.2</MicrosoftAspNetCoreTestingPackageVersion>
-    <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>3.0.0-preview.19078.2</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>3.0.0-preview3-27415-4</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.0.0-preview.19078.2</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
-    <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>3.0.0-preview.19078.2</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview3-27415-4</MicrosoftNETCoreAppPackageVersion>
-    <SystemDiagnosticsDiagnosticSourcePackageVersion>4.6.0-preview.19109.6</SystemDiagnosticsDiagnosticSourcePackageVersion>
-    <SystemTextEncodingsWebPackageVersion>4.6.0-preview.19109.6</SystemTextEncodingsWebPackageVersion>
+    <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>3.0.0-preview3.19120.3</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
+    <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-preview3.19120.3</MicrosoftAspNetCoreTestingPackageVersion>
+    <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>3.0.0-preview3.19120.3</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>3.0.0-preview3-27419-3</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.0.0-preview3.19120.3</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
+    <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>3.0.0-preview3.19120.3</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview3-27419-3</MicrosoftNETCoreAppPackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>4.6.0-preview3.19115.9</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemTextEncodingsWebPackageVersion>4.6.0-preview3.19115.9</SystemTextEncodingsWebPackageVersion>
   </PropertyGroup>
   <!--
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -128,8 +128,7 @@
     <VSIX_MicrosoftVisualStudioLanguageServicesPackageVersion>3.0.0-beta2-18612-05</VSIX_MicrosoftVisualStudioLanguageServicesPackageVersion>
     <VSIX_MicrosoftVisualStudioLanguageServicesRazorRemoteClientPackageVersion>3.0.0-beta2-18612-05</VSIX_MicrosoftVisualStudioLanguageServicesRazorRemoteClientPackageVersion>
     <XunitAnalyzersPackageVersion>0.10.0</XunitAnalyzersPackageVersion>
-    <XunitPackageVersion>2.3.1</XunitPackageVersion>
-    <XunitRunnerVisualStudioPackageVersion>2.4.0</XunitRunnerVisualStudioPackageVersion>
+    <XunitVersion>2.4.1</XunitVersion>
   </PropertyGroup>
   <!--
     These items will be used to install additional dotnet runtimes during bootstrapping. See tools.props.

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -109,7 +109,6 @@
     <MonoAddinsPackageVersion>1.3.8</MonoAddinsPackageVersion>
     <MonoDevelopSdkPackageVersion>1.0.1</MonoDevelopSdkPackageVersion>
     <MoqPackageVersion>4.10.0</MoqPackageVersion>
-    <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
     <!-- STOP!!! We need to reference the version of JSON that our HOSTS supprt. -->
     <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
     <VS_NewtonsoftJsonPackageVersion>9.0.1</VS_NewtonsoftJsonPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,6 +62,7 @@
     <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.0.0-preview3.19120.3</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
     <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>3.0.0-preview3.19120.3</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview3-27419-3</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview3.19115.9</MicrosoftNETCorePlatformsPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.6.0-preview3.19115.9</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemTextEncodingsWebPackageVersion>4.6.0-preview3.19115.9</SystemTextEncodingsWebPackageVersion>
   </PropertyGroup>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(MicrosoftAspNetCoreTestingPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/BuildVariables.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/BuildVariables.cs
@@ -7,7 +7,6 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
     {
         private static string _msBuildPath = string.Empty;
         private static string _microsoftNETCoreApp30PackageVersion = string.Empty;
-        private static string _netStandardLibrary20PackageVersion = string.Empty;
 
         static partial void InitializeVariables();
 
@@ -26,15 +25,6 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             {
                 InitializeVariables();
                 return _microsoftNETCoreApp30PackageVersion;
-            }
-        }
-
-        public static string NETStandardLibrary20PackageVersion
-        {
-            get
-            {
-                InitializeVariables();
-                return _netStandardLibrary20PackageVersion;
             }
         }
     }

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
@@ -74,7 +74,6 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 "/p:RunningAsTest=true",
 
                 $"/p:MicrosoftNETCoreApp30PackageVersion={BuildVariables.MicrosoftNETCoreApp30PackageVersion}",
-                $"/p:NETStandardLibrary20PackageVersion={BuildVariables.NETStandardLibrary20PackageVersion}",
             };
 
             if (!suppressRestore)

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/Microsoft.NET.Sdk.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/Microsoft.NET.Sdk.Razor.Test.csproj
@@ -73,7 +73,6 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         {
             _msBuildPath = @"$(_DesktopMSBuildPath)";
             _microsoftNETCoreApp30PackageVersion = "$(MicrosoftNETCoreApp30PackageVersion)";
-            _netStandardLibrary20PackageVersion = "$(NETStandardLibrary20PackageVersion)";
         }
     }
 }

--- a/src/Razor/test/testapps/Directory.Build.props
+++ b/src/Razor/test/testapps/Directory.Build.props
@@ -13,11 +13,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
-
-    <NETStandardImplicitPackageVersion>$(NETStandardLibrary20PackageVersion)</NETStandardImplicitPackageVersion>
-
     <!-- Working around an issue in XDT transforms -->
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
   </PropertyGroup>


### PR DESCRIPTION
* Update to latest extensions, corefx, and core-setup build
* Workaround dotnet/sdk#2976
* Update xunit to 2.4.1. (required to consume latest Microsoft.AspNetCore.Testing)
* Add workaround to resolve conflicts between SDK and dependency versions
* Remove NETStandard package version override