### PR TITLE
Change publish feed to workaround 'Waiting to obtain an exclusive lock on the feed.'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,6 @@ jobs:
     enableTelemetry: true
     helixRepo: aspnet/AspNetCore-Tooling
     helixType: build.product/
-    timeoutInMinutes: 180 # increase timeout since BAR publishing might wait a long time
     # enableMicrobuild can't be read from a user-defined variable (Azure DevOps limitation)
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       enableMicrobuild: true
@@ -74,7 +73,7 @@ jobs:
                 /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
       variables:
       - _DotNetPublishToBlobFeed : false
-      - _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+      - _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json
       - _PublishArgs: '/p:PublishToSymbolServer=false /p:PublishToAzure=false'
       - _BuildArgs: ''
       - _OfficialBuildIdArgs: ''

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,6 +34,7 @@
   <PropertyGroup>
     <RestoreSources>
       $(RestoreSources);
+      https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json;
       https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
       https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
       https://dotnet.myget.org/F/msbuild/api/v3/index.json;


### PR DESCRIPTION
We're getting consistent build timeouts. Changing to a unique feed instead. Each upstream partner will need to add this to restore sources.