### PR TITLE
Add ProjectWorkspaceState to ProjectSnapshotHandle.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/ProjectSnapshotHandle.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/ProjectSnapshotHandle.cs
@@ -10,7 +10,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
     {
         public ProjectSnapshotHandle(
             string filePath, 
-            RazorConfiguration configuration)
+            RazorConfiguration configuration,
+            ProjectWorkspaceState projectWorkspaceState)
         {
             if (filePath == null)
             {
@@ -19,10 +20,13 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             FilePath = filePath;
             Configuration = configuration;
+            ProjectWorkspaceState = projectWorkspaceState;
         }
 
         public RazorConfiguration Configuration { get; }
 
         public string FilePath { get; }
+
+        public ProjectWorkspaceState ProjectWorkspaceState { get; }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/ProjectSnapshotHandleJsonConverter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/ProjectSnapshotHandleJsonConverter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -29,8 +28,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Serialization
             var obj = JObject.Load(reader);
             var filePath = obj[nameof(ProjectSnapshotHandle.FilePath)].Value<string>();
             var configuration = obj[nameof(ProjectSnapshotHandle.Configuration)].ToObject<RazorConfiguration>(serializer);
-            
-            return new ProjectSnapshotHandle(filePath, configuration);
+            var projectWorkspaceState = obj[nameof(ProjectSnapshotHandle.ProjectWorkspaceState)].ToObject<ProjectWorkspaceState>(serializer);
+
+            return new ProjectSnapshotHandle(filePath, configuration, projectWorkspaceState);
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
@@ -51,6 +51,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Serialization
             {
                 writer.WritePropertyName(nameof(ProjectSnapshotHandle.Configuration));
                 serializer.Serialize(writer, handle.Configuration);
+            }
+
+
+            if (handle.ProjectWorkspaceState == null)
+            {
+                writer.WritePropertyName(nameof(ProjectSnapshotHandle.ProjectWorkspaceState));
+                writer.WriteNull();
+            }
+            else
+            {
+                writer.WritePropertyName(nameof(ProjectSnapshotHandle.ProjectWorkspaceState));
+                serializer.Serialize(writer, handle.ProjectWorkspaceState);
             }
 
             writer.WriteEndObject();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/ProjectSnapshotJsonConverter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/ProjectSnapshotJsonConverter.cs
@@ -7,8 +7,6 @@ using Newtonsoft.Json;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor.Serialization
 {
-    // We can't truly serialize a snapshot because it has access to a Workspace Project\
-    //
     // Instead we serialize to a ProjectSnapshotHandle and then use that to re-create the snapshot
     // inside the remote host.
     internal class ProjectSnapshotJsonConverter : JsonConverter
@@ -32,7 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Serialization
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             var project = (ProjectSnapshot)value;
-            var handle = new ProjectSnapshotHandle(project.FilePath, project.Configuration);
+            var handle = new ProjectSnapshotHandle(project.FilePath, project.Configuration, project.ProjectWorkspaceState);
 
             ProjectSnapshotHandleJsonConverter.Instance.WriteJson(writer, handle, serializer);
         }


### PR DESCRIPTION
- `ProjectSnapshotHandle` initially contained minimal information because `ProjectSnapshots` had direct access to the Roslyn workspace project they were associated with. Now `ProjectWorkspaceState`represents the Roslyn information that's needed for a `ProjectSnapshot` we can include it in the serialized information.
- Updated tests to reflect the new `ProjectWorkspaceState` inclusion in the `ProjectSnapshotHandle`

Thoughts on this? One implication of adding `ProjectWorkspaceState` to `ProjectSnapshotHandle` is that it makes the assumption that `ProjectWorkspaceState` will continue to be serializable. That being said could always change that later on as well given everything is internal. Wanted to make this change because I found myself needing to re-implement the project snapshot handle in VSCode 😄. WIth this I'd just be able to use what's done in Razor.