### PR TITLE
Move TagHelperResolver to CodeAnalysis.Workspaces

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.cs
@@ -65,11 +65,11 @@ namespace Microsoft.AspNetCore.Razor.Performance
             var services = TestServices.Create(
                 new IWorkspaceService[]
                 {
+                    TagHelperResolver,
                     new StaticProjectSnapshotProjectEngineFactory(),
                 },
                 new ILanguageService[]
                 {
-                    TagHelperResolver,
                 });
 
             return new DefaultProjectSnapshotManager(

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
@@ -50,8 +50,7 @@ namespace Microsoft.CodeAnalysis.Razor
 
             _projectManager = projectManager;
 
-            var razorLanguageServices = _projectManager.Workspace.Services.GetLanguageServices(RazorLanguage.Name);
-            _tagHelperResolver = razorLanguageServices.GetRequiredService<TagHelperResolver>();
+            _tagHelperResolver = _projectManager.Workspace.Services.GetRequiredService<TagHelperResolver>();
         }
 
         public override void Update(Project workspaceProject, ProjectSnapshot projectSnapshot)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperResolver.cs
@@ -4,11 +4,9 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
-namespace Microsoft.VisualStudio.Editor.Razor
+namespace Microsoft.CodeAnalysis.Razor
 {
     internal class DefaultTagHelperResolver : TagHelperResolver
     {
@@ -28,7 +26,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             {
                 return Task.FromResult(TagHelperResolutionResult.Empty);
             }
-            
+
             return GetTagHelpersAsync(workspaceProject, projectSnapshot.GetProjectEngine());
         }
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperResolverFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperResolverFactory.cs
@@ -4,15 +4,14 @@
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Razor;
 
-namespace Microsoft.VisualStudio.Editor.Razor
+namespace Microsoft.CodeAnalysis.Razor
 {
     [Shared]
-    [ExportLanguageServiceFactory(typeof(TagHelperResolver), RazorLanguage.Name, ServiceLayer.Default)]
-    internal class DefaultTagHelperResolverFactory : ILanguageServiceFactory
+    [ExportWorkspaceServiceFactory(typeof(TagHelperResolver), ServiceLayer.Default)]
+    internal class DefaultTagHelperResolverFactory : IWorkspaceServiceFactory
     {
-        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
         {
             return new DefaultTagHelperResolver();
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.CodeAnalysis.Razor
 {
-    internal abstract class TagHelperResolver : ILanguageService
+    internal abstract class TagHelperResolver : IWorkspaceService
     {
         public abstract Task<TagHelperResolutionResult> GetTagHelpersAsync(Project workspaceProject, ProjectSnapshot projectSnapshot, CancellationToken cancellationToken = default);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/OOPTagHelperResolverFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/OOPTagHelperResolverFactory.cs
@@ -1,26 +1,22 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Razor;
-using Microsoft.VisualStudio.Editor.Razor;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
     [System.Composition.Shared]
-    [ExportLanguageServiceFactory(typeof(TagHelperResolver), RazorLanguage.Name, ServiceLayer.Host)]
-    internal class OOPTagHelperResolverFactory : ILanguageServiceFactory
+    [ExportWorkspaceServiceFactory(typeof(TagHelperResolver), ServiceLayer.Host)]
+    internal class OOPTagHelperResolverFactory : IWorkspaceServiceFactory
     {
-        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
         {
             return new OOPTagHelperResolver(
-                languageServices.WorkspaceServices.GetRequiredService<ProjectSnapshotProjectEngineFactory>(),
-                languageServices.WorkspaceServices.GetRequiredService<ErrorReporter>(),
-                languageServices.WorkspaceServices.Workspace);
+                workspaceServices.GetRequiredService<ProjectSnapshotProjectEngineFactory>(),
+                workspaceServices.GetRequiredService<ErrorReporter>(),
+                workspaceServices.Workspace);
         }
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         private DefaultDocumentSnapshot LegacyDocument { get; }
 
-        protected override void ConfigureLanguageServices(List<ILanguageService> services)
+        protected override void ConfigureWorkspaceServices(List<IWorkspaceService> services)
         {
             services.Add(new TestTagHelperResolver());
         }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultProjectSnapshotTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultProjectSnapshotTest.cs
@@ -49,8 +49,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         private TestTagHelperResolver TagHelperResolver { get; }
 
         private List<TagHelperDescriptor> SomeTagHelpers { get; }
-
-        protected override void ConfigureLanguageServices(List<ILanguageService> services)
+        protected override void ConfigureWorkspaceServices(List<IWorkspaceService> services)
         {
             services.Add(TagHelperResolver);
         }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DocumentStateTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DocumentStateTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         private SourceText Text { get; }
 
-        protected override void ConfigureLanguageServices(List<ILanguageService> services)
+        protected override void ConfigureWorkspaceServices(List<IWorkspaceService> services)
         {
             services.Add(TagHelperResolver);
         }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         private SourceText Text { get; }
 
-        protected override void ConfigureLanguageServices(List<ILanguageService> services)
+        protected override void ConfigureWorkspaceServices(List<IWorkspaceService> services)
         {
             services.Add(TagHelperResolver);
         }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         private SourceText Text { get; }
 
-        protected override void ConfigureLanguageServices(List<ILanguageService> services)
+        protected override void ConfigureWorkspaceServices(List<IWorkspaceService> services)
         {
             TagHelperResolver = new TestTagHelperResolver();
             services.Add(TagHelperResolver);
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                             TestProjectData.SomeProjectNestedFile3.FilePath,
                         },
                         kvp.Value.OrderBy(f => f));
-                },
+           },
                 kvp =>
                 {
                     Assert.Equal(TestProjectData.SomeProjectNestedImportFile.TargetPath, kvp.Key);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/RazorExcerptServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/RazorExcerptServiceTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Razor
         private HostProject HostProject { get; }
         private HostDocument HostDocument { get; }
 
-        protected override void ConfigureLanguageServices(List<ILanguageService> services)
+        protected override void ConfigureWorkspaceServices(List<IWorkspaceService> services)
         {
             services.Add(new TestTagHelperResolver());
         }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/RazorSpanMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/RazorSpanMappingServiceTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Razor
         private HostProject HostProject { get; }
         private HostDocument HostDocument { get; }
 
-        protected override void ConfigureLanguageServices(List<ILanguageService> services)
+        protected override void ConfigureWorkspaceServices(List<IWorkspaceService> services)
         {
             services.Add(new TestTagHelperResolver());
         }

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultProjectWorkspaceStateGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultProjectWorkspaceStateGeneratorTest.cs
@@ -20,8 +20,8 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
             var tagHelperResolver = new TestTagHelperResolver();
             tagHelperResolver.TagHelpers.Add(TagHelperDescriptorBuilder.Create("ResolvableTagHelper", "TestAssembly").Build());
             ResolvableTagHelpers = tagHelperResolver.TagHelpers;
-            var languageServices = new List<ILanguageService>() { tagHelperResolver };
-            var testServices = TestServices.Create(languageServices);
+            var workspaceServices = new List<IWorkspaceService>() { tagHelperResolver };
+            var testServices = TestServices.Create(workspaceServices, Enumerable.Empty<ILanguageService>());
             Workspace = TestWorkspace.Create(testServices);
             var projectId = ProjectId.CreateNewId("Test");
             var solution = Workspace.CurrentSolution.AddProject(ProjectInfo.Create(

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         private DefaultVisualStudioDocumentTracker DocumentTracker { get; }
 
-        protected override void ConfigureLanguageServices(List<ILanguageService> services)
+        protected override void ConfigureWorkspaceServices(List<IWorkspaceService> services)
         {
             TagHelperResolver = new TestTagHelperResolver();
             services.Add(TagHelperResolver);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         private SourceText SourceText { get; }
 
-        protected override void ConfigureLanguageServices(List<ILanguageService> services)
+        protected override void ConfigureWorkspaceServices(List<IWorkspaceService> services)
         {
             services.Add(TagHelperResolver);
         }
@@ -322,8 +322,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             snapshot = ProjectManager.GetSnapshot(HostProject);
             Assert.Same(projectEngine, snapshot.GetProjectEngine());
         }
-
-        [ForegroundFact]
+       [ForegroundFact]
         public async Task DocumentOpened_UpdatesDocument()
         {
             // Arrange


### PR DESCRIPTION
- There's nothing specific about the TagHelperResolver that needs to be bound to VS. Moving it to the workspaces assembly so it can be used by VSCode.
