### PR TITLE
Removed unnecessary NoWarn property

### DIFF
--- a/src/Razor/src/Directory.Build.props
+++ b/src/Razor/src/Directory.Build.props
@@ -2,7 +2,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" Condition="'$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))'!= ''" />
 
   <PropertyGroup>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;cshtml;razor</PackageTags>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
[arcade](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props#L90) already adds 1591 to the list of NoWarn