### PR TITLE
Skip first run experience locally and on azure pipelines.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,8 @@ variables:
   value: true
 - name: _TeamName
   value: AspNetCore
+- name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+  value: true
 
 resources:
   containers:

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/MSBuildProcessManager.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/MSBuildProcessManager.cs
@@ -41,6 +41,10 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             {
                 processStartInfo.FileName = DotNetMuxer.MuxerPathOrDefault();
                 processStartInfo.Arguments = $"msbuild {arguments}";
+
+                // Suppresses the 'Welcome to .NET Core!' output that times out tests and causes locked file issues.
+                // When using dotnet we're not guarunteed to run in an environment where the dotnet.exe has had its first run experience already invoked.
+                processStartInfo.EnvironmentVariables["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "true";
             }
 
             var processResult = await RunProcessCoreAsync(processStartInfo, timeout);


### PR DESCRIPTION
- This would cause our functional tests to time out and occasionally crash due to dotnet first run experience sentinels being locked.

aspnet/AspNetCore-Internal#1859
