### PR TITLE
Temporarily skip test

### DIFF
--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildPerformanceTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildPerformanceTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         {
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/aspnet/AspNetCore-Internal/issues/1860")]
         [InitializeTestProject("SimpleMvc")]
         public async Task BuildMvcApp()
         {
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/aspnet/AspNetCore-Internal/issues/1860")]
         [InitializeTestProject("MvcWithComponents")]
         public async Task BuildMvcAppWithComponents()
         {


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore-Internal/issues/1860

This test only ever [failed](https://dnceng.visualstudio.com/public/_build/results?buildId=103959&view=ms.vss-test-web.build-test-results-tab) once on MacOS Release but skipping for a day just in case #greenbuildfriday