### PR TITLE
Remove rarely used public obsolete public API.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DocumentWriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DocumentWriter.cs
@@ -24,23 +24,6 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
             return new DefaultDocumentWriter(codeTarget, options);
         }
 
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("This method was intended to be static, use CreateDefault instead.")]
-        public DocumentWriter Create(CodeTarget codeTarget, RazorCodeGenerationOptions options)
-        {
-            if (codeTarget == null)
-            {
-                throw new ArgumentNullException(nameof(codeTarget));
-            }
-
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-
-            return new DefaultDocumentWriter(codeTarget, options);
-        }
-
         public abstract RazorCSharpDocument WriteDocument(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectChangeEventArgs.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectChangeEventArgs.cs
@@ -7,31 +7,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     internal class ProjectChangeEventArgs : EventArgs
     {
-        [Obsolete("Adding this as a workaround to unblock live share")]
-        public ProjectChangeEventArgs(string projectFilePath, ProjectChangeKind kind)
-        {
-            if (projectFilePath == null)
-            {
-                throw new ArgumentNullException(nameof(projectFilePath));
-            }
-
-            ProjectFilePath = projectFilePath;
-            Kind = kind;
-        }
-
-        [Obsolete("Adding this as a workaround to unblock live share")]
-        public ProjectChangeEventArgs(string projectFilePath, string documentFilePath, ProjectChangeKind kind)
-        {
-            if (projectFilePath == null)
-            {
-                throw new ArgumentNullException(nameof(projectFilePath));
-            }
-
-            ProjectFilePath = projectFilePath;
-            DocumentFilePath = documentFilePath;
-            Kind = kind;
-        }
-
         public ProjectChangeEventArgs(ProjectSnapshot older, ProjectSnapshot newer, ProjectChangeKind kind)
         {
             if (older == null && newer == null)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/DefaultTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/DefaultTagHelperDescriptorProvider.cs
@@ -9,12 +9,6 @@ namespace Microsoft.CodeAnalysis.Razor
 {
     public sealed class DefaultTagHelperDescriptorProvider : RazorEngineFeatureBase, ITagHelperDescriptorProvider
     {
-        [Obsolete(
-            "This property is obsolete will not be honored. Documentation will be included if " +
-            "TagHelperDescriptorProviderContext.IncludeDocumentation is set to true. Hidden tag helpers will" +
-            "be excluded from the results if TagHelperDescriptorProviderContext.ExcludeHidden is set to true.")]
-        public bool DesignTime { get; set; }
-
         public int Order { get; set; }
 
         public void Execute(TagHelperDescriptorProviderContext context)


### PR DESCRIPTION
- The `DocumentWriter` case should never be called because you need to override a lot of the internals of the RazorEngine to get to the document writer. Therefore, little harm in removing the method.
- `ProjectChangeEventArgs` used to be uised by the LiveShare extension. We've since taken ownership of those bits and no longer need to maintain those constructors.
- `DefaultTagHelperDescriptorProvider.DesignTime` didn't actually do anything. Removing since the code was truly dead and did nothing functionally.
- Made the decision to not remove a lot of the obsolete methods we have on RazorEngine because we'd be breaking people for no reason.

aspnet/AspNetCore#7146