### PR TITLE
Re-enable skipped test

### DIFF
--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildPerformanceTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildPerformanceTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         {
         }
 
-        [Fact(Skip = "https://github.com/aspnet/AspNetCore-Internal/issues/1860")]
+        [Fact]
         [InitializeTestProject("SimpleMvc")]
         public async Task BuildMvcApp()
         {
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             }
         }
 
-        [Fact(Skip = "https://github.com/aspnet/AspNetCore-Internal/issues/1860")]
+        [Fact]
         [InitializeTestProject("MvcWithComponents")]
         public async Task BuildMvcAppWithComponents()
         {
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 }
 
                 var match = matcher.Match(lines[i]);
-                Assert.True(match.Success, $"Line {lines[i]} did not match.");
+                Assert.True(match.Success, $"Line {lines[i]} did not match. Full Output: {output}");
 
                 var entry = new PerformanceSummaryEntry
                 {


### PR DESCRIPTION
Reverts https://github.com/aspnet/AspNetCore-Tooling/commit/0598ec449702813456129996dc854b75ac64649a

Fixes https://github.com/aspnet/AspNetCore-Internal/issues/1860

Added more logging. Will re-run here for a little while to check if it fails. If not(more likely because this test only ever failed once), I'll merge it and we'll have more info the next time if it fails.