### PR TITLE
[Port] Correctly normalize file path from network shares (#298)

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectFileSystem.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectFileSystem.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var file = new FileInfo(absolutePath);
             if (!absolutePath.StartsWith(absoluteBasePath))
             {
-                throw new InvalidOperationException($"The file '{file.FullName}' is not a descendent of the base path '{absoluteBasePath}'.");
+                throw new InvalidOperationException($"The file '{absolutePath}' is not a descendent of the base path '{absoluteBasePath}'.");
             }
 
             var relativePhysicalPath = file.FullName.Substring(absoluteBasePath.Length + 1); // Include leading separator
@@ -68,9 +68,15 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(path));
             }
 
-            var absolutePath = path;
-            if (!absolutePath.StartsWith(Root, StringComparison.OrdinalIgnoreCase))
+            var absolutePath = path.Replace('\\', '/');
+
+            // Check if the given path is an absolute path. It is absolute if,
+            // 1. It starts with Root or
+            // 2. It is a network share path and starts with a '//'. Eg. //servername/some/network/folder
+            if (!absolutePath.StartsWith(Root, StringComparison.OrdinalIgnoreCase) &&
+                !absolutePath.StartsWith("//", StringComparison.OrdinalIgnoreCase))
             {
+                // This is not an absolute path. Strip the leading slash if any and combine it with Root.
                 if (path[0] == '/' || path[0] == '\\')
                 {
                     path = path.Substring(1);


### PR DESCRIPTION
Port of the fix from https://github.com/aspnet/AspNetCore-Tooling/pull/298

@rynowak. fyi I am merging this to `release/vs16.0-preview4`. Let me know if you instead prefer we create a separate `release/vs16.0-preview4-servicing` branch.