### PR TITLE
Enable IntelliSense for new component parameters.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
@@ -101,9 +101,14 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                         project = e.OldSolution.GetProject(e.ProjectId);
                         var document = project.GetDocument(e.DocumentId);
 
+                        if (document.FilePath == null)
+                        {
+                            break;
+                        }
+
                         // Using EndsWith because Path.GetExtension will ignore everything before .cs
                         // Using Ordinal because the SDK generates these filenames.
-                        if (document.FilePath != null && document.FilePath.EndsWith(".cshtml.g.cs", StringComparison.Ordinal))
+                        if (document.FilePath.EndsWith(".cshtml.g.cs", StringComparison.Ordinal) || document.FilePath.EndsWith(".razor.g.cs", StringComparison.Ordinal))
                         {
                             EnqueueUpdate(e.ProjectId);
                         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/FilePathComparison.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/FilePathComparison.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.CodeAnalysis.Razor
+{
+    internal static class FilePathComparison
+    {
+        private static StringComparison? _instance;
+
+        public static StringComparison Instance
+        {
+            get
+            {
+                if (_instance == null && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    _instance = StringComparison.Ordinal;
+                }
+                else if (_instance == null)
+                {
+                    _instance = StringComparison.OrdinalIgnoreCase;
+                }
+
+                return _instance.Value;
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorDirectiveCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorDirectiveCompletionProvider.cs
@@ -97,8 +97,13 @@ namespace Microsoft.VisualStudio.Editor.Razor
             }
 
             // FilePath will be null when the editor is open for cases where we don't have a file on disk (C# interactive window and others).
-            if (context.Document?.FilePath == null ||
-                !context.Document.FilePath.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase))
+            if (context.Document?.FilePath == null)
+            {
+                // Cannot detect a file path, can't determine if we should provide directive completion.
+                return Task.CompletedTask;
+            }
+
+            if (!context.Document.FilePath.EndsWith(".cshtml", FilePathComparison.Instance) && !context.Document.FilePath.EndsWith(".razor", FilePathComparison.Instance))
             {
                 // Not a Razor file.
                 return Task.CompletedTask;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/RazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/RazorDynamicFileInfoProvider.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Internal;
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     [System.Composition.Shared]
-    [ExportMetadata("Extensions", new string[] { "cshtml", })]
+    [ExportMetadata("Extensions", new string[] { "cshtml", "razor", })]
     [Export(typeof(RazorDynamicFileInfoProvider))]
     [Export(typeof(IDynamicFileInfoProvider))]
     internal class RazorDynamicFileInfoProvider : IDynamicFileInfoProvider

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/TestProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/TestProjectWorkspaceStateGenerator.cs
@@ -28,5 +28,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Test
             var update = (workspaceProject, projectSnapshot);
             _updates.Add(update);
         }
+
+        public void ClearQueue()
+        {
+            _updates.Clear();
+        }
     }
 }


### PR DESCRIPTION
- Added a `FilePathComparison` object since not all string methods allow a comparer.
- Updated `RazorDirectiveCompletionProvider` to also understand `.razor` files. This is an edge case scenario where users have disabled modern completion and are using Razor components (you need a reg key to disable the modern completion or MS needs to disable it).
- Tested this in VS by referencing the latest Razor SDK (preview 3) from NuGet and then replacing the Razor design time targets in VS to be the ones from the preview 3 package.

![image](https://i.imgur.com/XNa0PVZ.gif)

#8064
