### PR TITLE
Don't reference FilePathComparison in RazorDirectiveCompletionProvider

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorDirectiveCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorDirectiveCompletionProvider.cs
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 return Task.CompletedTask;
             }
 
-            if (!context.Document.FilePath.EndsWith(".cshtml", FilePathComparison.Instance) && !context.Document.FilePath.EndsWith(".razor", FilePathComparison.Instance))
+            if (!context.Document.FilePath.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase) && !context.Document.FilePath.EndsWith(".razor", FilePathComparison.Instance))
             {
                 // Not a Razor file.
                 return Task.CompletedTask;


### PR DESCRIPTION
We don't want `CodeAnalysis.Razor` to load for non-cshtml completions. Referencing `FilePathComparison` makes that assembly to load. This is breaking RPS tests.