### PR TITLE
Move remaining Windows build job to BYOC queues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,6 @@ jobs:
     - job: Code_check
       displayName: Code check
       pool:
-        # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
         ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
           name: NetCorePublic-Int-Pool
           queue: BuildPool.Windows.10.Amd64.VS2019.BT.Open
@@ -55,11 +54,12 @@ jobs:
     jobs:
     - job: Windows
       pool:
-        # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
         ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-          name: dotnet-external-vs2019-preview
+          name: NetCorePublic-Int-Pool
+          queue: BuildPool.Windows.10.Amd64.VS2019.BT.Open
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          name: dotnet-internal-vs2019-preview
+          name: NetCoreInternal-Int-Pool
+          queue: BuildPool.Windows.10.Amd64.VS2019.BT
       strategy:
         matrix:
           debug:
@@ -95,6 +95,8 @@ jobs:
         - group: DotNet-Blob-Feed
         - group: DotNet-Symbol-Server-Pats
       steps:
+      - powershell: ./eng/scripts/InstallVisualStudio.ps1 -Edition BuildTools -Quiet
+        displayName: Install Build Tools for Visual Studio 2019
       - script: eng\common\cibuild.cmd 
           -configuration $(_BuildConfig)
           -prepareMachine

--- a/eng/scripts/InstallVisualStudio.ps1
+++ b/eng/scripts/InstallVisualStudio.ps1
@@ -1,0 +1,104 @@
+<#
+.SYNOPSIS
+    Installs or updates Visual Studio on a local developer machine.
+.DESCRIPTION
+    This installs Visual Studio along with all the workloads required to contribute to this repository.
+.PARAMETER Edition
+    Selects which 'offering' of Visual Studio to install. Must be one of these values:
+        BuildTools
+        Community
+        Professional
+        Enterprise (the default)
+.PARAMETER InstallPath
+    The location on disk where Visual Studio should be installed or updated. Default path is location of latest
+    existing installation of the specified edition, if any. If that VS edition is not currently installed, default
+    path is '${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\`$Edition".
+.PARAMETER Passive
+    Run the installer without requiring interaction.
+.PARAMETER Quiet
+    Run the installer without UI and wait for installation to complete.
+.LINK
+    https://visualstudio.com
+    https://github.com/aspnet/AspNetCore/blob/master/docs/BuildFromSource.md
+.EXAMPLE
+    To install VS 2019 Enterprise, run this command in PowerShell:
+
+        .\InstallVisualStudio.ps1
+#>
+[CmdletBinding(DefaultParameterSetName = 'Default')]
+param(
+    [ValidateSet('BuildTools','Community', 'Professional', 'Enterprise')]
+    [string]$Edition = 'Enterprise',
+    [string]$InstallPath,
+    [switch]$Passive,
+    [switch]$Quiet
+)
+
+if ($Passive -and $Quiet) {
+    Write-Host "The -Passive and -Quiet options cannot be used together." -f Red
+    Write-Host "Run ``Get-Help $PSCommandPath`` for more details." -f Red
+    exit 1
+}
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 1
+
+$intermedateDir = "$PSScriptRoot\obj"
+mkdir $intermedateDir -ErrorAction Ignore | Out-Null
+
+$bootstrapper = "$intermedateDir\vsinstaller.exe"
+$ProgressPreference = 'SilentlyContinue' # Workaround PowerShell/PowerShell#2138
+Invoke-WebRequest -Uri "https://aka.ms/vs/16/release/vs_$($Edition.ToLowerInvariant()).exe" -OutFile $bootstrapper
+
+$productId = "Microsoft.VisualStudio.Product.$Edition"
+if (-not $InstallPath) {
+    $vsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path $vsWhere)
+    {
+        $InstallPath = &$vsWhere -version '[16,17)' -latest -prerelease -products $productId -property installationPath
+    }
+}
+
+if (-not $InstallPath) {
+    $InstallPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\$Edition"
+}
+
+# no backslashes - this breaks the installer
+$InstallPath = $InstallPath.TrimEnd('\')
+
+[string[]] $arguments = @()
+if (Test-path $InstallPath) {
+    $arguments += 'modify'
+}
+
+$responseFile = "$PSScriptRoot\vs.json"
+if ("$Edition" -eq "BuildTools") {
+    $responseFile = "$PSScriptRoot\vs.buildtools.json"
+}
+
+$arguments += `
+    '--productId', $productId, `
+    '--installPath', "`"$InstallPath`"", `
+    '--in', "`"$responseFile`"", `
+    '--norestart'
+
+if ($Passive) {
+    $arguments += '--passive'
+}
+if ($Quiet) {
+    $arguments += '--quiet', '--wait'
+}
+
+Write-Host ""
+Write-Host "Installing Visual Studio 2019 $Edition" -f Magenta
+Write-Host ""
+Write-Host "Running '$bootstrapper $arguments'"
+
+$process = Start-Process -FilePath "$bootstrapper" -ArgumentList $arguments `
+    -PassThru -RedirectStandardError "$intermedateDir\errors.txt" -Verbose -Wait
+if ($process.ExitCode -ne 0) {
+    Get-Content "$intermedateDir\errors.txt" | Write-Error
+}
+
+Remove-Item "$intermedateDir\errors.txt" -errorAction SilentlyContinue
+exit $process.ExitCode

--- a/eng/scripts/vs.buildtools.json
+++ b/eng/scripts/vs.buildtools.json
@@ -1,0 +1,23 @@
+{
+    "channelUri": "https://aka.ms/vs/16/pre/channel",
+    "channelId": "VisualStudio.16.Preview",
+    "includeRecommended": false,
+    "addProductLang": [
+        "en-US"
+    ],
+    "add": [
+        "Microsoft.Net.Component.4.6.1.TargetingPack",
+        "Microsoft.Net.Component.4.6.2.TargetingPack",
+        "Microsoft.Net.Component.4.7.1.TargetingPack",
+        "Microsoft.Net.Component.4.7.2.SDK",
+        "Microsoft.Net.Component.4.7.2.TargetingPack",
+        "Microsoft.Net.Component.4.7.TargetingPack",
+        "Microsoft.VisualStudio.Component.FSharp.MSBuild",
+        "Microsoft.VisualStudio.Component.NuGet",
+        "Microsoft.VisualStudio.Component.NuGet.BuildTools",
+        "Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools",
+        "Microsoft.VisualStudio.Workload.MSBuildTools",
+        "Microsoft.VisualStudio.Workload.NetCoreBuildTools",
+        "Microsoft.VisualStudio.Workload.VisualStudioExtensionBuildTools"
+    ]
+}

--- a/eng/scripts/vs.json
+++ b/eng/scripts/vs.json
@@ -1,0 +1,19 @@
+{
+    "channelUri": "https://aka.ms/vs/16/pre/channel",
+    "channelId": "VisualStudio.16.Preview",
+    "includeRecommended": false,
+    "addProductLang": [
+        "en-US"
+    ],
+    "add": [
+        "Microsoft.Net.Component.4.6.1.TargetingPack",
+        "Microsoft.Net.Component.4.6.2.TargetingPack",
+        "Microsoft.Net.Component.4.7.1.TargetingPack",
+        "Microsoft.Net.Component.4.7.2.SDK",
+        "Microsoft.Net.Component.4.7.2.TargetingPack",
+        "Microsoft.Net.Component.4.7.TargetingPack",
+        "Microsoft.VisualStudio.Workload.ManagedDesktop",
+        "Microsoft.VisualStudio.Workload.NetCoreTools",
+        "Microsoft.VisualStudio.Workload.VisualStudioExtension"
+    ]
+}

--- a/global.json
+++ b/global.json
@@ -6,7 +6,8 @@
       "components": [
         "Microsoft.VisualStudio.Component.VSSDK"
       ]
-    }
+    },
+    "xcopy-msbuild": "16.0.0-rc1-alpha"
   },
   "sdk": {
     "version": "3.0.100-preview3-010280"


### PR DESCRIPTION
- aspnet/AspNetCore-Internal#2033
- install necessary Build Tools for Visual Studio 2019 components and workloads on CI
- copy updated InstallVisualStudio.ps1 script from aspnet/AspNetCore#8694
  - bring over associated vs*.json files but only install components and workloads needed in this repo