### PR TITLE
Chain coherence links up to aspnet/Extensions

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Extensions.CommandLineUtils.Sources" Version="3.0.0-preview4.19173.1">
+    <Dependency Name="Microsoft.Extensions.CommandLineUtils.Sources" Version="3.0.0-preview4.19175.2">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>53529bbc7740f3b6cf9253873c204b10ca4dafe2</Sha>
+      <Sha>d3aa695463bd62b9f3d7cf218a8825a163e69312</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.HashCodeCombiner.Sources" Version="3.0.0-preview4.19173.1">
+    <Dependency Name="Microsoft.Extensions.HashCodeCombiner.Sources" Version="3.0.0-preview4.19175.2">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>53529bbc7740f3b6cf9253873c204b10ca4dafe2</Sha>
+      <Sha>d3aa695463bd62b9f3d7cf218a8825a163e69312</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.NonCapturingTimer.Sources" Version="3.0.0-preview4.19173.1">
+    <Dependency Name="Microsoft.Extensions.NonCapturingTimer.Sources" Version="3.0.0-preview4.19175.2">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>53529bbc7740f3b6cf9253873c204b10ca4dafe2</Sha>
+      <Sha>d3aa695463bd62b9f3d7cf218a8825a163e69312</Sha>
     </Dependency>
     <Dependency Name="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview4.19164.7" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
@@ -25,7 +25,7 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>67fa5f44c982d3e7ea3d8f146b9c1922ff89d19c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview4-27522-10">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview4-27522-10" CoherentParentDependency="Microsoft.Extensions.CommandLineUtils.Sources">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>67fa5f44c982d3e7ea3d8f146b9c1922ff89d19c</Sha>
     </Dependency>
@@ -36,13 +36,13 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>d6a30736858f91b297fdd3ed4e3d1dfde67bdbdb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="3.0.0-preview4.19173.1">
+    <Dependency Name="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="3.0.0-preview4.19175.2">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>53529bbc7740f3b6cf9253873c204b10ca4dafe2</Sha>
+      <Sha>d3aa695463bd62b9f3d7cf218a8825a163e69312</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Testing" Version="3.0.0-preview4.19173.1">
+    <Dependency Name="Microsoft.AspNetCore.Testing" Version="3.0.0-preview4.19175.2">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>53529bbc7740f3b6cf9253873c204b10ca4dafe2</Sha>
+      <Sha>d3aa695463bd62b9f3d7cf218a8825a163e69312</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19162.7">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -55,12 +55,12 @@
 
   -->
   <PropertyGroup Label="Automated">
-    <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>3.0.0-preview4.19173.1</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
-    <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-preview4.19173.1</MicrosoftAspNetCoreTestingPackageVersion>
-    <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>3.0.0-preview4.19173.1</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
+    <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>3.0.0-preview4.19175.2</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
+    <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-preview4.19175.2</MicrosoftAspNetCoreTestingPackageVersion>
+    <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>3.0.0-preview4.19175.2</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
     <MicrosoftExtensionsDependencyModelPackageVersion>3.0.0-preview4-27522-10</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.0.0-preview4.19173.1</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
-    <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>3.0.0-preview4.19173.1</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
+    <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.0.0-preview4.19175.2</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
+    <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>3.0.0-preview4.19175.2</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview4-27522-10</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview4.19164.7</MicrosoftNETCorePlatformsPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.6.0-preview4.19164.7</SystemDiagnosticsDiagnosticSourcePackageVersion>


### PR DESCRIPTION
- specific Extensions package doesn't matter much since packages from that repo will move together
- should reduce the builds of AspNetCore-Tooling that AspNetCore can't take

In this first iteration, Extensions hasn't built recently and (so) no other dependencies changed