### PR TITLE
Remove base.BuildRenderTree calls

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentDocumentClassifierPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentDocumentClassifierPass.cs
@@ -13,7 +13,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
     internal class ComponentDocumentClassifierPass : DocumentClassifierPassBase
     {
         public static readonly string ComponentDocumentKind = "component.1.0";
-        private static readonly object BuildRenderTreeBaseCallAnnotation = new object();
 
         /// <summary>
         /// The fallback value of the root namespace. Only used if the fallback root namespace
@@ -116,20 +115,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
                     ParameterName = "builder",
                     TypeName = ComponentsApi.RenderTreeBuilder.FullTypeName,
                 });
-
-                // We need to call the 'base' method as the first statement.
-                var callBase = new CSharpCodeIntermediateNode();
-                callBase.Annotations.Add(BuildRenderTreeBaseCallAnnotation, true);
-                callBase.Children.Add(new IntermediateToken
-                {
-                    Kind = TokenKind.CSharp,
-                    Content = $"base.{ComponentsApi.ComponentBase.BuildRenderTree}(builder);"
-                });
-                method.Children.Insert(0, callBase);
             }
         }
-
-        internal static bool IsBuildRenderTreeBaseCall(CSharpCodeIntermediateNode node)
-            => node.Annotations[BuildRenderTreeBaseCallAnnotation] != null;
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentWhitespacePass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentWhitespacePass.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
                     case CSharpCodeIntermediateNode codeIntermediateNode:
                         shouldRemoveNode = false;
-                        shouldContinueIteration = ComponentDocumentClassifierPass.IsBuildRenderTreeBaseCall(codeIntermediateNode);
+                        shouldContinueIteration = false;
                         break;
 
                     default:

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.codegen.cs
@@ -30,7 +30,6 @@ IDisposable __typeHelper = default(IDisposable);
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent.cshtml"
        __o = this.ToString();

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.ir.txt
@@ -15,8 +15,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (25:1,0 [91] BasicComponent.cshtml) - div
                     HtmlAttribute - (29:1,4 [25] BasicComponent.cshtml) -  class=" - "
                         CSharpExpressionAttributeValue - (37:1,12 [16] BasicComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.mappings.txt
@@ -5,19 +5,19 @@ Generated Location: (641:17,0 [11] )
 
 Source Location: (38:1,13 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent.cshtml)
 |this.ToString()|
-Generated Location: (1275:35,13 [15] )
+Generated Location: (1231:34,13 [15] )
 |this.ToString()|
 
 Source Location: (79:3,5 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent.cshtml)
 |string.Format("{0}", "Hello")|
-Generated Location: (1458:42,6 [29] )
+Generated Location: (1414:41,6 [29] )
 |string.Format("{0}", "Hello")|
 
 Source Location: (132:6,12 [37] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent.cshtml)
 |
     void IDisposable.Dispose(){ }
 |
-Generated Location: (1710:51,12 [37] )
+Generated Location: (1666:50,12 [37] )
 |
     void IDisposable.Dispose(){ }
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_Runtime.codegen.cs
@@ -14,7 +14,6 @@ namespace __GeneratedComponent
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "div");
             builder.AddAttribute(1, "class", this.ToString());
             builder.AddContent(2, "\r\n    Hello world\r\n    ");

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_Runtime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_Runtime.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (102:4,1 [37] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - AspNetCore_d3c3d6059615673cb46fc4974164d61eabadb890 - Microsoft.AspNetCore.Components.ComponentBase - IDisposable
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (25:1,0 [91] BasicComponent.cshtml) - div
                     HtmlAttribute - (29:1,4 [25] BasicComponent.cshtml) -  class=" - "
                         CSharpExpressionAttributeValue - (37:1,12 [16] BasicComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.codegen.cs
@@ -26,7 +26,6 @@ using System.Threading.Tasks;
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, "async (e) => await Task.Delay(10)");
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
                 MarkupElement - (31:1,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - input

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.codegen.cs
@@ -26,7 +26,6 @@ using System.Threading.Tasks;
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, OnClick);
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
                 MarkupElement - (31:1,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Generated Location: (285:11,0 [28] )
 
 Source Location: (48:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
-Generated Location: (1068:29,135 [7] )
+Generated Location: (1024:28,135 [7] )
 |OnClick|
 
 Source Location: (73:2,12 [91] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -15,7 +15,7 @@ Source Location: (73:2,12 [91] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1210:34,12 [91] )
+Generated Location: (1166:33,12 [91] )
 |
     Task OnClick(UIMouseEventArgs e) 
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.codegen.cs
@@ -26,7 +26,6 @@ using System.Threading.Tasks;
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, "async (e) => await Task.Delay(10)");
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
                 MarkupElement - (31:1,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - input

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
@@ -26,7 +26,6 @@ using System.Threading.Tasks;
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, OnClick);
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
                 MarkupElement - (31:1,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Generated Location: (285:11,0 [28] )
 
 Source Location: (48:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
-Generated Location: (1068:29,135 [7] )
+Generated Location: (1024:28,135 [7] )
 |OnClick|
 
 Source Location: (73:2,12 [73] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -15,7 +15,7 @@ Source Location: (73:2,12 [73] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1210:34,12 [73] )
+Generated Location: (1166:33,12 [73] )
 |
     Task OnClick() 
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [40] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1056:26,25 [11] )
+Generated Location: (1012:25,25 [11] )
 |ParentValue|
 
 Source Location: (54:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (2082:49,12 [50] )
+Generated Location: (2038:48,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [44] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml) - SomeParam - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1062:26,29 [11] )
+Generated Location: (1018:25,29 [11] )
 |ParentValue|
 
 Source Location: (58:1,12 [65] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |
-Generated Location: (1655:44,12 [65] )
+Generated Location: (1611:43,12 [65] )
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [40] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1056:26,25 [11] )
+Generated Location: (1012:25,25 [11] )
 |ParentValue|
 
 Source Location: (54:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1923:48,12 [50] )
+Generated Location: (1879:47,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [40] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1056:26,25 [11] )
+Generated Location: (1012:25,25 [11] )
 |ParentValue|
 
 Source Location: (54:1,12 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "42";
 |
-Generated Location: (1923:48,12 [55] )
+Generated Location: (1879:47,12 [55] )
 |
     public string ParentValue { get; set; } = "42";
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [50] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1066:26,35 [11] )
+Generated Location: (1022:25,35 [11] )
 |ParentValue|
 
 Source Location: (64:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1676:48,12 [50] )
+Generated Location: (1632:47,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [50] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (995:26,35 [11] )
+Generated Location: (951:25,35 [11] )
 |ParentValue|
 
 Source Location: (64:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1644:47,12 [50] )
+Generated Location: (1600:46,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [40] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1056:26,25 [11] )
+Generated Location: (1012:25,25 [11] )
 |ParentValue|
 
 Source Location: (54:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1825:49,12 [50] )
+Generated Location: (1781:48,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [44] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml) - SomeParam - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1062:26,29 [11] )
+Generated Location: (1018:25,29 [11] )
 |ParentValue|
 
 Source Location: (58:1,12 [65] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |
-Generated Location: (1498:44,12 [65] )
+Generated Location: (1454:43,12 [65] )
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [40] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1056:26,25 [11] )
+Generated Location: (1012:25,25 [11] )
 |ParentValue|
 
 Source Location: (54:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1666:48,12 [50] )
+Generated Location: (1622:47,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [40] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (985:26,25 [11] )
+Generated Location: (941:25,25 [11] )
 |ParentValue|
 
 Source Location: (54:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1634:47,12 [50] )
+Generated Location: (1590:46,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [40] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1056:26,25 [11] )
+Generated Location: (1012:25,25 [11] )
 |ParentValue|
 
 Source Location: (54:1,12 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "42";
 |
-Generated Location: (1666:48,12 [55] )
+Generated Location: (1622:47,12 [55] )
 |
     public string ParentValue { get; set; } = "42";
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [38] x:\dir\subdir\Test\TestComponent.cshtml) - InputText
                     ComponentAttribute - (23:0,23 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (23:0,23 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |person.Name|
-Generated Location: (1055:26,23 [11] )
+Generated Location: (1011:25,23 [11] )
 |person.Name|
 
 Source Location: (56:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     Person person = new Person();
 |
-Generated Location: (1653:48,1 [37] )
+Generated Location: (1609:47,1 [37] )
 |
     Person person = new Person();
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(CurrentDate, "MM/dd");
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => CurrentDate = __value, CurrentDate, "MM/dd");
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [77] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (41:0,41 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (888:23,71 [11] )
+Generated Location: (844:22,71 [11] )
 |CurrentDate|
 
 Source Location: (91:1,12 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1192:29,12 [77] )
+Generated Location: (1148:28,12 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [56] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (41:0,41 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (888:23,71 [11] )
+Generated Location: (844:22,71 [11] )
 |ParentValue|
 
 Source Location: (70:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1174:29,12 [50] )
+Generated Location: (1130:28,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [33] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (17:0,17 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (18:0,18 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (888:23,71 [11] )
+Generated Location: (844:22,71 [11] )
 |ParentValue|
 
 Source Location: (47:1,12 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1174:29,12 [55] )
+Generated Location: (1130:28,12 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [32] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (17:0,17 [11] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (17:0,17 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (888:23,71 [11] )
+Generated Location: (844:22,71 [11] )
 |ParentValue|
 
 Source Location: (46:1,12 [55] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.mappings.txt
@@ -7,7 +7,7 @@ Source Location: (46:1,12 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1174:29,12 [55] )
+Generated Location: (1130:28,12 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [27] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (11:0,11 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (12:0,12 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (888:23,71 [11] )
+Generated Location: (844:22,71 [11] )
 |ParentValue|
 
 Source Location: (41:1,12 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1174:29,12 [55] )
+Generated Location: (1130:28,12 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    RenderFragment<string> header = (context) => 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [46] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [46] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  RenderFragment<string> header = (context) => 
                 Template - (49:0,49 [38] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (2:0,2 [46] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderFragment<string> header = (context) => |
-Generated Location: (889:25,2 [46] )
+Generated Location: (845:24,2 [46] )
 | RenderFragment<string> header = (context) => |
 
 Source Location: (55:0,55 [26] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLowerInvariant()|
-Generated Location: (1141:33,55 [26] )
+Generated Location: (1097:32,55 [26] )
 |context.ToLowerInvariant()|
 
 Source Location: (87:0,87 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
-Generated Location: (1392:41,87 [2] )
+Generated Location: (1348:40,87 [2] )
 |; |
 
 Source Location: (113:1,21 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |header|
-Generated Location: (1623:49,21 [6] )
+Generated Location: (1579:48,21 [6] )
 |header|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    RenderFragment<string> header = (context) => 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [46] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [46] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  RenderFragment<string> header = (context) => 
                 Template - (49:0,49 [38] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (2:0,2 [46] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderFragment<string> header = (context) => |
-Generated Location: (889:25,2 [46] )
+Generated Location: (845:24,2 [46] )
 | RenderFragment<string> header = (context) => |
 
 Source Location: (55:0,55 [26] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLowerInvariant()|
-Generated Location: (1141:33,55 [26] )
+Generated Location: (1097:32,55 [26] )
 |context.ToLowerInvariant()|
 
 Source Location: (87:0,87 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
-Generated Location: (1392:41,87 [2] )
+Generated Location: (1348:40,87 [2] )
 |; |
 
 Source Location: (113:1,21 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |header|
-Generated Location: (1623:49,21 [6] )
+Generated Location: (1579:48,21 [6] )
 |header|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(Enabled);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => Enabled = __value, Enabled);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [8] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (30:0,30 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |Enabled|
-Generated Location: (888:23,71 [7] )
+Generated Location: (844:22,71 [7] )
 |Enabled|
 
 Source Location: (55:1,12 [41] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public bool Enabled { get; set; }
 |
-Generated Location: (1162:29,12 [41] )
+Generated Location: (1118:28,12 [41] )
 |
     public bool Enabled { get; set; }
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(CurrentDate, Format);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => CurrentDate = __value, CurrentDate, Format);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [63] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
@@ -1,11 +1,11 @@
 Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (888:23,71 [11] )
+Generated Location: (844:22,71 [11] )
 |CurrentDate|
 
 Source Location: (54:0,54 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |Format|
-Generated Location: (901:23,84 [6] )
+Generated Location: (857:22,84 [6] )
 |Format|
 
 Source Location: (77:1,12 [135] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -14,7 +14,7 @@ Source Location: (77:1,12 [135] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public string Format { get; set; } = "MM/dd/yyyy";
 |
-Generated Location: (1190:29,12 [135] )
+Generated Location: (1146:28,12 [135] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(CurrentDate, "MM/dd/yyyy");
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => CurrentDate = __value, CurrentDate, "MM/dd/yyyy");
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [66] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (888:23,71 [11] )
+Generated Location: (844:22,71 [11] )
 |CurrentDate|
 
 Source Location: (80:1,12 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1202:29,12 [77] )
+Generated Location: (1158:28,12 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (888:23,71 [11] )
+Generated Location: (844:22,71 [11] )
 |ParentValue|
 
 Source Location: (55:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1174:29,12 [50] )
+Generated Location: (1130:28,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [29] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (13:0,13 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (14:0,14 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (888:23,71 [11] )
+Generated Location: (844:22,71 [11] )
 |ParentValue|
 
 Source Location: (43:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1174:29,12 [50] )
+Generated Location: (1130:28,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = typeof(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [42] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentTypeArgument - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - TItem
                         IntermediateToken - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - string

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |string|
-Generated Location: (933:26,19 [6] )
+Generated Location: (889:25,19 [6] )
 |string|
 
 Source Location: (34:0,34 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hi"|
-Generated Location: (1196:35,34 [4] )
+Generated Location: (1152:34,34 [4] )
 |"hi"|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = typeof(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [43] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentTypeArgument - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - TItem
                         IntermediateToken - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - string

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |string|
-Generated Location: (933:26,19 [6] )
+Generated Location: (889:25,19 [6] )
 |string|
 
 Source Location: (36:0,36 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1251:35,36 [5] )
+Generated Location: (1207:34,36 [5] )
 |Value|
 
 Source Location: (57:1,12 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1845:57,12 [21] )
+Generated Location: (1801:56,12 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = typeof(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [43] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentTypeArgument - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - TItem
                         IntermediateToken - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - string

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |string|
-Generated Location: (933:26,19 [6] )
+Generated Location: (889:25,19 [6] )
 |string|
 
 Source Location: (36:0,36 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1186:35,36 [5] )
+Generated Location: (1142:34,36 [5] )
 |Value|
 
 Source Location: (57:1,12 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1819:56,12 [21] )
+Generated Location: (1775:55,12 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [42] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (35:0,35 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - (36:0,36 [4] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (37:0,37 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |18|
-Generated Location: (1017:26,37 [2] )
+Generated Location: (973:25,37 [2] )
 |18|
 
 Source Location: (23:0,23 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1237:34,23 [5] )
+Generated Location: (1193:33,23 [5] )
 |Value|
 
 Source Location: (56:1,12 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1705:51,12 [21] )
+Generated Location: (1661:50,12 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [30] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (23:0,23 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (23:0,23 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1056:26,23 [5] )
+Generated Location: (1012:25,23 [5] )
 |Value|
 
 Source Location: (44:1,12 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1457:44,12 [21] )
+Generated Location: (1413:43,12 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = typeof(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [90] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent -  - ChildContent - context
                         HtmlContent - (41:0,41 [4] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |string|
-Generated Location: (933:26,19 [6] )
+Generated Location: (889:25,19 [6] )
 |string|
 
 Source Location: (34:0,34 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hi"|
-Generated Location: (1196:35,34 [4] )
+Generated Location: (1152:34,34 [4] )
 |"hi"|
 
 Source Location: (51:1,8 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLower()|
-Generated Location: (1486:44,8 [17] )
+Generated Location: (1442:43,8 [17] )
 |context.ToLower()|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [77] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent -  - ChildContent - context
                         HtmlContent - (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (21:0,21 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hi"|
-Generated Location: (1001:26,21 [4] )
+Generated Location: (957:25,21 [4] )
 |"hi"|
 
 Source Location: (38:1,8 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLower()|
-Generated Location: (1183:34,8 [17] )
+Generated Location: (1139:33,8 [17] )
 |context.ToLower()|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = typeof(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [56] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentTypeArgument - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - TItem
                         IntermediateToken - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - string

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |string|
-Generated Location: (933:26,19 [6] )
+Generated Location: (889:25,19 [6] )
 |string|
 
 Source Location: (34:0,34 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hi"|
-Generated Location: (1196:35,34 [4] )
+Generated Location: (1152:34,34 [4] )
 |"hi"|
 
 Source Location: (50:0,50 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |17|
-Generated Location: (1408:44,50 [2] )
+Generated Location: (1364:43,50 [2] )
 |17|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute_TypeInference/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute_TypeInference/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [43] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (19:0,19 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - (20:0,20 [6] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute_TypeInference/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (21:0,21 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hi"|
-Generated Location: (1001:26,21 [4] )
+Generated Location: (957:25,21 [4] )
 |"hi"|
 
 Source Location: (37:0,37 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |17|
-Generated Location: (1184:34,37 [2] )
+Generated Location: (1140:33,37 [2] )
 |17|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic_TypeInference/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic_TypeInference/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [29] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (19:0,19 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - (20:0,20 [6] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic_TypeInference/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (21:0,21 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hi"|
-Generated Location: (1001:26,21 [4] )
+Generated Location: (957:25,21 [4] )
 |"hi"|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic_TypeInference_Multiple/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic_TypeInference_Multiple/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic_TypeInference_Multiple/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic_TypeInference_Multiple/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [29] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (19:0,19 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - (20:0,20 [6] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic_TypeInference_Multiple/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic_TypeInference_Multiple/TestComponent.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (21:0,21 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hi"|
-Generated Location: (1001:26,21 [4] )
+Generated Location: (957:25,21 [4] )
 |"hi"|
 
 Source Location: (52:1,21 [14] x:\dir\subdir\Test\TestComponent.cshtml)
 |"how are you?"|
-Generated Location: (1407:42,21 [14] )
+Generated Location: (1363:41,21 [14] )
 |"how are you?"|
 
 Source Location: (93:2,21 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |"bye!"|
-Generated Location: (1823:58,21 [6] )
+Generated Location: (1779:57,21 [6] )
 |"bye!"|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.codegen.cs
@@ -27,7 +27,6 @@ using Microsoft.AspNetCore.Components.RenderTree;
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
    RenderChildComponent(builder); 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.ir.txt
@@ -15,8 +15,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (50:0,50 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (50:0,50 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
                 CSharpCode - (56:2,2 [32] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Generated Location: (320:12,0 [49] )
 
 Source Location: (56:2,2 [32] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderChildComponent(builder); |
-Generated Location: (1060:32,2 [32] )
+Generated Location: (1016:31,2 [32] )
 | RenderChildComponent(builder); |
 
 Source Location: (105:4,12 [75] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -13,7 +13,7 @@ Source Location: (105:4,12 [75] x:\dir\subdir\Test\TestComponent.cshtml)
     void RenderChildComponent(RenderTreeBuilder builder)
     {
         |
-Generated Location: (1275:41,12 [75] )
+Generated Location: (1231:40,12 [75] )
 |
     void RenderChildComponent(RenderTreeBuilder builder)
     {
@@ -23,7 +23,7 @@ Source Location: (195:7,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     }
 |
-Generated Location: (1782:61,23 [9] )
+Generated Location: (1738:60,23 [9] )
 |
     }
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.codegen.cs
@@ -27,7 +27,6 @@ using Microsoft.AspNetCore.Components.RenderTree;
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
   

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.ir.txt
@@ -15,8 +15,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (50:0,50 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (50:0,50 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
                 CSharpCode - (54:1,2 [50] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.mappings.txt
@@ -8,7 +8,7 @@ Source Location: (54:1,2 [50] x:\dir\subdir\Test\TestComponent.cshtml)
     void RenderChildComponent()
     {
         |
-Generated Location: (1060:32,2 [50] )
+Generated Location: (1016:31,2 [50] )
 |
     void RenderChildComponent()
     {
@@ -18,13 +18,13 @@ Source Location: (119:4,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     }
 |
-Generated Location: (1554:52,23 [9] )
+Generated Location: (1510:51,23 [9] )
 |
     }
 |
 
 Source Location: (135:8,2 [25] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderChildComponent(); |
-Generated Location: (1685:60,2 [25] )
+Generated Location: (1641:59,2 [25] )
 | RenderChildComponent(); |
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = typeof(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [228] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent - (57:1,2 [58] x:\dir\subdir\Test\TestComponent.cshtml) - ChildContent - context
                         MarkupElement - (71:1,16 [29] x:\dir\subdir\Test\TestComponent.cshtml) - div

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.mappings.txt
@@ -1,25 +1,25 @@
 Source Location: (20:0,20 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |string|
-Generated Location: (934:26,20 [6] )
+Generated Location: (890:25,20 [6] )
 |string|
 
 Source Location: (34:0,34 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |int|
-Generated Location: (1139:35,34 [3] )
+Generated Location: (1095:34,34 [3] )
 |int|
 
 Source Location: (46:0,46 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hi"|
-Generated Location: (1411:44,46 [4] )
+Generated Location: (1367:43,46 [4] )
 |"hi"|
 
 Source Location: (77:1,22 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLower()|
-Generated Location: (1715:53,22 [17] )
+Generated Location: (1671:52,22 [17] )
 |context.ToLower()|
 
 Source Location: (158:3,3 [29] x:\dir\subdir\Test\TestComponent.cshtml)
 |System.Math.Max(0, item.Item)|
-Generated Location: (2068:63,6 [29] )
+Generated Location: (2024:62,6 [29] )
 |System.Math.Max(0, item.Item)|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [229] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent - (58:1,2 [58] x:\dir\subdir\Test\TestComponent.cshtml) - ChildContent - context
                         MarkupElement - (72:1,16 [29] x:\dir\subdir\Test\TestComponent.cshtml) - div

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (21:0,21 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hi"|
-Generated Location: (1001:26,21 [4] )
+Generated Location: (957:25,21 [4] )
 |"hi"|
 
 Source Location: (36:0,36 [16] x:\dir\subdir\Test\TestComponent.cshtml)
 |new List<long>()|
-Generated Location: (1183:34,36 [16] )
+Generated Location: (1139:33,36 [16] )
 |new List<long>()|
 
 Source Location: (78:1,22 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLower()|
-Generated Location: (1391:42,22 [17] )
+Generated Location: (1347:41,22 [17] )
 |context.ToLower()|
 
 Source Location: (159:3,3 [29] x:\dir\subdir\Test\TestComponent.cshtml)
 |System.Math.Max(0, item.Item)|
-Generated Location: (1597:51,6 [29] )
+Generated Location: (1553:50,6 [29] )
 |System.Math.Max(0, item.Item)|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Simple/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Simple/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Simple/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Simple/TestComponent.ir.txt
@@ -14,6 +14,4 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [15] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = "";
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [91] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent -  - ChildContent - context
                         HtmlContent - (26:0,26 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [47] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent -  - ChildContent - context
                         MarkupElement - (13:0,13 [20] x:\dir\subdir\Test\TestComponent.cshtml) - child

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitChildContent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitChildContent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [61] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent - (13:0,13 [34] x:\dir\subdir\Test\TestComponent.cshtml) - ChildContent - context
                         HtmlContent - (27:0,27 [5] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = new System.Action<Microsoft.AspNetCore.Components.UIEventArgs>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (993:26,23 [9] )
+Generated Location: (949:25,23 [9] )
 |Increment|
 
 Source Location: (51:2,12 [100] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (51:2,12 [100] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1500:46,12 [100] )
+Generated Location: (1456:45,12 [100] )
 |
     private int counter;
     private void Increment(UIEventArgs e) {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment<System.String>)((context) => (builder2) => {
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [64] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent - (13:0,13 [37] x:\dir\subdir\Test\TestComponent.cshtml) - ChildContent - context
                         CSharpExpression - (28:0,28 [7] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (28:0,28 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |context|
-Generated Location: (1062:26,28 [7] )
+Generated Location: (1018:25,28 [7] )
 |context|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [49] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (29:0,29 [16] x:\dir\subdir\Test\TestComponent.cshtml) - StringProperty - AttributeStructure.DoubleQuotes
                         CSharpExpression - (31:0,31 [13] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (31:0,31 [13] x:\dir\subdir\Test\TestComponent.cshtml)
 |42.ToString()|
-Generated Location: (1010:26,31 [13] )
+Generated Location: (966:25,31 [13] )
 |42.ToString()|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = "";
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment<System.String>)((context) => (builder2) => {
 #nullable restore

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [107] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent -  - ChildContent - context
                         HtmlContent - (26:0,26 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (54:0,54 [26] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLowerInvariant()|
-Generated Location: (1111:27,54 [26] )
+Generated Location: (1067:26,54 [26] )
 |context.ToLowerInvariant()|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = "";
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment<System.String>)((item) => (builder2) => {
 #nullable restore

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [164] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent - (30:1,2 [118] x:\dir\subdir\Test\TestComponent.cshtml) - ChildContent - item
                         HtmlContent - (59:1,31 [15] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (93:2,32 [23] x:\dir\subdir\Test\TestComponent.cshtml)
 |item.ToLowerInvariant()|
-Generated Location: (1086:27,32 [23] )
+Generated Location: (1042:26,32 [23] )
 |item.ToLowerInvariant()|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = "";
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment<System.String>)((item) => (builder2) => {
 #nullable restore

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [164] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent - (45:1,2 [103] x:\dir\subdir\Test\TestComponent.cshtml) - ChildContent - item
                         HtmlContent - (59:1,16 [15] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (93:2,32 [23] x:\dir\subdir\Test\TestComponent.cshtml)
 |item.ToLowerInvariant()|
-Generated Location: (1086:27,32 [23] )
+Generated Location: (1042:26,32 [23] )
 |item.ToLowerInvariant()|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = new System.Action<Microsoft.AspNetCore.Components.UIEventArgs>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [49] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [24] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [23] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (24:0,24 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |e => { Increment(); }|
-Generated Location: (994:26,24 [21] )
+Generated Location: (950:25,24 [21] )
 |e => { Increment(); }|
 
 Source Location: (65:2,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (65:2,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1513:46,12 [87] )
+Generated Location: (1469:45,12 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = "";
             __o = 
 #nullable restore

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [72] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute -  - some-attribute - AttributeStructure.DoubleQuotes
                         HtmlContent - (29:0,29 [3] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (55:0,55 [13] x:\dir\subdir\Test\TestComponent.cshtml)
 |43.ToString()|
-Generated Location: (985:27,55 [13] )
+Generated Location: (941:26,55 [13] )
 |43.ToString()|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.codegen.cs
@@ -42,7 +42,6 @@ global::System.Object __typeHelper = "/AnotherRoute/{id}";
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.ir.txt
@@ -18,6 +18,4 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (45:2,0 [15] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [132] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (32:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml) - IntProperty - AttributeStructure.DoubleQuotes
                         IntermediateToken - (32:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - 123

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (32:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |123|
-Generated Location: (995:26,17 [3] )
+Generated Location: (951:25,17 [3] )
 |123|
 
 Source Location: (56:2,18 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |true|
-Generated Location: (1247:35,18 [4] )
+Generated Location: (1203:34,18 [4] )
 |true|
 
 Source Location: (115:4,20 [14] x:\dir\subdir\Test\TestComponent.cshtml)
 |new SomeType()|
-Generated Location: (1524:45,20 [14] )
+Generated Location: (1480:44,20 [14] )
 |new SomeType()|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [37] x:\dir\subdir\Test\TestComponent.cshtml) - DynamicElement
                     ComponentAttribute - (25:0,25 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (26:0,26 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
-Generated Location: (1050:26,26 [7] )
+Generated Location: (1006:25,26 [7] )
 |OnClick|
 
 Source Location: (53:2,12 [62] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Action<UIMouseEventArgs> OnClick { get; set; }
 |
-Generated Location: (1558:46,12 [62] )
+Generated Location: (1514:45,12 [62] )
 |
     private Action<UIMouseEventArgs> OnClick { get; set; }
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [43] x:\dir\subdir\Test\TestComponent.cshtml) - CoolnessMeter
                     ComponentAttribute - (25:0,25 [14] x:\dir\subdir\Test\TestComponent.cshtml) - Coolness - AttributeStructure.DoubleQuotes
                         CSharpExpression - (26:0,26 [13] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (27:0,27 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |"very-cool"|
-Generated Location: (1005:26,27 [11] )
+Generated Location: (961:25,27 [11] )
 |"very-cool"|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.codegen.cs
@@ -46,7 +46,6 @@ global::System.Object TItem2 = null;
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 6 "x:\dir\subdir\Test\TestComponent.cshtml"
  foreach (var item2 in Items2)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.ir.txt
@@ -16,8 +16,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (39:0,39 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (39:0,39 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
                 HtmlContent - (79:3,0 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
@@ -17,20 +17,20 @@ Source Location: (98:5,1 [38] x:\dir\subdir\Test\TestComponent.cshtml)
 |foreach (var item2 in Items2)
 {
     |
-Generated Location: (1456:51,1 [38] )
+Generated Location: (1412:50,1 [38] )
 |foreach (var item2 in Items2)
 {
     |
 
 Source Location: (146:8,5 [19] x:\dir\subdir\Test\TestComponent.cshtml)
 |ChildContent(item2)|
-Generated Location: (1622:60,6 [19] )
+Generated Location: (1578:59,6 [19] )
 |ChildContent(item2)|
 
 Source Location: (176:9,8 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |
 }|
-Generated Location: (1773:67,8 [3] )
+Generated Location: (1729:66,8 [3] )
 |
 }|
 
@@ -40,7 +40,7 @@ Source Location: (193:11,12 [164] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter] List<TItem2> Items2 { get; set; }
     [Parameter] RenderFragment<TItem2> ChildContent { get; set; }
 |
-Generated Location: (1960:77,12 [164] )
+Generated Location: (1916:76,12 [164] )
 |
     [Parameter] TItem1 Item1 { get; set; }
     [Parameter] List<TItem2> Items2 { get; set; }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_IgnoresStaticAndAliasUsings/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_IgnoresStaticAndAliasUsings/TestComponent.codegen.cs
@@ -34,7 +34,6 @@ using Foo = Test3;
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_IgnoresStaticAndAliasUsings/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_IgnoresStaticAndAliasUsings/TestComponent.ir.txt
@@ -16,8 +16,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (33:0,33 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (33:0,33 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
                 HtmlContent - (53:1,18 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithDocType/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithDocType/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithDocType/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithDocType/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (0:0,0 [17] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (0:0,0 [17] x:\dir\subdir\Test\TestComponent.cshtml) - Html - <!DOCTYPE html>\n
                 MarkupElement - (17:1,0 [13] x:\dir\subdir\Test\TestComponent.cshtml) - div

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithFullyQualifiedTagNames/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithFullyQualifiedTagNames/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithFullyQualifiedTagNames/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithFullyQualifiedTagNames/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [15] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                 HtmlContent - (15:0,15 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (15:0,15 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithImportsFile/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithImportsFile/TestComponent.codegen.cs
@@ -34,7 +34,6 @@ using System.Reflection;
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithImportsFile/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithImportsFile/TestComponent.ir.txt
@@ -16,8 +16,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Counter
                 HtmlContent - (11:0,11 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (11:0,11 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithRef/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithRef/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = "";
             __o = "";
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithRef/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithRef/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [72] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute -  - ParamBefore - AttributeStructure.DoubleQuotes
                         HtmlContent - (26:0,26 [6] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithRef/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithRef/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (39:0,39 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |myInstance|
-Generated Location: (1123:30,39 [10] )
+Generated Location: (1079:29,39 [10] )
 |myInstance|
 
 Source Location: (88:2,12 [104] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -8,7 +8,7 @@ Source Location: (88:2,12 [104] x:\dir\subdir\Test\TestComponent.cshtml)
     private Test.MyComponent myInstance;
     public void Foo() { System.GC.KeepAlive(myInstance); }
 |
-Generated Location: (1493:46,12 [104] )
+Generated Location: (1449:45,12 [104] )
 |
     private Test.MyComponent myInstance;
     public void Foo() { System.GC.KeepAlive(myInstance); }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = "";
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [96] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent -  - ChildContent - context
                         HtmlContent - (45:0,45 [11] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (18:0,18 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |myInstance|
-Generated Location: (1079:29,18 [10] )
+Generated Location: (1035:28,18 [10] )
 |myInstance|
 
 Source Location: (112:4,12 [104] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -8,7 +8,7 @@ Source Location: (112:4,12 [104] x:\dir\subdir\Test\TestComponent.cshtml)
     private Test.MyComponent myInstance;
     public void Foo() { System.GC.KeepAlive(myInstance); }
 |
-Generated Location: (1449:45,12 [104] )
+Generated Location: (1405:44,12 [104] )
 |
     private Test.MyComponent myInstance;
     public void Foo() { System.GC.KeepAlive(myInstance); }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.codegen.cs
@@ -49,7 +49,6 @@ global::System.Object __typeHelper = "/AnotherRoute/{id}";
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.ir.txt
@@ -19,8 +19,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (57:2,12 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (57:2,12 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
                 Component - (59:3,0 [15] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives_AmbiguousImport/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives_AmbiguousImport/TestComponent.codegen.cs
@@ -34,7 +34,6 @@ using Test3;
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives_AmbiguousImport/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives_AmbiguousImport/TestComponent.ir.txt
@@ -16,8 +16,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (12:0,12 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (12:0,12 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
                 HtmlContent - (26:1,12 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
                 MarkupElement - (45:3,0 [55] x:\dir\subdir\Test\TestComponent.cshtml) - elem

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.mappings.txt
@@ -2,13 +2,13 @@ Source Location: (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
 | 
   var myValue = "Expression value";
 |
-Generated Location: (889:25,2 [40] )
+Generated Location: (845:24,2 [40] )
 | 
   var myValue = "Expression value";
 |
 
 Source Location: (88:3,43 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |myValue|
-Generated Location: (1092:33,43 [7] )
+Generated Location: (1048:32,43 [7] )
 |myValue|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
                 MarkupElement - (45:3,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - elem

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.mappings.txt
@@ -2,13 +2,13 @@ Source Location: (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
 | 
   var myValue = "Expression value";
 |
-Generated Location: (889:25,2 [40] )
+Generated Location: (845:24,2 [40] )
 | 
   var myValue = "Expression value";
 |
 
 Source Location: (87:3,42 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |myValue|
-Generated Location: (1091:33,42 [7] )
+Generated Location: (1047:32,42 [7] )
 |myValue|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                     myElem = default(Microsoft.AspNetCore.Components.ElementRef);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [79] x:\dir\subdir\Test\TestComponent.cshtml) - elem
                     HtmlContent - (67:0,67 [5] x:\dir\subdir\Test\TestComponent.cshtml)
                         IntermediateToken - (67:0,67 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (36:0,36 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |myElem|
-Generated Location: (923:25,36 [6] )
+Generated Location: (879:24,36 [6] )
 |myElem|
 
 Source Location: (95:2,12 [122] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -8,7 +8,7 @@ Source Location: (95:2,12 [122] x:\dir\subdir\Test\TestComponent.cshtml)
     private Microsoft.AspNetCore.Components.ElementRef myElem;
     public void Foo() { System.GC.KeepAlive(myElem); }
 |
-Generated Location: (1167:34,12 [122] )
+Generated Location: (1123:33,12 [122] )
 |
     private Microsoft.AspNetCore.Components.ElementRef myElem;
     public void Foo() { System.GC.KeepAlive(myElem); }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [91] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [66] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [65] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (24:0,24 [63] x:\dir\subdir\Test\TestComponent.cshtml)
 |EventCallback.Factory.Create<UIMouseEventArgs>(this, Increment)|
-Generated Location: (1202:26,24 [63] )
+Generated Location: (1158:25,24 [63] )
 |EventCallback.Factory.Create<UIMouseEventArgs>(this, Increment)|
 
 Source Location: (107:2,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (107:2,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1764:46,12 [87] )
+Generated Location: (1720:45,12 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1201:26,23 [9] )
+Generated Location: (1157:25,23 [9] )
 |Increment|
 
 Source Location: (51:2,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (51:2,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1709:46,12 [87] )
+Generated Location: (1665:45,12 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1201:26,23 [9] )
+Generated Location: (1157:25,23 [9] )
 |Increment|
 
 Source Location: (51:2,12 [105] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (51:2,12 [105] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1709:46,12 [105] )
+Generated Location: (1665:45,12 [105] )
 |
     private int counter;
     private void Increment(UIMouseEventArgs e) {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1201:26,23 [9] )
+Generated Location: (1157:25,23 [9] )
 |Increment|
 
 Source Location: (51:2,12 [141] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -11,7 +11,7 @@ Source Location: (51:2,12 [141] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1709:46,12 [141] )
+Generated Location: (1665:45,12 [141] )
 |
     private int counter;
     private Task Increment(UIMouseEventArgs e) {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1201:26,23 [9] )
+Generated Location: (1157:25,23 [9] )
 |Increment|
 
 Source Location: (51:2,12 [123] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -11,7 +11,7 @@ Source Location: (51:2,12 [123] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1709:46,12 [123] )
+Generated Location: (1665:45,12 [123] )
 |
     private int counter;
     private Task Increment() {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1201:26,23 [9] )
+Generated Location: (1157:25,23 [9] )
 |Increment|
 
 Source Location: (51:2,12 [106] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (51:2,12 [106] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1709:46,12 [106] )
+Generated Location: (1665:45,12 [106] )
 |
     private int counter;
     private void Increment(UIChangeEventArgs e) {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [73] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [48] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [47] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (24:0,24 [45] x:\dir\subdir\Test\TestComponent.cshtml)
 |EventCallback.Factory.Create(this, Increment)|
-Generated Location: (1102:26,24 [45] )
+Generated Location: (1058:25,24 [45] )
 |EventCallback.Factory.Create(this, Increment)|
 
 Source Location: (89:2,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (89:2,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1646:46,12 [87] )
+Generated Location: (1602:45,12 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1101:26,23 [9] )
+Generated Location: (1057:25,23 [9] )
 |Increment|
 
 Source Location: (51:2,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (51:2,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1609:46,12 [87] )
+Generated Location: (1565:45,12 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1101:26,23 [9] )
+Generated Location: (1057:25,23 [9] )
 |Increment|
 
 Source Location: (51:2,12 [95] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (51:2,12 [95] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1609:46,12 [95] )
+Generated Location: (1565:45,12 [95] )
 |
     private int counter;
     private void Increment(object e) {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1101:26,23 [9] )
+Generated Location: (1057:25,23 [9] )
 |Increment|
 
 Source Location: (51:2,12 [123] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -11,7 +11,7 @@ Source Location: (51:2,12 [123] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1609:46,12 [123] )
+Generated Location: (1565:45,12 [123] )
 |
     private int counter;
     private Task Increment() {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1101:26,23 [9] )
+Generated Location: (1057:25,23 [9] )
 |Increment|
 
 Source Location: (51:2,12 [131] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -11,7 +11,7 @@ Source Location: (51:2,12 [131] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1609:46,12 [131] )
+Generated Location: (1565:45,12 [131] )
 |
     private int counter;
     private Task Increment(object e) {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandlerTagHelper_EscapeQuotes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandlerTagHelper_EscapeQuotes/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIFocusEventArgs>(this, "alert(\"Test\");");
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandlerTagHelper_EscapeQuotes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandlerTagHelper_EscapeQuotes/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [34] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [14] x:\dir\subdir\Test\TestComponent.cshtml) - onfocus=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, OnClick);
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (17:0,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
-Generated Location: (952:23,135 [7] )
+Generated Location: (908:22,135 [7] )
 |OnClick|
 
 Source Location: (42:1,12 [44] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -8,7 +8,7 @@ Source Location: (42:1,12 [44] x:\dir\subdir\Test\TestComponent.cshtml)
     void OnClick(UIEventArgs e) {
     }
 |
-Generated Location: (1094:28,12 [44] )
+Generated Location: (1050:27,12 [44] )
 |
     void OnClick(UIEventArgs e) {
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, OnClick);
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (17:0,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
-Generated Location: (952:23,135 [7] )
+Generated Location: (908:22,135 [7] )
 |OnClick|
 
 Source Location: (42:1,12 [49] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -8,7 +8,7 @@ Source Location: (42:1,12 [49] x:\dir\subdir\Test\TestComponent.cshtml)
     void OnClick(UIMouseEventArgs e) {
     }
 |
-Generated Location: (1094:28,12 [49] )
+Generated Location: (1050:27,12 [49] )
 |
     void OnClick(UIMouseEventArgs e) {
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, x => { });
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [31] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [11] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (18:0,18 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |x => { }|
-Generated Location: (952:23,135 [8] )
+Generated Location: (908:22,135 [8] )
 |x => { }|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, OnClick);
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (17:0,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
-Generated Location: (952:23,135 [7] )
+Generated Location: (908:22,135 [7] )
 |OnClick|
 
 Source Location: (42:1,12 [49] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -8,7 +8,7 @@ Source Location: (42:1,12 [49] x:\dir\subdir\Test\TestComponent.cshtml)
     void OnClick(UIMouseEventArgs e) {
     }
 |
-Generated Location: (1094:28,12 [49] )
+Generated Location: (1050:27,12 [49] )
 |
     void OnClick(UIMouseEventArgs e) {
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, x => { });
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [31] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [11] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (18:0,18 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |x => { }|
-Generated Location: (952:23,135 [8] )
+Generated Location: (908:22,135 [8] )
 |x => { }|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, OnClick);
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (17:0,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
-Generated Location: (952:23,135 [7] )
+Generated Location: (908:22,135 [7] )
 |OnClick|
 
 Source Location: (42:1,12 [31] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -8,7 +8,7 @@ Source Location: (42:1,12 [31] x:\dir\subdir\Test\TestComponent.cshtml)
     void OnClick() {
     }
 |
-Generated Location: (1094:28,12 [31] )
+Generated Location: (1050:27,12 [31] )
 |
     void OnClick() {
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, () => { });
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [32] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (18:0,18 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
-Generated Location: (952:23,135 [9] )
+Generated Location: (908:22,135 [9] )
 |() => { }|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, "foo");
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [23] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [3] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = typeof(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [44] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentTypeArgument - (19:0,19 [3] x:\dir\subdir\Test\TestComponent.cshtml) - TItem
                         IntermediateToken - (19:0,19 [3] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - int

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef/TestComponent.mappings.txt
@@ -1,16 +1,16 @@
 Source Location: (19:0,19 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |int|
-Generated Location: (933:26,19 [3] )
+Generated Location: (889:25,19 [3] )
 |int|
 
 Source Location: (29:0,29 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |3|
-Generated Location: (1185:35,29 [1] )
+Generated Location: (1141:34,29 [1] )
 |3|
 
 Source Location: (37:0,37 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |_my|
-Generated Location: (1512:46,37 [3] )
+Generated Location: (1468:45,37 [3] )
 |_my|
 
 Source Location: (60:2,12 [90] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -18,7 +18,7 @@ Source Location: (60:2,12 [90] x:\dir\subdir\Test\TestComponent.cshtml)
     private MyComponent<int> _my;
     public void Foo() { System.GC.KeepAlive(_my); }
 |
-Generated Location: (1882:62,12 [90] )
+Generated Location: (1838:61,12 [90] )
 |
     private MyComponent<int> _my;
     public void Foo() { System.GC.KeepAlive(_my); }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [34] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (19:0,19 [1] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         IntermediateToken - (19:0,19 [1] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - 3

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference/TestComponent.mappings.txt
@@ -1,11 +1,11 @@
 Source Location: (19:0,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |3|
-Generated Location: (999:26,19 [1] )
+Generated Location: (955:25,19 [1] )
 |3|
 
 Source Location: (27:0,27 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |_my|
-Generated Location: (1183:34,27 [3] )
+Generated Location: (1139:33,27 [3] )
 |_my|
 
 Source Location: (50:2,12 [90] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -13,7 +13,7 @@ Source Location: (50:2,12 [90] x:\dir\subdir\Test\TestComponent.cshtml)
     private MyComponent<int> _my;
     public void Foo() { System.GC.KeepAlive(_my); }
 |
-Generated Location: (1561:52,12 [90] )
+Generated Location: (1517:51,12 [90] )
 |
     private MyComponent<int> _my;
     public void Foo() { System.GC.KeepAlive(_my); }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateTest_MyComponent_0(builder, -1, -1, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [87] x:\dir\subdir\Test\TestComponent.cshtml) - Test.MyComponent
                     ComponentChildContent -  - ChildContent - context
                         HtmlContent - (33:0,33 [4] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (26:0,26 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hi"|
-Generated Location: (1011:26,26 [4] )
+Generated Location: (967:25,26 [4] )
 |"hi"|
 
 Source Location: (43:1,8 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLower()|
-Generated Location: (1193:34,8 [17] )
+Generated Location: (1149:33,8 [17] )
 |context.ToLower()|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 __o = "My value";

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpExpression - (2:0,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [10] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - "My value"
                 HtmlContent - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (2:0,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |"My value"|
-Generated Location: (893:25,6 [10] )
+Generated Location: (849:24,6 [10] )
 |"My value"|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - SomeOtherComponent
                 HtmlContent - (22:0,22 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (22:0,22 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -26,7 +26,6 @@ using System;
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
                 MarkupElement - (17:2,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
                 MarkupElement - (45:3,0 [38] x:\dir\subdir\Test\TestComponent.cshtml) - div

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.mappings.txt
@@ -2,13 +2,13 @@ Source Location: (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
 | 
   var myValue = "Expression value";
 |
-Generated Location: (889:25,2 [40] )
+Generated Location: (845:24,2 [40] )
 | 
   var myValue = "Expression value";
 |
 
 Source Location: (51:3,6 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |myValue|
-Generated Location: (1055:33,6 [7] )
+Generated Location: (1011:32,6 [7] )
 |myValue|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddAttribute(-1, "Header", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [87] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent - (19:1,4 [20] x:\dir\subdir\Test\TestComponent.cshtml) - Header - context
                         HtmlContent - (27:1,12 [3] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (55:2,14 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |"bye!"|
-Generated Location: (1159:29,14 [6] )
+Generated Location: (1115:28,14 [6] )
 |"bye!"|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    RenderFragment<Test.Context> template = (context) => 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [54] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [54] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  RenderFragment<Test.Context> template = (context) => 
                 Template - (57:0,57 [50] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.mappings.txt
@@ -1,25 +1,25 @@
 Source Location: (2:0,2 [54] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderFragment<Test.Context> template = (context) => |
-Generated Location: (889:25,2 [54] )
+Generated Location: (845:24,2 [54] )
 | RenderFragment<Test.Context> template = (context) => |
 
 Source Location: (63:0,63 [13] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.Index|
-Generated Location: (1157:33,63 [13] )
+Generated Location: (1113:32,63 [13] )
 |context.Index|
 
 Source Location: (80:0,80 [22] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.Item.ToLower()|
-Generated Location: (1373:40,80 [22] )
+Generated Location: (1329:39,80 [22] )
 |context.Item.ToLower()|
 
 Source Location: (107:0,107 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
-Generated Location: (1640:48,107 [2] )
+Generated Location: (1596:47,107 [2] )
 |; |
 
 Source Location: (136:1,24 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |template|
-Generated Location: (1873:56,24 [8] )
+Generated Location: (1829:55,24 [8] )
 |template|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
   

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    RenderFragment<Person> p = (person) => 
                 Template - (48:1,44 [45] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.mappings.txt
@@ -1,19 +1,19 @@
 Source Location: (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     RenderFragment<Person> p = (person) => |
-Generated Location: (889:25,2 [45] )
+Generated Location: (845:24,2 [45] )
 |
     RenderFragment<Person> p = (person) => |
 
 Source Location: (73:1,69 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |person.Name|
-Generated Location: (1250:35,69 [11] )
+Generated Location: (1206:34,69 [11] )
 |person.Name|
 
 Source Location: (93:1,89 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |;
 |
-Generated Location: (1819:54,89 [3] )
+Generated Location: (1775:53,89 [3] )
 |;
 |
 
@@ -24,7 +24,7 @@ Source Location: (111:3,12 [76] x:\dir\subdir\Test\TestComponent.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (2003:63,12 [76] )
+Generated Location: (1959:62,12 [76] )
 |
     class Person
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
   

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    RenderFragment<Person> p = (person) => 
                 Template - (48:1,44 [45] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.mappings.txt
@@ -1,25 +1,25 @@
 Source Location: (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     RenderFragment<Person> p = (person) => |
-Generated Location: (889:25,2 [45] )
+Generated Location: (845:24,2 [45] )
 |
     RenderFragment<Person> p = (person) => |
 
 Source Location: (73:1,69 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |person.Name|
-Generated Location: (1250:35,69 [11] )
+Generated Location: (1206:34,69 [11] )
 |person.Name|
 
 Source Location: (93:1,89 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |;
 |
-Generated Location: (1819:54,89 [3] )
+Generated Location: (1775:53,89 [3] )
 |;
 |
 
 Source Location: (116:4,2 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hello, world!"|
-Generated Location: (2067:62,6 [15] )
+Generated Location: (2023:61,6 [15] )
 |"hello, world!"|
 
 Source Location: (164:7,12 [76] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -29,7 +29,7 @@ Source Location: (164:7,12 [76] x:\dir\subdir\Test\TestComponent.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (2446:80,12 [76] )
+Generated Location: (2402:79,12 [76] )
 |
     class Person
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    RenderFragment<Person> template = (person) => 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [47] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [47] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  RenderFragment<Person> template = (person) => 
                 Template - (50:0,50 [23] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (2:0,2 [47] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderFragment<Person> template = (person) => |
-Generated Location: (889:25,2 [47] )
+Generated Location: (845:24,2 [47] )
 | RenderFragment<Person> template = (person) => |
 
 Source Location: (56:0,56 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |person.Name|
-Generated Location: (1143:33,56 [11] )
+Generated Location: (1099:32,56 [11] )
 |person.Name|
 
 Source Location: (73:0,73 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
-Generated Location: (1365:41,73 [2] )
+Generated Location: (1321:40,73 [2] )
 |; |
 
 Source Location: (108:1,30 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |template|
-Generated Location: (1603:49,30 [8] )
+Generated Location: (1559:48,30 [8] )
 |template|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 __o = RenderPerson((person) => (builder2) => {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpExpression - (1:0,1 [49] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (1:0,1 [25] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - RenderPerson((person) => 
                     Template - (27:0,27 [23] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.mappings.txt
@@ -1,16 +1,16 @@
 Source Location: (1:0,1 [25] x:\dir\subdir\Test\TestComponent.cshtml)
 |RenderPerson((person) => |
-Generated Location: (893:25,6 [25] )
+Generated Location: (849:24,6 [25] )
 |RenderPerson((person) => |
 
 Source Location: (33:0,33 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |person.Name|
-Generated Location: (1038:28,33 [11] )
+Generated Location: (994:27,33 [11] )
 |person.Name|
 
 Source Location: (50:0,50 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |)|
-Generated Location: (1105:34,0 [1] )
+Generated Location: (1061:33,0 [1] )
 |)|
 
 Source Location: (65:1,12 [138] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -22,7 +22,7 @@ Source Location: (65:1,12 [138] x:\dir\subdir\Test\TestComponent.cshtml)
 
     object RenderPerson(RenderFragment<Person> p) => null;
 |
-Generated Location: (1290:43,12 [138] )
+Generated Location: (1246:42,12 [138] )
 |
     class Person
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
   

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    RenderFragment<Person> p = (person) => 
                 Template - (48:1,44 [23] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.mappings.txt
@@ -1,19 +1,19 @@
 Source Location: (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     RenderFragment<Person> p = (person) => |
-Generated Location: (889:25,2 [45] )
+Generated Location: (845:24,2 [45] )
 |
     RenderFragment<Person> p = (person) => |
 
 Source Location: (54:1,50 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |person.Name|
-Generated Location: (1135:34,50 [11] )
+Generated Location: (1091:33,50 [11] )
 |person.Name|
 
 Source Location: (71:1,67 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |;
 |
-Generated Location: (1351:42,67 [3] )
+Generated Location: (1307:41,67 [3] )
 |;
 |
 
@@ -24,7 +24,7 @@ Source Location: (89:3,12 [76] x:\dir\subdir\Test\TestComponent.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (1535:51,12 [76] )
+Generated Location: (1491:50,12 [76] )
 |
     class Person
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 __o = RenderPerson((person) => (builder2) => {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpExpression - (2:0,2 [49] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [25] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - RenderPerson((person) => 
                     Template - (28:0,28 [23] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.mappings.txt
@@ -1,16 +1,16 @@
 Source Location: (2:0,2 [25] x:\dir\subdir\Test\TestComponent.cshtml)
 |RenderPerson((person) => |
-Generated Location: (893:25,6 [25] )
+Generated Location: (849:24,6 [25] )
 |RenderPerson((person) => |
 
 Source Location: (34:0,34 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |person.Name|
-Generated Location: (1039:28,34 [11] )
+Generated Location: (995:27,34 [11] )
 |person.Name|
 
 Source Location: (51:0,51 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |)|
-Generated Location: (1106:34,0 [1] )
+Generated Location: (1062:33,0 [1] )
 |)|
 
 Source Location: (67:1,12 [138] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -22,7 +22,7 @@ Source Location: (67:1,12 [138] x:\dir\subdir\Test\TestComponent.cshtml)
 
     object RenderPerson(RenderFragment<Person> p) => null;
 |
-Generated Location: (1291:43,12 [138] )
+Generated Location: (1247:42,12 [138] )
 |
     class Person
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_NonGeneric_AsComponentParameter/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_NonGeneric_AsComponentParameter/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    RenderFragment template = 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_NonGeneric_AsComponentParameter/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_NonGeneric_AsComponentParameter/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [27] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [27] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  RenderFragment template = 
                 Template - (30:0,30 [15] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_NonGeneric_AsComponentParameter/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_NonGeneric_AsComponentParameter/TestComponent.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (2:0,2 [27] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderFragment template = |
-Generated Location: (889:25,2 [27] )
+Generated Location: (845:24,2 [27] )
 | RenderFragment template = |
 
 Source Location: (45:0,45 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
-Generated Location: (1127:34,45 [2] )
+Generated Location: (1083:33,45 [2] )
 |; |
 
 Source Location: (72:1,22 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |template|
-Generated Location: (1293:42,22 [8] )
+Generated Location: (1249:41,22 [8] )
 |template|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 __o = RenderPerson((builder2) => {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpExpression - (1:0,1 [27] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (1:0,1 [13] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - RenderPerson(
                     Template - (15:0,15 [13] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (1:0,1 [13] x:\dir\subdir\Test\TestComponent.cshtml)
 |RenderPerson(|
-Generated Location: (893:25,6 [13] )
+Generated Location: (849:24,6 [13] )
 |RenderPerson(|
 
 Source Location: (28:0,28 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |)|
-Generated Location: (926:27,0 [1] )
+Generated Location: (882:26,0 [1] )
 |)|
 
 Source Location: (43:1,12 [54] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     object RenderPerson(RenderFragment p) => null;
 |
-Generated Location: (1111:36,12 [54] )
+Generated Location: (1067:35,12 [54] )
 |
     object RenderPerson(RenderFragment p) => null;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - Counter
                     ComponentAttribute - (17:0,17 [1] x:\dir\subdir\Test\TestComponent.cshtml) - v - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (17:0,17 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |y|
-Generated Location: (977:26,17 [1] )
+Generated Location: (933:25,17 [1] )
 |y|
 
 Source Location: (36:1,12 [24] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string y = null;
 |
-Generated Location: (1592:47,12 [24] )
+Generated Location: (1548:46,12 [24] )
 |
     string y = null;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [60] x:\dir\subdir\Test\TestComponent.cshtml) - User
                     ComponentAttribute - (17:0,17 [9] x:\dir\subdir\Test\TestComponent.cshtml) - Name - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.mappings.txt
@@ -1,11 +1,11 @@
 Source Location: (18:0,18 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |UserName|
-Generated Location: (978:26,18 [8] )
+Generated Location: (934:25,18 [8] )
 |UserName|
 
 Source Location: (44:0,44 [12] x:\dir\subdir\Test\TestComponent.cshtml)
 |UserIsActive|
-Generated Location: (1375:36,44 [12] )
+Generated Location: (1331:35,44 [12] )
 |UserIsActive|
 
 Source Location: (76:2,12 [88] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -13,7 +13,7 @@ Source Location: (76:2,12 [88] x:\dir\subdir\Test\TestComponent.cshtml)
     public string UserName { get; set; }
     public bool UserIsActive { get; set; }
 |
-Generated Location: (2020:57,12 [88] )
+Generated Location: (1976:56,12 [88] )
 |
     public string UserName { get; set; }
     public bool UserIsActive { get; set; }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_772/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_772/TestComponent.codegen.cs
@@ -31,7 +31,6 @@ global::System.Object __typeHelper = "/";
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = "";
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_772/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_772/TestComponent.ir.txt
@@ -16,8 +16,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (11:1,0 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (11:1,0 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
                 MarkupElement - (13:2,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - h1

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_773/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_773/TestComponent.codegen.cs
@@ -31,7 +31,6 @@ global::System.Object __typeHelper = "/";
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = "";
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_773/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_773/TestComponent.ir.txt
@@ -16,8 +16,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (11:1,0 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (11:1,0 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
                 MarkupElement - (13:2,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - h1

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_784/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_784/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, OnComponentHover);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_784/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_784/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [73] x:\dir\subdir\Test\TestComponent.cshtml) - p
                     HtmlAttribute - (16:0,16 [17] x:\dir\subdir\Test\TestComponent.cshtml) - onmouseover=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_784/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_784/TestComponent.mappings.txt
@@ -1,11 +1,11 @@
 Source Location: (17:0,17 [16] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnComponentHover|
-Generated Location: (952:23,135 [16] )
+Generated Location: (908:22,135 [16] )
 |OnComponentHover|
 
 Source Location: (55:0,55 [13] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentBgColor|
-Generated Location: (1097:26,55 [13] )
+Generated Location: (1053:25,55 [13] )
 |ParentBgColor|
 
 Source Location: (87:1,12 [132] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -16,7 +16,7 @@ Source Location: (87:1,12 [132] x:\dir\subdir\Test\TestComponent.cshtml)
     {
     }
 |
-Generated Location: (1294:35,12 [132] )
+Generated Location: (1250:34,12 [132] )
 |
     public string ParentBgColor { get; set; } = "#FFFFFF";
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ScriptTag_WithErrorSuppressed/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ScriptTag_WithErrorSuppressed/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ScriptTag_WithErrorSuppressed/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ScriptTag_WithErrorSuppressed/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [144] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlContent - (5:0,5 [6] x:\dir\subdir\Test\TestComponent.cshtml)
                         IntermediateToken - (5:0,5 [6] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n    

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
 __o = "My value";

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1
                     HtmlContent - (4:0,4 [5] x:\dir\subdir\Test\TestComponent.cshtml)
                         IntermediateToken - (4:0,4 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (20:2,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |"My value"|
-Generated Location: (893:25,6 [10] )
+Generated Location: (849:24,6 [10] )
 |"My value"|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1
                     HtmlContent - (4:0,4 [5] x:\dir\subdir\Test\TestComponent.cshtml)
                         IntermediateToken - (4:0,4 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -31,7 +31,6 @@ global::System.Object __typeHelper = "/my/url";
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.ir.txt
@@ -16,8 +16,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1
                     HtmlContent - (4:0,4 [5] x:\dir\subdir\Test\TestComponent.cshtml)
                         IntermediateToken - (4:0,4 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/WhiteSpace_InsideAttribute_InMarkupBlock/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/WhiteSpace_InsideAttribute_InMarkupBlock/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/WhiteSpace_InsideAttribute_InMarkupBlock/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/WhiteSpace_InsideAttribute_InMarkupBlock/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [37] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (4:0,4 [21] x:\dir\subdir\Test\TestComponent.cshtml) -  class=" - "
                         HtmlAttributeValue - (12:0,12 [5] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.codegen.cs
@@ -20,7 +20,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
       __o = Foo;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.ir.txt
@@ -14,8 +14,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [18] x:\dir\subdir\Test\TestComponent.cshtml) - elem
                     HtmlAttribute - (5:0,5 [10] x:\dir\subdir\Test\TestComponent.cshtml) -  attr= - 
                         CSharpExpressionAttributeValue - (11:0,11 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (12:0,12 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |Foo|
-Generated Location: (899:25,12 [3] )
+Generated Location: (855:24,12 [3] )
 |Foo|
 
 Source Location: (36:1,16 [29] x:\dir\subdir\Test\TestComponent.cshtml)
 |
         int Foo = 18;
     |
-Generated Location: (1090:34,16 [29] )
+Generated Location: (1046:33,16 [29] )
 |
         int Foo = 18;
     |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "onclick", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, "async (e) => await Task.Delay(10)"));
             builder.CloseElement();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (31:1,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (47:1,16 [33] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "onclick", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, OnClick));
             builder.CloseElement();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (31:1,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (47:1,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (73:2,12 [91] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (939:23,12 [91] )
+Generated Location: (895:22,12 [91] )
 |
     Task OnClick(UIMouseEventArgs e) 
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "onclick", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, "async (e) => await Task.Delay(10)"));
             builder.CloseElement();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (31:1,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (47:1,16 [33] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "onclick", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, OnClick));
             builder.CloseElement();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (31:1,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (47:1,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (73:2,12 [73] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (939:23,12 [73] )
+Generated Location: (895:22,12 [73] )
 |
     Task OnClick() 
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue)));
             builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.Int32>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.Int32>(this, Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue))));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [40] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (54:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1537:25,12 [50] )
+Generated Location: (1493:24,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue), 2, Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue)), 3, () => ParentValue);
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [44] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml) - SomeParam - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (58:1,12 [65] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |
-Generated Location: (1054:21,12 [65] )
+Generated Location: (1010:20,12 [65] )
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue)));
             builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.Int32>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.Int32>(this, Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue))));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [40] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (54:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1340:24,12 [50] )
+Generated Location: (1296:23,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue)));
             builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.Int32>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.Int32>(this, Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue))));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [40] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (54:1,12 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "42";
 |
-Generated Location: (1340:24,12 [55] )
+Generated Location: (1296:23,12 [55] )
 |
     public string ParentValue { get; set; } = "42";
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue)));
             builder.AddAttribute(2, "OnChanged", new System.Action<System.Int32>(__value => ParentValue = __value));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [50] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (64:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1080:24,12 [50] )
+Generated Location: (1036:23,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue));
             builder.AddAttribute(2, "OnChanged", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [50] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (64:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1062:24,12 [50] )
+Generated Location: (1018:23,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue)));
             builder.AddAttribute(2, "ValueChanged", new System.Action<System.Int32>(__value => ParentValue = __value));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [40] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (54:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1280:25,12 [50] )
+Generated Location: (1236:24,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue), 2, __value => ParentValue = __value, 3, () => ParentValue);
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [44] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml) - SomeParam - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (58:1,12 [65] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |
-Generated Location: (897:21,12 [65] )
+Generated Location: (853:20,12 [65] )
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue)));
             builder.AddAttribute(2, "ValueChanged", new System.Action<System.Int32>(__value => ParentValue = __value));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [40] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (54:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1083:24,12 [50] )
+Generated Location: (1039:23,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue));
             builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [40] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (54:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1065:24,12 [50] )
+Generated Location: (1021:23,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue)));
             builder.AddAttribute(2, "ValueChanged", new System.Action<System.Int32>(__value => ParentValue = __value));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [40] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (54:1,12 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "42";
 |
-Generated Location: (1083:24,12 [55] )
+Generated Location: (1039:23,12 [55] )
 |
     public string ParentValue { get; set; } = "42";
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.InputText>(0);
             builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(Microsoft.AspNetCore.Components.BindMethods.GetValue(person.Name)));
             builder.AddAttribute(2, "ValueChanged", new System.Action<System.String>(__value => person.Name = __value));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [38] x:\dir\subdir\Test\TestComponent.cshtml) - InputText
                     ComponentAttribute - (23:0,23 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (56:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     Person person = new Person();
 |
-Generated Location: (1072:24,1 [37] )
+Generated Location: (1028:23,1 [37] )
 |
     Person person = new Person();
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "text");
             builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(CurrentDate, "MM/dd"));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [77] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (91:1,12 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1120:25,12 [77] )
+Generated Location: (1076:24,12 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "text");
             builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [56] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (70:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1102:25,12 [50] )
+Generated Location: (1058:24,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "div");
             builder.AddAttribute(1, "myvalue", Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue));
             builder.AddAttribute(2, "myevent", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [33] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (17:0,17 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (47:1,12 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1047:24,12 [55] )
+Generated Location: (1003:23,12 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "div");
             builder.AddAttribute(1, "myvalue", Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue));
             builder.AddAttribute(2, "myevent", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [32] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (17:0,17 [11] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (46:1,12 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1047:24,12 [55] )
+Generated Location: (1003:23,12 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "div");
             builder.AddAttribute(1, "myvalue", Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue));
             builder.AddAttribute(2, "myevent", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [27] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (11:0,11 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (41:1,12 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1047:24,12 [55] )
+Generated Location: (1003:23,12 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    RenderFragment<string> header = (context) => 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [46] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [46] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  RenderFragment<string> header = (context) => 
                 Template - (49:0,49 [38] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (2:0,2 [46] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderFragment<string> header = (context) => |
-Generated Location: (621:18,2 [46] )
+Generated Location: (577:17,2 [46] )
 | RenderFragment<string> header = (context) => |
 
 Source Location: (87:0,87 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
-Generated Location: (1080:30,87 [2] )
+Generated Location: (1036:29,87 [2] )
 |; |
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    RenderFragment<string> header = (context) => 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [46] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [46] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  RenderFragment<string> header = (context) => 
                 Template - (49:0,49 [38] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (2:0,2 [46] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderFragment<string> header = (context) => |
-Generated Location: (621:18,2 [46] )
+Generated Location: (577:17,2 [46] )
 | RenderFragment<string> header = (context) => |
 
 Source Location: (87:0,87 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
-Generated Location: (1080:30,87 [2] )
+Generated Location: (1036:29,87 [2] )
 |; |
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "checkbox");
             builder.AddAttribute(2, "checked", Microsoft.AspNetCore.Components.BindMethods.GetValue(Enabled));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [8] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (55:1,12 [41] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public bool Enabled { get; set; }
 |
-Generated Location: (1096:25,12 [41] )
+Generated Location: (1052:24,12 [41] )
 |
     public bool Enabled { get; set; }
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "text");
             builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(CurrentDate, Format));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [63] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
@@ -4,7 +4,7 @@ Source Location: (77:1,12 [135] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public string Format { get; set; } = "MM/dd/yyyy";
 |
-Generated Location: (1118:25,12 [135] )
+Generated Location: (1074:24,12 [135] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "text");
             builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(CurrentDate, "MM/dd/yyyy"));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [66] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (80:1,12 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1130:25,12 [77] )
+Generated Location: (1086:24,12 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "text");
             builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (55:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1102:25,12 [50] )
+Generated Location: (1058:24,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(ParentValue));
             builder.AddAttribute(2, "onchange", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [29] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (13:0,13 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (43:1,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1048:24,12 [50] )
+Generated Location: (1004:23,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent<string>>(0);
             builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<string>("hi"));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [42] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentTypeArgument - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - TItem
                         IntermediateToken - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - string

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent<string>>(0);
             builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<string>(Microsoft.AspNetCore.Components.BindMethods.GetValue(Value)));
             builder.AddAttribute(2, "ItemChanged", new System.Action<string>(__value => Value = __value));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [43] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentTypeArgument - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - TItem
                         IntermediateToken - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - string

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (57:1,12 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1065:24,12 [21] )
+Generated Location: (1021:23,12 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent<string>>(0);
             builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.BindMethods.GetValue(Value));
             builder.AddAttribute(2, "ItemChanged", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => Value = __value, Value));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [43] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentTypeArgument - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - TItem
                         IntermediateToken - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - string

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (57:1,12 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1053:24,12 [21] )
+Generated Location: (1009:23,12 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, 18, 2, Microsoft.AspNetCore.Components.BindMethods.GetValue(Value), 3, Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => Value = __value, Value));
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [42] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (35:0,35 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - (36:0,36 [4] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (56:1,12 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (951:21,12 [21] )
+Generated Location: (907:20,12 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, Microsoft.AspNetCore.Components.BindMethods.GetValue(Value), 2, __value => Value = __value);
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [30] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (23:0,23 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (44:1,12 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (863:21,12 [21] )
+Generated Location: (819:20,12 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent<string>>(0);
             builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<string>("hi"));
             builder.AddAttribute(2, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment<string>)((context) => (builder2) => {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [90] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent -  - ChildContent - context
                         HtmlContent - (41:0,41 [4] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, "hi", 2, (context) => (builder2) => {
                 builder2.AddContent(3, "\r\n  ");
                 builder2.OpenElement(4, "div");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [77] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent -  - ChildContent - context
                         HtmlContent - (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent<string>>(0);
             builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<string>("hi"));
             builder.AddAttribute(2, "Other", 17);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [56] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentTypeArgument - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - TItem
                         IntermediateToken - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - string

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute_TypeInference/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, "hi", 2, 17);
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute_TypeInference/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [43] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (19:0,19 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - (20:0,20 [6] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic_TypeInference/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, "hi");
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic_TypeInference/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [29] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (19:0,19 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - (20:0,20 [6] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic_TypeInference_Multiple/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic_TypeInference_Multiple/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, "hi");
             builder.AddContent(2, "\r\n");
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_1(builder, 3, 4, "how are you?");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic_TypeInference_Multiple/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic_TypeInference_Multiple/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [29] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (19:0,19 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - (20:0,20 [6] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.codegen.cs
@@ -14,7 +14,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
    RenderChildComponent(builder); 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.ir.txt
@@ -8,8 +8,6 @@ Document -
         UsingDirective - (1:0,1 [51] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Components.RenderTree
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (56:2,2 [32] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (56:2,2 [32] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  RenderChildComponent(builder); 
             CSharpCode - (105:4,12 [67] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (56:2,2 [32] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderChildComponent(builder); |
-Generated Location: (676:19,2 [32] )
+Generated Location: (632:18,2 [32] )
 | RenderChildComponent(builder); |
 
 Source Location: (105:4,12 [67] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -8,7 +8,7 @@ Source Location: (105:4,12 [67] x:\dir\subdir\Test\TestComponent.cshtml)
     void RenderChildComponent(RenderTreeBuilder builder)
     {
 |
-Generated Location: (891:28,12 [67] )
+Generated Location: (847:27,12 [67] )
 |
     void RenderChildComponent(RenderTreeBuilder builder)
     {
@@ -17,7 +17,7 @@ Generated Location: (891:28,12 [67] )
 Source Location: (197:8,0 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |    }
 |
-Generated Location: (1250:41,0 [7] )
+Generated Location: (1206:40,0 [7] )
 |    }
 |
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.codegen.cs
@@ -14,7 +14,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
   

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.ir.txt
@@ -8,8 +8,6 @@ Document -
         UsingDirective - (1:0,1 [51] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Components.RenderTree
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (54:1,2 [42] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (54:1,2 [42] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    void RenderChildComponent()\n    {\n
                 HtmlContent - (96:4,0 [8] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.mappings.txt
@@ -3,7 +3,7 @@ Source Location: (54:1,2 [42] x:\dir\subdir\Test\TestComponent.cshtml)
     void RenderChildComponent()
     {
 |
-Generated Location: (676:19,2 [42] )
+Generated Location: (632:18,2 [42] )
 |
     void RenderChildComponent()
     {
@@ -12,12 +12,12 @@ Generated Location: (676:19,2 [42] )
 Source Location: (121:5,0 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |    }
 |
-Generated Location: (1026:32,0 [7] )
+Generated Location: (982:31,0 [7] )
 |    }
 |
 
 Source Location: (135:8,2 [25] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderChildComponent(); |
-Generated Location: (1199:40,2 [25] )
+Generated Location: (1155:39,2 [25] )
 | RenderChildComponent(); |
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent<string, int>>(0);
             builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<string>("hi"));
             builder.AddAttribute(2, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment<string>)((context) => (builder2) => {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [228] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent - (57:1,2 [58] x:\dir\subdir\Test\TestComponent.cshtml) - ChildContent - context
                         MarkupElement - (71:1,16 [29] x:\dir\subdir\Test\TestComponent.cshtml) - div

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, "hi", 2, new List<long>(), 3, (context) => (builder2) => {
                 builder2.OpenElement(4, "div");
                 builder2.AddContent(5, context.ToLower());

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [229] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent - (58:1,2 [58] x:\dir\subdir\Test\TestComponent.cshtml) - ChildContent - context
                         MarkupElement - (72:1,16 [29] x:\dir\subdir\Test\TestComponent.cshtml) - div

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Simple/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Simple/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.CloseComponent();
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Simple/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Simple/TestComponent.ir.txt
@@ -7,6 +7,4 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [15] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "MyAttr", "abc");
             builder.AddAttribute(2, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [91] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent -  - ChildContent - context
                         HtmlContent - (26:0,26 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
                 builder2.AddMarkupContent(2, "<child>hello</child>");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [47] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent -  - ChildContent - context
                         MarkupBlock -  - <child>hello</child>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitChildContent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
                 builder2.AddContent(2, "hello");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitChildContent/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [61] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent - (13:0,13 [34] x:\dir\subdir\Test\TestComponent.cshtml) - ChildContent - context
                         HtmlContent - (27:0,27 [5] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "OnClick", new System.Action<Microsoft.AspNetCore.Components.UIEventArgs>(Increment));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (51:2,12 [100] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (900:23,12 [100] )
+Generated Location: (856:22,12 [100] )
 |
     private int counter;
     private void Increment(UIEventArgs e) {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment<System.String>)((context) => (builder2) => {
                 builder2.AddContent(2, context);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [64] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent - (13:0,13 [37] x:\dir\subdir\Test\TestComponent.cshtml) - ChildContent - context
                         CSharpExpression - (28:0,28 [7] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "StringProperty", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(42.ToString()));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [49] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (29:0,29 [16] x:\dir\subdir\Test\TestComponent.cshtml) - StringProperty - AttributeStructure.DoubleQuotes
                         CSharpExpression - (31:0,31 [13] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "MyAttr", "abc");
             builder.AddAttribute(2, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment<System.String>)((context) => (builder2) => {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [107] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent -  - ChildContent - context
                         HtmlContent - (26:0,26 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "MyAttr", "abc");
             builder.AddAttribute(2, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment<System.String>)((item) => (builder2) => {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [164] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent - (30:1,2 [118] x:\dir\subdir\Test\TestComponent.cshtml) - ChildContent - item
                         HtmlContent - (59:1,31 [15] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "MyAttr", "abc");
             builder.AddAttribute(2, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment<System.String>)((item) => (builder2) => {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [164] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent - (45:1,2 [103] x:\dir\subdir\Test\TestComponent.cshtml) - ChildContent - item
                         HtmlContent - (59:1,16 [15] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "OnClick", new System.Action<Microsoft.AspNetCore.Components.UIEventArgs>(e => { Increment(); }));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [49] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [24] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [23] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (65:2,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (912:23,12 [87] )
+Generated Location: (868:22,12 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "some-attribute", "foo");
             builder.AddAttribute(2, "another-attribute", 43.ToString());

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [72] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute -  - some-attribute - AttributeStructure.DoubleQuotes
                         HtmlContent - (29:0,29 [3] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.codegen.cs
@@ -15,7 +15,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.CloseComponent();
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.ir.txt
@@ -9,6 +9,4 @@ Document -
         RouteAttributeExtensionNode -  - /AnotherRoute/{id}
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (45:2,0 [15] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "IntProperty", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(123));
             builder.AddAttribute(2, "BoolProperty", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Boolean>(true));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [132] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (32:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml) - IntProperty - AttributeStructure.DoubleQuotes
                         IntermediateToken - (32:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - 123

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.DynamicElement>(0);
             builder.AddAttribute(1, "onclick", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, OnClick));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [37] x:\dir\subdir\Test\TestComponent.cshtml) - DynamicElement
                     ComponentAttribute - (25:0,25 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (53:2,12 [62] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Action<UIMouseEventArgs> OnClick { get; set; }
 |
-Generated Location: (955:23,12 [62] )
+Generated Location: (911:22,12 [62] )
 |
     private Action<UIMouseEventArgs> OnClick { get; set; }
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.CoolnessMeter>(0);
             builder.AddAttribute(1, "Coolness", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>("very-cool"));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [43] x:\dir\subdir\Test\TestComponent.cshtml) - CoolnessMeter
                     ComponentAttribute - (25:0,25 [14] x:\dir\subdir\Test\TestComponent.cshtml) - Coolness - AttributeStructure.DoubleQuotes
                         CSharpExpression - (26:0,26 [13] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddMarkupContent(0, "<h1>Item1</h1>\r\n");
 #nullable restore
 #line 6 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (1:0,1 [40] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase -  - TItem1, TItem2
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupBlock -  - <h1>Item1</h1>\n
                 CSharpCode - (98:5,1 [34] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (98:5,1 [34] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - foreach (var item2 in Items2)\n{\n

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (98:5,1 [34] x:\dir\subdir\Test\TestComponent.cshtml)
 |foreach (var item2 in Items2)
 {
 |
-Generated Location: (700:21,1 [34] )
+Generated Location: (656:20,1 [34] )
 |foreach (var item2 in Items2)
 {
 |
@@ -10,7 +10,7 @@ Generated Location: (700:21,1 [34] )
 Source Location: (178:10,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}
 |
-Generated Location: (1176:38,0 [3] )
+Generated Location: (1132:37,0 [3] )
 |}
 |
 
@@ -20,7 +20,7 @@ Source Location: (193:11,12 [164] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter] List<TItem2> Items2 { get; set; }
     [Parameter] RenderFragment<TItem2> ChildContent { get; set; }
 |
-Generated Location: (1361:47,12 [164] )
+Generated Location: (1317:46,12 [164] )
 |
     [Parameter] TItem1 Item1 { get; set; }
     [Parameter] List<TItem2> Items2 { get; set; }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_IgnoresStaticAndAliasUsings/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_IgnoresStaticAndAliasUsings/TestComponent.codegen.cs
@@ -15,7 +15,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.CloseComponent();
             builder.AddMarkupContent(1, "\r\n<SomeComponent></SomeComponent>");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_IgnoresStaticAndAliasUsings/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_IgnoresStaticAndAliasUsings/TestComponent.ir.txt
@@ -9,7 +9,5 @@ Document -
         UsingDirective - (36:1,1 [19] x:\dir\subdir\Test\TestComponent.cshtml) - Foo = Test3
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (55:2,0 [15] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                 MarkupBlock -  - \n<SomeComponent></SomeComponent>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithDocType/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithDocType/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddContent(0, "<!DOCTYPE html>\r\n");
             builder.AddMarkupContent(1, "<div>\r\n</div>");
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithDocType/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithDocType/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (0:0,0 [17] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (0:0,0 [17] x:\dir\subdir\Test\TestComponent.cshtml) - Html - <!DOCTYPE html>\n
                 MarkupBlock -  - <div>\n</div>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithFullyQualifiedTagNames/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithFullyQualifiedTagNames/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.CloseComponent();
             builder.AddContent(1, "\r\n");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithFullyQualifiedTagNames/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithFullyQualifiedTagNames/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [15] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                 HtmlContent - (15:0,15 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (15:0,15 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithImportsFile/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithImportsFile/TestComponent.codegen.cs
@@ -15,7 +15,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.Counter>(0);
             builder.CloseComponent();
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithImportsFile/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithImportsFile/TestComponent.ir.txt
@@ -9,6 +9,4 @@ Document -
         UsingDirective - (21:1,1 [25] x:\dir\subdir\Test\_Imports.razor) - System.Reflection
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Counter

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "ParamBefore", "before");
             builder.AddAttribute(2, "ParamAfter", "after");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [72] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute -  - ParamBefore - AttributeStructure.DoubleQuotes
                         HtmlContent - (26:0,26 [6] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (39:0,39 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |myInstance|
-Generated Location: (907:22,39 [10] )
+Generated Location: (863:21,39 [10] )
 |myInstance|
 
 Source Location: (88:2,12 [104] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -8,7 +8,7 @@ Source Location: (88:2,12 [104] x:\dir\subdir\Test\TestComponent.cshtml)
     private Test.MyComponent myInstance;
     public void Foo() { System.GC.KeepAlive(myInstance); }
 |
-Generated Location: (1199:34,12 [104] )
+Generated Location: (1155:33,12 [104] )
 |
     private Test.MyComponent myInstance;
     public void Foo() { System.GC.KeepAlive(myInstance); }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "SomeProp", "val");
             builder.AddAttribute(2, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [96] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent -  - ChildContent - context
                         HtmlContent - (45:0,45 [11] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (18:0,18 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |myInstance|
-Generated Location: (1106:28,18 [10] )
+Generated Location: (1062:27,18 [10] )
 |myInstance|
 
 Source Location: (112:4,12 [104] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -8,7 +8,7 @@ Source Location: (112:4,12 [104] x:\dir\subdir\Test\TestComponent.cshtml)
     private Test.MyComponent myInstance;
     public void Foo() { System.GC.KeepAlive(myInstance); }
 |
-Generated Location: (1398:40,12 [104] )
+Generated Location: (1354:39,12 [104] )
 |
     private Test.MyComponent myInstance;
     public void Foo() { System.GC.KeepAlive(myInstance); }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.codegen.cs
@@ -16,7 +16,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.CloseComponent();
             builder.AddContent(1, "\r\n");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.ir.txt
@@ -10,8 +10,6 @@ Document -
         RouteAttributeExtensionNode -  - /AnotherRoute/{id}
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (59:3,0 [15] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                 HtmlContent - (74:3,15 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (74:3,15 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives_AmbiguousImport/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives_AmbiguousImport/TestComponent.codegen.cs
@@ -15,7 +15,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.CloseComponent();
             builder.AddContent(1, "\r\n");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives_AmbiguousImport/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives_AmbiguousImport/TestComponent.ir.txt
@@ -9,8 +9,6 @@ Document -
         UsingDirective - (15:1,1 [13] x:\dir\subdir\Test\TestComponent.cshtml) - Test3
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (28:2,0 [15] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                 HtmlContent - (43:2,15 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (43:2,15 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
                 MarkupElement - (45:3,0 [55] x:\dir\subdir\Test\TestComponent.cshtml) - elem

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
 | 
   var myValue = "Expression value";
 |
-Generated Location: (621:18,2 [40] )
+Generated Location: (577:17,2 [40] )
 | 
   var myValue = "Expression value";
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
                 MarkupElement - (45:3,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - elem

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
 | 
   var myValue = "Expression value";
 |
-Generated Location: (621:18,2 [40] )
+Generated Location: (577:17,2 [40] )
 | 
   var myValue = "Expression value";
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithRef/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithRef/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "elem");
             builder.AddAttribute(1, "attributebefore", "before");
             builder.AddAttribute(2, "attributeafter", "after");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithRef/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithRef/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [79] x:\dir\subdir\Test\TestComponent.cshtml) - elem
                     HtmlContent - (67:0,67 [5] x:\dir\subdir\Test\TestComponent.cshtml)
                         IntermediateToken - (67:0,67 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithRef/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithRef/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (36:0,36 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |myElem|
-Generated Location: (898:22,36 [6] )
+Generated Location: (854:21,36 [6] )
 |myElem|
 
 Source Location: (95:2,12 [122] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -8,7 +8,7 @@ Source Location: (95:2,12 [122] x:\dir\subdir\Test\TestComponent.cshtml)
     private Microsoft.AspNetCore.Components.ElementRef myElem;
     public void Foo() { System.GC.KeepAlive(myElem); }
 |
-Generated Location: (1211:35,12 [122] )
+Generated Location: (1167:34,12 [122] )
 |
     private Microsoft.AspNetCore.Components.ElementRef myElem;
     public void Foo() { System.GC.KeepAlive(myElem); }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, EventCallback.Factory.Create<UIMouseEventArgs>(this, Increment))));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [91] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [66] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [65] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (107:2,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1163:23,12 [87] )
+Generated Location: (1119:22,12 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, Increment)));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (51:2,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1109:23,12 [87] )
+Generated Location: (1065:22,12 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, Increment)));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (51:2,12 [105] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1109:23,12 [105] )
+Generated Location: (1065:22,12 [105] )
 |
     private int counter;
     private void Increment(UIMouseEventArgs e) {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, Increment)));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.mappings.txt
@@ -6,7 +6,7 @@ Source Location: (51:2,12 [141] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1109:23,12 [141] )
+Generated Location: (1065:22,12 [141] )
 |
     private int counter;
     private Task Increment(UIMouseEventArgs e) {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, Increment)));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.mappings.txt
@@ -6,7 +6,7 @@ Source Location: (51:2,12 [123] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1109:23,12 [123] )
+Generated Location: (1065:22,12 [123] )
 |
     private int counter;
     private Task Increment() {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, Increment)));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (51:2,12 [106] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1109:23,12 [106] )
+Generated Location: (1065:22,12 [106] )
 |
     private int counter;
     private void Increment(UIChangeEventArgs e) {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, EventCallback.Factory.Create(this, Increment))));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [73] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [48] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [47] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (89:2,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1045:23,12 [87] )
+Generated Location: (1001:22,12 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, Increment)));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (51:2,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1009:23,12 [87] )
+Generated Location: (965:22,12 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, Increment)));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (51:2,12 [95] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1009:23,12 [95] )
+Generated Location: (965:22,12 [95] )
 |
     private int counter;
     private void Increment(object e) {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, Increment)));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.mappings.txt
@@ -6,7 +6,7 @@ Source Location: (51:2,12 [123] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1009:23,12 [123] )
+Generated Location: (965:22,12 [123] )
 |
     private int counter;
     private Task Increment() {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, Increment)));
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (22:0,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - AttributeStructure.DoubleQuotes
                         CSharpExpression - (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.mappings.txt
@@ -6,7 +6,7 @@ Source Location: (51:2,12 [131] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1009:23,12 [131] )
+Generated Location: (965:22,12 [131] )
 |
     private int counter;
     private Task Increment(object e) {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandlerTagHelper_EscapeQuotes/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandlerTagHelper_EscapeQuotes/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "onfocus", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIFocusEventArgs>(this, "alert(\"Test\");"));
             builder.CloseElement();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandlerTagHelper_EscapeQuotes/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandlerTagHelper_EscapeQuotes/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [34] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [14] x:\dir\subdir\Test\TestComponent.cshtml) - onfocus=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "onclick", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, OnClick));
             builder.CloseElement();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.mappings.txt
@@ -3,7 +3,7 @@ Source Location: (42:1,12 [44] x:\dir\subdir\Test\TestComponent.cshtml)
     void OnClick(UIEventArgs e) {
     }
 |
-Generated Location: (939:23,12 [44] )
+Generated Location: (895:22,12 [44] )
 |
     void OnClick(UIEventArgs e) {
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "onclick", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, OnClick));
             builder.CloseElement();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.mappings.txt
@@ -3,7 +3,7 @@ Source Location: (42:1,12 [49] x:\dir\subdir\Test\TestComponent.cshtml)
     void OnClick(UIMouseEventArgs e) {
     }
 |
-Generated Location: (939:23,12 [49] )
+Generated Location: (895:22,12 [49] )
 |
     void OnClick(UIMouseEventArgs e) {
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "onclick", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, x => { }));
             builder.CloseElement();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [31] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [11] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "onclick", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, OnClick));
             builder.CloseElement();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.mappings.txt
@@ -3,7 +3,7 @@ Source Location: (42:1,12 [49] x:\dir\subdir\Test\TestComponent.cshtml)
     void OnClick(UIMouseEventArgs e) {
     }
 |
-Generated Location: (939:23,12 [49] )
+Generated Location: (895:22,12 [49] )
 |
     void OnClick(UIMouseEventArgs e) {
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "onclick", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, x => { }));
             builder.CloseElement();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [31] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [11] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "onclick", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, OnClick));
             builder.CloseElement();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.mappings.txt
@@ -3,7 +3,7 @@ Source Location: (42:1,12 [31] x:\dir\subdir\Test\TestComponent.cshtml)
     void OnClick() {
     }
 |
-Generated Location: (939:23,12 [31] )
+Generated Location: (895:22,12 [31] )
 |
     void OnClick() {
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "onclick", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, () => { }));
             builder.CloseElement();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [32] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "onclick", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, "foo"));
             builder.CloseElement();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [23] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (16:0,16 [3] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent<int>>(0);
             builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<int>(3));
             builder.AddComponentReferenceCapture(2, (__value) => {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [44] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentTypeArgument - (19:0,19 [3] x:\dir\subdir\Test\TestComponent.cshtml) - TItem
                         IntermediateToken - (19:0,19 [3] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - int

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (37:0,37 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |_my|
-Generated Location: (898:21,37 [3] )
+Generated Location: (854:20,37 [3] )
 |_my|
 
 Source Location: (60:2,12 [90] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -8,7 +8,7 @@ Source Location: (60:2,12 [90] x:\dir\subdir\Test\TestComponent.cshtml)
     private MyComponent<int> _my;
     public void Foo() { System.GC.KeepAlive(_my); }
 |
-Generated Location: (1188:33,12 [90] )
+Generated Location: (1144:32,12 [90] )
 |
     private MyComponent<int> _my;
     public void Foo() { System.GC.KeepAlive(_my); }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, 3, 2, (__value) => {
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [34] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (19:0,19 [1] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         IntermediateToken - (19:0,19 [1] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - 3

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (27:0,27 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |_my|
-Generated Location: (757:19,27 [3] )
+Generated Location: (713:18,27 [3] )
 |_my|
 
 Source Location: (50:2,12 [90] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -8,7 +8,7 @@ Source Location: (50:2,12 [90] x:\dir\subdir\Test\TestComponent.cshtml)
     private MyComponent<int> _my;
     public void Foo() { System.GC.KeepAlive(_my); }
 |
-Generated Location: (985:30,12 [90] )
+Generated Location: (941:29,12 [90] )
 |
     private MyComponent<int> _my;
     public void Foo() { System.GC.KeepAlive(_my); }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             __Blazor.Test.TestComponent.TypeInference.CreateTest_MyComponent_0(builder, 0, 1, "hi", 2, (context) => (builder2) => {
                 builder2.AddContent(3, "\r\n  ");
                 builder2.OpenElement(4, "div");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [87] x:\dir\subdir\Test\TestComponent.cshtml) - Test.MyComponent
                     ComponentChildContent -  - ChildContent - context
                         HtmlContent - (33:0,33 [4] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddContent(0, "My value");
             builder.AddContent(1, "\r\n\r\n");
             builder.AddMarkupContent(2, "<h1>Hello</h1>");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpExpression - (2:0,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [10] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - "My value"
                 HtmlContent - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.SomeOtherComponent>(0);
             builder.CloseComponent();
             builder.AddContent(1, "\r\n\r\n");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - SomeOtherComponent
                 HtmlContent - (22:0,22 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (22:0,22 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddMarkupContent(0, "<h1>Hello</h1>");
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.ir.txt
@@ -7,6 +7,4 @@ Document -
         UsingDirective - (1:0,1 [14] x:\dir\subdir\Test\TestComponent.cshtml) - System
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupBlock -  - <h1>Hello</h1>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
                 MarkupElement - (45:3,0 [38] x:\dir\subdir\Test\TestComponent.cshtml) - div

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
 | 
   var myValue = "Expression value";
 |
-Generated Location: (621:18,2 [40] )
+Generated Location: (577:17,2 [40] )
 | 
   var myValue = "Expression value";
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "Header", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
                 builder2.AddContent(2, "Hi!");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [87] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentChildContent - (19:1,4 [20] x:\dir\subdir\Test\TestComponent.cshtml) - Header - context
                         HtmlContent - (27:1,12 [3] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    RenderFragment<Test.Context> template = (context) => 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [54] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [54] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  RenderFragment<Test.Context> template = (context) => 
                 Template - (57:0,57 [50] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (2:0,2 [54] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderFragment<Test.Context> template = (context) => |
-Generated Location: (621:18,2 [54] )
+Generated Location: (577:17,2 [54] )
 | RenderFragment<Test.Context> template = (context) => |
 
 Source Location: (107:0,107 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
-Generated Location: (1253:33,107 [2] )
+Generated Location: (1209:32,107 [2] )
 |; |
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
   

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    RenderFragment<Person> p = (person) => 
                 Template - (48:1,44 [45] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.mappings.txt
@@ -1,14 +1,14 @@
 Source Location: (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     RenderFragment<Person> p = (person) => |
-Generated Location: (621:18,2 [45] )
+Generated Location: (577:17,2 [45] )
 |
     RenderFragment<Person> p = (person) => |
 
 Source Location: (93:1,89 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |;
 |
-Generated Location: (1255:33,89 [3] )
+Generated Location: (1211:32,89 [3] )
 |;
 |
 
@@ -19,7 +19,7 @@ Source Location: (111:3,12 [76] x:\dir\subdir\Test\TestComponent.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (1439:42,12 [76] )
+Generated Location: (1395:41,12 [76] )
 |
     class Person
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
   

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    RenderFragment<Person> p = (person) => 
                 Template - (48:1,44 [45] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.mappings.txt
@@ -1,14 +1,14 @@
 Source Location: (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     RenderFragment<Person> p = (person) => |
-Generated Location: (621:18,2 [45] )
+Generated Location: (577:17,2 [45] )
 |
     RenderFragment<Person> p = (person) => |
 
 Source Location: (93:1,89 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |;
 |
-Generated Location: (1255:33,89 [3] )
+Generated Location: (1211:32,89 [3] )
 |;
 |
 
@@ -19,7 +19,7 @@ Source Location: (164:7,12 [76] x:\dir\subdir\Test\TestComponent.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (1841:50,12 [76] )
+Generated Location: (1797:49,12 [76] )
 |
     class Person
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    RenderFragment<Person> template = (person) => 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [47] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [47] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  RenderFragment<Person> template = (person) => 
                 Template - (50:0,50 [23] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (2:0,2 [47] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderFragment<Person> template = (person) => |
-Generated Location: (621:18,2 [47] )
+Generated Location: (577:17,2 [47] )
 | RenderFragment<Person> template = (person) => |
 
 Source Location: (73:0,73 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
-Generated Location: (1052:30,73 [2] )
+Generated Location: (1008:29,73 [2] )
 |; |
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddContent(0, RenderPerson((person) => (builder2) => {
                 builder2.OpenElement(1, "div");
                 builder2.AddContent(2, person.Name);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpExpression - (1:0,1 [49] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (1:0,1 [25] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - RenderPerson((person) => 
                     Template - (27:0,27 [23] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.mappings.txt
@@ -7,7 +7,7 @@ Source Location: (65:1,12 [138] x:\dir\subdir\Test\TestComponent.cshtml)
 
     object RenderPerson(RenderFragment<Person> p) => null;
 |
-Generated Location: (933:26,12 [138] )
+Generated Location: (889:25,12 [138] )
 |
     class Person
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
   

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    RenderFragment<Person> p = (person) => 
                 Template - (48:1,44 [23] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.mappings.txt
@@ -1,14 +1,14 @@
 Source Location: (2:0,2 [45] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     RenderFragment<Person> p = (person) => |
-Generated Location: (621:18,2 [45] )
+Generated Location: (577:17,2 [45] )
 |
     RenderFragment<Person> p = (person) => |
 
 Source Location: (71:1,67 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |;
 |
-Generated Location: (1044:31,67 [3] )
+Generated Location: (1000:30,67 [3] )
 |;
 |
 
@@ -19,7 +19,7 @@ Source Location: (89:3,12 [76] x:\dir\subdir\Test\TestComponent.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (1228:40,12 [76] )
+Generated Location: (1184:39,12 [76] )
 |
     class Person
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddContent(0, RenderPerson((person) => (builder2) => {
                 builder2.OpenElement(1, "div");
                 builder2.AddContent(2, person.Name);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpExpression - (2:0,2 [49] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [25] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - RenderPerson((person) => 
                     Template - (28:0,28 [23] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.mappings.txt
@@ -7,7 +7,7 @@ Source Location: (67:1,12 [138] x:\dir\subdir\Test\TestComponent.cshtml)
 
     object RenderPerson(RenderFragment<Person> p) => null;
 |
-Generated Location: (933:26,12 [138] )
+Generated Location: (889:25,12 [138] )
 |
     class Person
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_AsComponentParameter/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_AsComponentParameter/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
    RenderFragment template = 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_AsComponentParameter/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_AsComponentParameter/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpCode - (2:0,2 [27] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (2:0,2 [27] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  RenderFragment template = 
                 Template - (30:0,30 [15] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_AsComponentParameter/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_AsComponentParameter/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (2:0,2 [27] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderFragment template = |
-Generated Location: (621:18,2 [27] )
+Generated Location: (577:17,2 [27] )
 | RenderFragment template = |
 
 Source Location: (45:0,45 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
-Generated Location: (925:28,45 [2] )
+Generated Location: (881:27,45 [2] )
 |; |
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddContent(0, RenderPerson((builder2) => {
                 builder2.AddMarkupContent(1, "<div>HI</div>");
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 CSharpExpression - (1:0,1 [27] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (1:0,1 [13] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - RenderPerson(
                     Template - (15:0,15 [13] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (43:1,12 [54] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     object RenderPerson(RenderFragment p) => null;
 |
-Generated Location: (840:24,12 [54] )
+Generated Location: (796:23,12 [54] )
 |
     object RenderPerson(RenderFragment p) => null;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.Counter>(0);
             builder.AddAttribute(1, "v", Microsoft.AspNetCore.Components.BindMethods.GetValue(y));
             builder.AddAttribute(2, "vChanged", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => y = __value, y));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - Counter
                     ComponentAttribute - (17:0,17 [1] x:\dir\subdir\Test\TestComponent.cshtml) - v - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (36:1,12 [24] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string y = null;
 |
-Generated Location: (1023:24,12 [24] )
+Generated Location: (979:23,12 [24] )
 |
     string y = null;
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenComponent<Test.User>(0);
             builder.AddAttribute(1, "Name", Microsoft.AspNetCore.Components.BindMethods.GetValue(UserName));
             builder.AddAttribute(2, "NameChanged", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => UserName = __value, UserName));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 Component - (0:0,0 [60] x:\dir\subdir\Test\TestComponent.cshtml) - User
                     ComponentAttribute - (17:0,17 [9] x:\dir\subdir\Test\TestComponent.cshtml) - Name - AttributeStructure.DoubleQuotes
                         CSharpExpression - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.mappings.txt
@@ -3,7 +3,7 @@ Source Location: (76:2,12 [88] x:\dir\subdir\Test\TestComponent.cshtml)
     public string UserName { get; set; }
     public bool UserIsActive { get; set; }
 |
-Generated Location: (1345:26,12 [88] )
+Generated Location: (1301:25,12 [88] )
 |
     public string UserName { get; set; }
     public bool UserIsActive { get; set; }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_772/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_772/TestComponent.codegen.cs
@@ -14,7 +14,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddMarkupContent(0, "<h1>Hello, world!</h1>\r\n\r\nWelcome to your new app.\r\n\r\n");
             builder.OpenComponent<Test.SurveyPrompt>(1);
             builder.AddAttribute(2, "Title", "\r\n");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_772/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_772/TestComponent.ir.txt
@@ -8,8 +8,6 @@ Document -
         RouteAttributeExtensionNode -  - /
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupBlock -  - <h1>Hello, world!</h1>\n\nWelcome to your new app.\n\n
                 Component - (67:6,0 [23] x:\dir\subdir\Test\TestComponent.cshtml) - SurveyPrompt
                     ComponentAttribute - (88:6,21 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Title - AttributeStructure.DoubleQuotes

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_773/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_773/TestComponent.codegen.cs
@@ -14,7 +14,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddMarkupContent(0, "<h1>Hello, world!</h1>\r\n\r\nWelcome to your new app.\r\n\r\n");
             builder.OpenComponent<Test.SurveyPrompt>(1);
             builder.AddAttribute(2, "Title", "<div>Test!</div>");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_773/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_773/TestComponent.ir.txt
@@ -8,8 +8,6 @@ Document -
         RouteAttributeExtensionNode -  - /
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupBlock -  - <h1>Hello, world!</h1>\n\nWelcome to your new app.\n\n
                 Component - (67:6,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - SurveyPrompt
                     ComponentAttribute - (88:6,21 [16] x:\dir\subdir\Test\TestComponent.cshtml) - Title - AttributeStructure.DoubleQuotes

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_784/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_784/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "p");
             builder.AddAttribute(1, "onmouseover", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, OnComponentHover));
             builder.AddAttribute(2, "style", "background:" + " " + (ParentBgColor) + ";");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_784/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_784/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [73] x:\dir\subdir\Test\TestComponent.cshtml) - p
                     HtmlAttribute - (16:0,16 [17] x:\dir\subdir\Test\TestComponent.cshtml) - onmouseover=" - "
                         CSharpExpressionAttributeValue -  - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_784/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_784/TestComponent.mappings.txt
@@ -6,7 +6,7 @@ Source Location: (87:1,12 [132] x:\dir\subdir\Test\TestComponent.cshtml)
     {
     }
 |
-Generated Location: (1040:24,12 [132] )
+Generated Location: (996:23,12 [132] )
 |
     public string ParentBgColor { get; set; } = "#FFFFFF";
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ScriptTag_WithErrorSuppressed/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ScriptTag_WithErrorSuppressed/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "div");
             builder.AddContent(1, "\r\n    ");
             builder.OpenElement(2, "script");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ScriptTag_WithErrorSuppressed/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ScriptTag_WithErrorSuppressed/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [144] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlContent - (5:0,5 [6] x:\dir\subdir\Test\TestComponent.cshtml)
                         IntermediateToken - (5:0,5 [6] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n    

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddMarkupContent(0, "<h1>Hello</h1>\r\n\r\n");
             builder.AddContent(1, "My value");
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupBlock -  - <h1>Hello</h1>\n\n
                 CSharpExpression - (20:2,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (20:2,2 [10] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - "My value"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddMarkupContent(0, "<h1>Hello</h1>\r\n\r\n");
             builder.OpenComponent<Test.SomeOtherComponent>(1);
             builder.CloseComponent();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.ir.txt
@@ -7,7 +7,5 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupBlock -  - <h1>Hello</h1>\n\n
                 Component - (18:2,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - SomeOtherComponent

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -14,7 +14,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddMarkupContent(0, "<h1>Hello</h1>");
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.ir.txt
@@ -8,6 +8,4 @@ Document -
         RouteAttributeExtensionNode -  - /my/url
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupBlock -  - <h1>Hello</h1>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/WhiteSpace_InsideAttribute_InMarkupBlock/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/WhiteSpace_InsideAttribute_InMarkupBlock/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.AddMarkupContent(0, "<div class=\"first second\">Hello</div>");
         }
         #pragma warning restore 1998

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/WhiteSpace_InsideAttribute_InMarkupBlock/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/WhiteSpace_InsideAttribute_InMarkupBlock/TestComponent.ir.txt
@@ -7,6 +7,4 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupBlock -  - <div class="first second">Hello</div>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.codegen.cs
@@ -13,7 +13,6 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "elem");
             builder.AddAttribute(1, "attr", Foo);
             builder.CloseElement();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.ir.txt
@@ -7,8 +7,6 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - 
-                    IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 MarkupElement - (0:0,0 [18] x:\dir\subdir\Test\TestComponent.cshtml) - elem
                     HtmlAttribute - (5:0,5 [10] x:\dir\subdir\Test\TestComponent.cshtml) -  attr= - 
                         CSharpExpressionAttributeValue - (11:0,11 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (36:1,16 [29] x:\dir\subdir\Test\TestComponent.cshtml)
 |
         int Foo = 18;
     |
-Generated Location: (817:23,16 [29] )
+Generated Location: (773:22,16 [29] )
 |
         int Foo = 18;
     |


### PR DESCRIPTION
This can only be merged *after* https://github.com/aspnet/AspNetCore/pull/8818, otherwise we'll break the upstream repo.

I'd recommend looking at the first commit separately from the second (which is purely a giant set of baseline diffs).