### PR TITLE
Prevent build failures and warnings when building 2.x projects

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Component.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Component.targets
@@ -21,6 +21,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
+    <_RazorGenerateComponentDeclarationDesignTimeDependsOn>ResolveRazorConfiguration;ResolveRazorComponentInputs;AssignRazorComponentTargetPaths;RazorGenerateComponentDeclaration</_RazorGenerateComponentDeclarationDesignTimeDependsOn>
+    <_RazorGenerateComponentDesignTimeDependsOn>ResolveRazorComponentInputs;AssignRazorComponentTargetPaths</_RazorGenerateComponentDesignTimeDependsOn>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <!-- Used for tracking inputs to component generation -->
     <_RazorComponentInputHash></_RazorComponentInputHash>
     <_RazorComponentInputCacheFile>$(IntermediateOutputPath)$(MSBuildProjectName).RazorComponent.input.cache</_RazorComponentInputCacheFile>

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
@@ -74,13 +74,4 @@ Copyright (c) .NET Foundation. All rights reserved.
     <None Remove="**\*.razor" />
   </ItemGroup>
 
-  <!-- 
-    Wire-ups for design-time build targets. These have to be here because the design time targetes need to exist
-    on a downlevel SDK which doesn't have components support.
-  -->
-  <PropertyGroup>
-    <_RazorGenerateComponentDeclarationDesignTimeDependsOn>ResolveRazorConfiguration;ResolveRazorComponentInputs;AssignRazorComponentTargetPaths;RazorGenerateComponentDeclaration</_RazorGenerateComponentDeclarationDesignTimeDependsOn>
-    <_RazorGenerateComponentDesignTimeDependsOn>ResolveRazorComponentInputs;AssignRazorComponentTargetPaths</_RazorGenerateComponentDesignTimeDependsOn>
-  </PropertyGroup>
-
 </Project>

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -374,11 +374,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
     <Warning Text="Unable to resolve a Razor configuration for the value '$(RazorDefaultConfiguration)'. Available configurations '@(RazorConfiguration->'%(Identity)', ', ')'.'"
       Code="RAZORSDK1000"
-      Condition="'@(ResolvedRazorConfiguration->Count())' == '0'" />
+      Condition="'$(_Targeting30OrNewerRazorLangVersion)' == 'true' AND '@(ResolvedRazorConfiguration->Count())' == '0'" />
 
     <Warning Text="More than one Razor configuration was resolved for the value '$(RazorDefaultConfiguration)'. Available configurations '@(RazorConfiguration->'%(Identity)', ', ')'."
       Code="RAZORSDK1001"
-      Condition="'@(ResolvedRazorConfiguration->Count())' &gt; '1'" />
+      Condition="'$(_Targeting30OrNewerRazorLangVersion)' == 'true' AND '@(ResolvedRazorConfiguration->Count())' &gt; '1'" />
+
+    <!-- For a 3.0 project, targeting a RazorLangVersion is nearly always an error condition -->
+    <Warning Text="Detected Razor language version downgrade. This is typically caused by a reference to the Microsoft.AspNetCore.Razor.Design package. Consider removing this package reference."
+      Code="RAZORSDK1006"
+      Condition="'$(_Targeting30OrNewerRazorLangVersion)' != 'true' AND '$(_TargetFrameworkVersionWithoutV)' &gt; '2.9'" />
 
     <FindInList
         List="@(RazorExtension)"


### PR DESCRIPTION
* Move targets for component design time generation to
Components.targets

* Provide a better error message when referencing a 2.x Razor.Design
package in a 3.0 project

* Do not produce a warning for unresolved configuration when building
2.x projects

Fixes https://github.com/aspnet/AspNetCore/issues/8899
