### PR TITLE
Expand RazorProject.GetItem to take in FileKinds when getting items.

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/CodeGenerationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/CodeGenerationBenchmark.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Razor.Performance
             
             ProjectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, fileSystem, b => RazorExtensions.Register(b)); ;
 
-            MSN = fileSystem.GetItem(Path.Combine(root.FullName, "MSN.cshtml"));
+            MSN = fileSystem.GetItem(Path.Combine(root.FullName, "MSN.cshtml"), FileKinds.Legacy);
         }
 
         public RazorProjectEngine ProjectEngine { get; }

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/SyntaxTreeGenerationBenckmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/SyntaxTreeGenerationBenckmark.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Razor.Performance
 
             ProjectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, fileSystem, b => RazorExtensions.Register(b)); ;
 
-            var projectItem = fileSystem.GetItem(Path.Combine(root.FullName, "MSN.cshtml"));
+            var projectItem = fileSystem.GetItem(Path.Combine(root.FullName, "MSN.cshtml"), FileKinds.Legacy);
             MSN = RazorSourceDocument.ReadFrom(projectItem);
 
             var directiveFeature = ProjectEngine.EngineFeatures.OfType<IRazorDirectiveFeature>().FirstOrDefault();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectFileSystem.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectFileSystem.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 });
         }
 
-        public override RazorProjectItem GetItem(string path)
+        public override RazorProjectItem GetItem(string path, string fileKind)
         {
             var absoluteBasePath = NormalizeAndEnsureValidPath("/");
             var absolutePath = NormalizeAndEnsureValidPath(path);
@@ -58,7 +58,13 @@ namespace Microsoft.AspNetCore.Razor.Language
             var relativePhysicalPath = file.FullName.Substring(absoluteBasePath.Length + 1); // Include leading separator
             var filePath = "/" + relativePhysicalPath.Replace(Path.DirectorySeparatorChar, '/');
 
-            return new DefaultRazorProjectItem("/", filePath, relativePhysicalPath, fileKind: null, new FileInfo(absolutePath));
+            return new DefaultRazorProjectItem("/", filePath, relativePhysicalPath, fileKind, new FileInfo(absolutePath));
+        }
+
+        [Obsolete("Use GetItem(string path, string fileKind) instead.")]
+        public override RazorProjectItem GetItem(string path)
+        {
+            return GetItem(path, fileKind: null);
         }
 
         protected override string NormalizeAndEnsureValidPath(string path)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/EmptyProjectFileSystem.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/EmptyProjectFileSystem.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -14,10 +15,16 @@ namespace Microsoft.AspNetCore.Razor.Language
             return Enumerable.Empty<RazorProjectItem>();
         }
 
+        [Obsolete("Use GetItem(string path, string fileKind) instead.")]
         public override RazorProjectItem GetItem(string path)
         {
+            return GetItem(path, fileKind: null);
+        }
+
+        public override RazorProjectItem GetItem(string path, string fileKind)
+        {
             NormalizeAndEnsureValidPath(path);
-            return new NotFoundProjectItem(string.Empty, path);
+            return new NotFoundProjectItem(string.Empty, path, fileKind);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/NotFoundProjectItem.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/NotFoundProjectItem.cs
@@ -16,10 +16,12 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// </summary>
         /// <param name="basePath">The base path.</param>
         /// <param name="path">The path.</param>
-        public NotFoundProjectItem(string basePath, string path)
+        /// <param name="fileKind">The file kind</param>
+        public NotFoundProjectItem(string basePath, string path, string fileKind)
         {
             BasePath = basePath;
             FilePath = path;
+            FileKind = fileKind ?? FileKinds.GetFileKindFromFilePath(path);
         }
 
         /// <inheritdoc />
@@ -27,6 +29,9 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         /// <inheritdoc />
         public override string FilePath { get; }
+
+        /// <inheritdoc />
+        public override string FileKind { get; }
 
         /// <inheritdoc />
         public override bool Exists => false;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/RazorProject.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/RazorProject.cs
@@ -18,6 +18,9 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// </summary>
         /// <param name="basePath">The base path.</param>
         /// <returns>The sequence of <see cref="RazorProjectItem"/>.</returns>
+        /// <remarks>
+        /// Project items returned by this method have inferred FileKinds from their corresponding file paths.
+        /// </remarks>
         public abstract IEnumerable<RazorProjectItem> EnumerateItems(string basePath);
 
         /// <summary>
@@ -25,7 +28,16 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// </summary>
         /// <param name="path">The path.</param>
         /// <returns>The <see cref="RazorProjectItem"/>.</returns>
+        [Obsolete("Use GetItem(string path, string fileKind) instead.")]
         public abstract RazorProjectItem GetItem(string path);
+
+        /// <summary>
+        /// Gets a <see cref="RazorProjectItem"/> for the specified path.
+        /// </summary>
+        /// <param name="path">The path.</param>
+        /// <param name="fileKind">The file kind</param>
+        /// <returns>The <see cref="RazorProjectItem"/>.</returns>
+        public abstract RazorProjectItem GetItem(string path, string fileKind);
 
         /// <summary>
         /// Gets the sequence of files named <paramref name="fileName"/> that are applicable to the specified path.
@@ -38,6 +50,8 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// traverses to the project root.
         /// e.g.
         /// /Views/Home/View.cshtml -> [ /Views/Home/FileName.cshtml, /Views/FileName.cshtml, /FileName.cshtml ]
+        /// 
+        /// Project items returned by this method have inferred FileKinds from their corresponding file paths.
         /// </remarks>
         public IEnumerable<RazorProjectItem> FindHierarchicalItems(string path, string fileName)
         {
@@ -56,6 +70,8 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// traverses to the <paramref name="basePath"/>.
         /// e.g.
         /// (/Views, /Views/Home/View.cshtml) -> [ /Views/Home/FileName.cshtml, /Views/FileName.cshtml ]
+        /// 
+        /// Project items returned by this method have inferred FileKinds from their corresponding file paths.
         /// </remarks>
         public virtual IEnumerable<RazorProjectItem> FindHierarchicalItems(string basePath, string path, string fileName)
         {
@@ -101,7 +117,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 builder.Append(fileName);
 
                 var itemPath = builder.ToString();
-                yield return GetItem(itemPath);
+                yield return GetItem(itemPath, fileKind: null);
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/VirtualRazorProjectFileSystem.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/VirtualRazorProjectFileSystem.cs
@@ -19,10 +19,16 @@ namespace Microsoft.AspNetCore.Razor.Language
             return directory?.EnumerateItems() ?? Enumerable.Empty<RazorProjectItem>();
         }
 
+        [Obsolete("Use GetItem(string path, string fileKind) instead.")]
         public override RazorProjectItem GetItem(string path)
         {
+            return GetItem(path, fileKind: null);
+        }
+
+        public override RazorProjectItem GetItem(string path, string fileKind)
+        {
             path = NormalizeAndEnsureValidPath(path);
-            return _root.GetItem(path) ?? new NotFoundProjectItem(string.Empty, path);
+            return _root.GetItem(path) ?? new NotFoundProjectItem(string.Empty, path, fileKind);
         }
 
         public void Add(RazorProjectItem projectItem)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Tools/CompositeRazorProjectFileSystem.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Tools/CompositeRazorProjectFileSystem.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 
 namespace Microsoft.AspNetCore.Razor.Tools
@@ -28,12 +27,18 @@ namespace Microsoft.AspNetCore.Razor.Tools
             }
         }
 
+        [Obsolete("Use GetItem(string path, string fileKind) instead.")]
         public override RazorProjectItem GetItem(string path)
+        {
+            return GetItem(path, fileKind: null);
+        }
+
+        public override RazorProjectItem GetItem(string path, string fileKind)
         {
             RazorProjectItem razorProjectItem = null;
             foreach (var fileSystem in FileSystems)
             {
-                razorProjectItem = fileSystem.GetItem(path);
+                razorProjectItem = fileSystem.GetItem(path, fileKind);
                 if (razorProjectItem != null && razorProjectItem.Exists)
                 {
                     return razorProjectItem;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Tools/GenerateCommand.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Tools/GenerateCommand.cs
@@ -305,7 +305,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
             {
                 var inputItem = inputs[i];
 
-                var codeDocument = engine.Process(engine.FileSystem.GetItem(inputItem.FilePath));
+                var codeDocument = engine.Process(engine.FileSystem.GetItem(inputItem.FilePath, inputItem.FileKind));
                 var csharpDocument = codeDocument.GetCSharpDocument();
                 outputs[i] = new OutputItem(inputItem, csharpDocument);
             });

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         {
             var projectEngine = project.GetProjectEngine();
             var importFeatures = projectEngine.ProjectFeatures.OfType<IImportProjectFeature>();
-            var projectItem = projectEngine.FileSystem.GetItem(HostDocument.FilePath);
+            var projectItem = projectEngine.FileSystem.GetItem(HostDocument.FilePath, HostDocument.FileKind);
             var importItems = importFeatures.SelectMany(f => f.GetImports(projectItem));
             if (importItems == null)
             {
@@ -379,12 +379,12 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 var projectEngine = project.GetProjectEngine();
                 foreach (var item in imports)
                 {
-                    var importProjectItem = item.FilePath == null ? null : projectEngine.FileSystem.GetItem(item.FilePath);
+                    var importProjectItem = item.FilePath == null ? null : projectEngine.FileSystem.GetItem(item.FilePath, item.FileKind);
                     var sourceDocument = await GetRazorSourceDocumentAsync(item.Document, importProjectItem).ConfigureAwait(false);
                     importSources.Add(sourceDocument);
                 }
 
-                var projectItem = document.FilePath == null ? null : projectEngine.FileSystem.GetItem(document.FilePath);
+                var projectItem = document.FilePath == null ? null : projectEngine.FileSystem.GetItem(document.FilePath, document.FileKind);
                 var documentSource = await GetRazorSourceDocumentAsync(document, projectItem).ConfigureAwait(false);
 
 
@@ -464,6 +464,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 }
 
                 public string FilePath { get; }
+
+                public string FileKind => Document.FileKind;
 
                 public VersionStamp Version { get; }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var documents = Documents.Add(hostDocument.FilePath, DocumentState.Create(Services, hostDocument, loader));
 
             // Compute the effect on the import map
-            var importTargetPaths = GetImportDocumentTargetPaths(hostDocument.TargetPath);
+            var importTargetPaths = GetImportDocumentTargetPaths(hostDocument);
             var importsToRelatedDocuments = AddToImportsToRelatedDocuments(ImportsToRelatedDocuments, hostDocument, importTargetPaths);
 
             // Now check if the updated document is an import - it's important this this happens after
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }
 
             // Compute the effect on the import map
-            var importTargetPaths = GetImportDocumentTargetPaths(hostDocument.TargetPath);
+            var importTargetPaths = GetImportDocumentTargetPaths(hostDocument);
             var importsToRelatedDocuments = RemoveFromImportsToRelatedDocuments(ImportsToRelatedDocuments, hostDocument, importTargetPaths);
 
             var state = new ProjectState(this, ProjectDifference.DocumentRemoved, HostProject, ProjectWorkspaceState, documents, importsToRelatedDocuments);
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             foreach (var document in documents)
             {
-                var importTargetPaths = GetImportDocumentTargetPaths(document.Value.HostDocument.TargetPath);
+                var importTargetPaths = GetImportDocumentTargetPaths(document.Value.HostDocument);
                 importsToRelatedDocuments = AddToImportsToRelatedDocuments(importsToRelatedDocuments, document.Value.HostDocument, importTargetPaths);
             }
 
@@ -418,11 +418,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 });
         }
 
-        public List<string> GetImportDocumentTargetPaths(string targetPath)
+        public List<string> GetImportDocumentTargetPaths(HostDocument hostDocument)
         {
             var projectEngine = ProjectEngine;
             var importFeatures = projectEngine.ProjectFeatures.OfType<IImportProjectFeature>();
-            var projectItem = projectEngine.FileSystem.GetItem(targetPath);
+            var projectItem = projectEngine.FileSystem.GetItem(hostDocument.TargetPath, hostDocument.FileKind);
             var importItems = importFeatures.SelectMany(f => f.GetImports(projectItem)).Where(i => i.FilePath != null);
 
             // Target path looks like `Foo\\Bar.cshtml`

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultImportDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultImportDocumentManager.cs
@@ -108,10 +108,9 @@ namespace Microsoft.VisualStudio.Editor.Razor
         private IEnumerable<RazorProjectItem> GetImportItems(VisualStudioDocumentTracker tracker)
         {
             var projectEngine = tracker.ProjectSnapshot.GetProjectEngine();
-
-            // It's not correct to use the file system to examine items in tooling, but it's a safe assumption
-            // for right now that imports are a .cshtml file.
-            var trackerItem = projectEngine.FileSystem.GetItem(tracker.FilePath);
+            var documentSnapshot = tracker.ProjectSnapshot.GetDocument(tracker.FilePath);
+            var fileKind = documentSnapshot?.FileKind;
+            var trackerItem = projectEngine.FileSystem.GetItem(tracker.FilePath, fileKind);
             var importFeatures = projectEngine.ProjectFeatures.OfType<IImportProjectFeature>();
             var importItems = importFeatures.SelectMany(f => f.GetImports(trackerItem));
             var physicalImports = importItems.Where(import => import.FilePath != null);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectFileSystemTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectFileSystemTest.cs
@@ -248,7 +248,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var fileSystem = new DefaultRazorProjectFileSystem(TestFolder);
 
             // Act
-            var item = fileSystem.GetItem(filePath);
+            var item = fileSystem.GetItem(filePath, fileKind: null);
 
             // Assert
             Assert.True(item.Exists);
@@ -266,7 +266,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var fileSystem = new DefaultRazorProjectFileSystem(TestFolder);
 
             // Act
-            var item = fileSystem.GetItem(path);
+            var item = fileSystem.GetItem(path, fileKind: null);
 
             // Assert
             Assert.False(item.Exists);
@@ -282,7 +282,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             // Act & Assert
             ExceptionAssert.Throws<InvalidOperationException>(
-                () => fileSystem.GetItem(path),
+                () => fileSystem.GetItem(path, fileKind: null),
                 $"The file '{path.Replace('\\', '/')}' is not a descendent of the base path '{rootPath}'.");
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestRazorProject.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestRazorProject.cs
@@ -26,11 +26,17 @@ namespace Microsoft.AspNetCore.Razor.Language
             throw new NotImplementedException();
         }
 
+        [Obsolete("Use GetItem(string path, string fileKind) instead.")]
         public override RazorProjectItem GetItem(string path)
+        {
+            return GetItem(path, fileKind: null);
+        }
+
+        public override RazorProjectItem GetItem(string path, string fileKind)
         {
             if (!_lookup.TryGetValue(path, out var value))
             {
-                value = new NotFoundProjectItem("", path);
+                value = new NotFoundProjectItem("", path, fileKind);
             }
 
             return value;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/VirtualRazorProjectFileSystemTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/VirtualRazorProjectFileSystemTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             // Act
             projectSystem.Add(new TestRazorProjectItem("/different-file.cshtml"));
-            var result = projectSystem.GetItem(path);
+            var result = projectSystem.GetItem(path, fileKind: null);
 
             // Assert
             Assert.False(result.Exists);
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             // Act
             projectSystem.Add(projectItem);
-            var actual = projectSystem.GetItem(path);
+            var actual = projectSystem.GetItem(path, fileKind: null);
 
             // Assert
             Assert.Same(projectItem, actual);
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             // Act
             projectSystem.Add(projectItem);
-            var actual = projectSystem.GetItem(path);
+            var actual = projectSystem.GetItem(path, fileKind: null);
 
             // Assert
             Assert.Same(projectItem, actual);
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var projectSystem = new VirtualRazorProjectFileSystem();
 
             // Act
-            var actual = projectSystem.GetItem("/subDirectory/dir3/file.cshtml");
+            var actual = projectSystem.GetItem("/subDirectory/dir3/file.cshtml", fileKind: null);
 
             // Assert
             Assert.False(actual.Exists);
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             // Act
             projectSystem.Add(projectItem);
-            var actual = projectSystem.GetItem("/subDirectory/dir3/file.cshtml");
+            var actual = projectSystem.GetItem("/subDirectory/dir3/file.cshtml", fileKind: null);
 
             // Assert
             Assert.False(actual.Exists);
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             // Act
             projectSystem.Add(projectItem);
-            var actual = projectSystem.GetItem("/subDirectory/dir2/file2.cshtml");
+            var actual = projectSystem.GetItem("/subDirectory/dir2/file2.cshtml", fileKind: null);
 
             // Assert
             Assert.False(actual.Exists);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestRazorProjectFileSystem.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestRazorProjectFileSystem.cs
@@ -28,11 +28,17 @@ namespace Microsoft.AspNetCore.Razor.Language
             throw new NotImplementedException();
         }
 
+        [Obsolete("Use GetItem(string path, string fileKind) instead.")]
         public override RazorProjectItem GetItem(string path)
+        {
+            return GetItem(path, fileKind: null);
+        }
+
+        public override RazorProjectItem GetItem(string path, string fileKind)
         {
             if (!_lookup.TryGetValue(path, out var value))
             {
-                value = new NotFoundProjectItem("", path);
+                value = new NotFoundProjectItem("", path, fileKind);
             }
 
             return value;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Tools.Test/CompositeRazorProjectFileSystemTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Tools.Test/CompositeRazorProjectFileSystemTest.cs
@@ -59,20 +59,20 @@ namespace Microsoft.AspNetCore.Razor.Tools
             // Arrange
             var basePath = "base-path";
             var filePath = "file-path";
-            var file1 = new NotFoundProjectItem(basePath, filePath);
+            var file1 = new NotFoundProjectItem(basePath, filePath, fileKind: null);
             var file2 = new TestRazorProjectItem(filePath);
             RazorProjectItem nullItem = null;
             var fileSystem1 = Mock.Of<RazorProjectFileSystem>(
-                f => f.GetItem(filePath) == file1);
+                f => f.GetItem(filePath, null) == file1);
             var fileSystem2 = Mock.Of<RazorProjectFileSystem>(
-                f => f.GetItem(filePath) == nullItem);
+                f => f.GetItem(filePath, null) == nullItem);
             var fileSystem3 = Mock.Of<RazorProjectFileSystem>(
-                f => f.GetItem(filePath) == file2);
+                f => f.GetItem(filePath, null) == file2);
 
             var compositeRazorProjectFileSystem = new CompositeRazorProjectFileSystem(new[] { fileSystem1, fileSystem2, fileSystem3 });
 
             // Act
-            var result = compositeRazorProjectFileSystem.GetItem(filePath);
+            var result = compositeRazorProjectFileSystem.GetItem(filePath, fileKind: null);
 
             // Assert
             Assert.Same(file2, result);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             Version = VersionStamp.Create();
 
             // Create a new HostDocument to avoid mutating the code container
+            ComponentCshtmlHostDocument = new HostDocument(TestProjectData.SomeProjectCshtmlComponentFile5);
             ComponentHostDocument = new HostDocument(TestProjectData.SomeProjectComponentFile1);
             LegacyHostDocument = new HostDocument(TestProjectData.SomeProjectFile1);
             NestedComponentHostDocument = new HostDocument(TestProjectData.SomeProjectNestedComponentFile3);
@@ -33,6 +34,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             documentState = DocumentState.Create(Workspace.Services, ComponentHostDocument, () => Task.FromResult(textAndVersion));
             ComponentDocument = new DefaultDocumentSnapshot(project, documentState);
 
+            documentState = DocumentState.Create(Workspace.Services, ComponentCshtmlHostDocument, () => Task.FromResult(textAndVersion));
+            ComponentCshtmlDocument = new DefaultDocumentSnapshot(project, documentState);
+
             documentState = DocumentState.Create(Workspace.Services, NestedComponentHostDocument, () => Task.FromResult(textAndVersion));
             NestedComponentDocument = new DefaultDocumentSnapshot(project, documentState);
         }
@@ -43,9 +47,13 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         private HostDocument ComponentHostDocument { get; }
 
+        private HostDocument ComponentCshtmlHostDocument { get; }
+
         private HostDocument LegacyHostDocument { get; }
 
         private DefaultDocumentSnapshot ComponentDocument { get; }
+
+        private DefaultDocumentSnapshot ComponentCshtmlDocument { get; }
 
         private DefaultDocumentSnapshot LegacyDocument { get; }
 
@@ -71,6 +79,17 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         // This is a sanity test that we invoke component codegen for components. It's a little fragile but
         // necessary.
+
+        [Fact]
+        public async Task GetGeneratedOutputAsync_CshtmlComponent_ContainsComponentImports()
+        {
+            // Act
+            await ComponentCshtmlDocument.GetGeneratedOutputAsync();
+
+            // Assert
+            Assert.NotNull(ComponentCshtmlHostDocument.GeneratedCodeContainer.Output);
+            Assert.Contains("using Microsoft.AspNetCore.Components", ComponentCshtmlHostDocument.GeneratedCodeContainer.Output.GeneratedCode);
+        }
         [Fact]
         public async Task GetGeneratedOutputAsync_Component()
         {

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/TestProjectData.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/TestProjectData.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.Razor
             SomeProjectComponentImportFile1 = new HostDocument(Path.Combine(baseDirectory, "SomeProject", "_Imports.razor"), "_Imports.razor", FileKinds.Component);
             SomeProjectNestedComponentFile3 = new HostDocument(Path.Combine(baseDirectory, "SomeProject", "Nested", "File3.razor"), "Nested\\File1.razor", FileKinds.Component);
             SomeProjectNestedComponentFile4 = new HostDocument(Path.Combine(baseDirectory, "SomeProject", "Nested", "File4.razor"), "Nested\\File2.razor", FileKinds.Component);
+            SomeProjectCshtmlComponentFile5 = new HostDocument(Path.Combine(baseDirectory, "SomeProject", "File5.cshtml"), "File5.cshtml", FileKinds.Component);
 
             AnotherProject = new HostProject(Path.Combine(baseDirectory, "AnotherProject", "AnotherProject.csproj"), RazorConfiguration.Default, "AnotherProject");
             AnotherProjectFile1 = new HostDocument(Path.Combine(baseDirectory, "AnotherProject", "File1.cshtml"), "File1.cshtml", FileKinds.Legacy);
@@ -58,6 +59,7 @@ namespace Microsoft.CodeAnalysis.Razor
         public static readonly HostDocument SomeProjectComponentImportFile1;
         public static readonly HostDocument SomeProjectNestedComponentFile3;
         public static readonly HostDocument SomeProjectNestedComponentFile4;
+        public static readonly HostDocument SomeProjectCshtmlComponentFile5;
 
         public static readonly HostProject AnotherProject;
         public static readonly HostDocument AnotherProjectFile1;


### PR DESCRIPTION
- Obsoleted old `GetItem` API.
- Updated tests to take new API.
- Added a new test to verify the broken scenario.

#8972
