### PR TITLE
Fix csharp intellisense in _Imports.razor

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentImports/_Imports.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentImports/_Imports.codegen.cs
@@ -45,6 +45,13 @@ MainLayout __typeHelper = default(MainLayout);
         #pragma warning disable 1998
         protected void Execute()
         {
+#nullable restore
+#line 5 "x:\dir\subdir\Test\_Imports.razor"
+__o = Foo;
+
+#line default
+#line hidden
+#nullable disable
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentImports/_Imports.diagnostics.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentImports/_Imports.diagnostics.txt
@@ -1,2 +1,2 @@
-x:\dir\subdir\Test\_Imports.razor(6,1): Error RZ10003: Markup, code and block directives are not valid in component imports.
 x:\dir\subdir\Test\_Imports.razor(5,2): Error RZ10003: Markup, code and block directives are not valid in component imports.
+x:\dir\subdir\Test\_Imports.razor(6,1): Error RZ10003: Markup, code and block directives are not valid in component imports.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentImports/_Imports.diagnostics.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentImports/_Imports.diagnostics.txt
@@ -1,2 +1,2 @@
-x:\dir\subdir\Test\_Imports.razor(5,1): Error RZ10003: Markup, code and block directives are not valid in component imports.
 x:\dir\subdir\Test\_Imports.razor(6,1): Error RZ10003: Markup, code and block directives are not valid in component imports.
+x:\dir\subdir\Test\_Imports.razor(5,2): Error RZ10003: Markup, code and block directives are not valid in component imports.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentImports/_Imports.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentImports/_Imports.ir.txt
@@ -19,3 +19,6 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected - void - Execute
+                CSharpExpression - (69:4,1 [3] x:\dir\subdir\Test\_Imports.razor)
+                    IntermediateToken - (69:4,1 [3] x:\dir\subdir\Test\_Imports.razor) - CSharp - Foo
+                IntermediateToken - (69:4,1 [3] x:\dir\subdir\Test\_Imports.razor) - CSharp - Foo

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentImports/_Imports.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentImports/_Imports.mappings.txt
@@ -13,3 +13,8 @@ Source Location: (56:3,8 [10] x:\dir\subdir\Test\_Imports.razor)
 Generated Location: (849:32,0 [10] )
 |MainLayout|
 
+Source Location: (69:4,1 [3] x:\dir\subdir\Test\_Imports.razor)
+|Foo|
+Generated Location: (1300:49,6 [3] )
+|Foo|
+

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.codegen.cs
@@ -16,6 +16,7 @@ namespace Test
         #pragma warning disable 1998
         protected void Execute()
         {
+            builder.AddContent(0, Foo);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.diagnostics.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.diagnostics.txt
@@ -1,2 +1,2 @@
-x:\dir\subdir\Test\_Imports.razor(6,1): Error RZ10003: Markup, code and block directives are not valid in component imports.
 x:\dir\subdir\Test\_Imports.razor(5,2): Error RZ10003: Markup, code and block directives are not valid in component imports.
+x:\dir\subdir\Test\_Imports.razor(6,1): Error RZ10003: Markup, code and block directives are not valid in component imports.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.diagnostics.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.diagnostics.txt
@@ -1,2 +1,2 @@
-x:\dir\subdir\Test\_Imports.razor(5,1): Error RZ10003: Markup, code and block directives are not valid in component imports.
 x:\dir\subdir\Test\_Imports.razor(6,1): Error RZ10003: Markup, code and block directives are not valid in component imports.
+x:\dir\subdir\Test\_Imports.razor(5,2): Error RZ10003: Markup, code and block directives are not valid in component imports.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.ir.txt
@@ -11,3 +11,6 @@ Document -
             IntermediateToken -  - CSharp - [Microsoft.AspNetCore.Components.Layouts.LayoutAttribute(typeof(MainLayout))]
         ClassDeclaration -  - public - _Imports - System.Object - 
             MethodDeclaration -  - protected - void - Execute
+                CSharpExpression - (69:4,1 [3] x:\dir\subdir\Test\_Imports.razor)
+                    IntermediateToken - (69:4,1 [3] x:\dir\subdir\Test\_Imports.razor) - CSharp - Foo
+                IntermediateToken - (69:4,1 [3] x:\dir\subdir\Test\_Imports.razor) - CSharp - Foo


### PR DESCRIPTION
Before this we weren't generating any IR for CSharp code except add errors for them. I'm now generating IR nodes for CSharp that are not part of html attributes.