### PR TITLE
Add support for 'Default' RazorConfiguration

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultProjectEngineFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultProjectEngineFactory.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.Razor;
 
 namespace Microsoft.VisualStudio.Editor.Razor
 {
-
     [ExportCustomProjectEngineFactory("Default", SupportsSerialization = true)]
     internal class DefaultProjectEngineFactory : IProjectEngineFactory
     {

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultProjectEngineFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultProjectEngineFactory.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.VisualStudio.Editor.Razor
+{
+
+    [ExportCustomProjectEngineFactory("Default", SupportsSerialization = true)]
+    internal class DefaultProjectEngineFactory : IProjectEngineFactory
+    {
+        public RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            return RazorProjectEngine.Create(configuration, fileSystem, b =>
+            {
+                CompilerFeatures.Register(b);
+
+                configure?.Invoke(b);
+
+                // See comments on MangleClassNames
+                var componentDocumentClassifier = b.Features.OfType<ComponentDocumentClassifierPass>().FirstOrDefault();
+                if (componentDocumentClassifier != null)
+                {
+                    componentDocumentClassifier.MangleClassNames = true;
+                }
+            });
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
@@ -163,12 +163,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 return false;
             }
 
-            if (!TryGetExtensionNames(configurationItem, out var extensionNames))
-            {
-                configuration = null;
-                return false;
-            }
-
+            var extensionNames = GetExtensionNames(configurationItem);
             if (!TryGetExtensions(extensionNames, state, out var extensions))
             {
                 configuration = null;
@@ -264,20 +259,16 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         }
 
         // Internal for testing
-        internal static bool TryGetExtensionNames(
-            Item configurationItem, 
-            out string[] configuredExtensionNames)
+        internal static string[] GetExtensionNames(Item configurationItem)
         {
             // The list of extension names might not be present, because the configuration may not have any.
             configurationItem.Value.TryGetValue(Rules.RazorConfiguration.ExtensionsProperty, out var extensionNames);
             if (string.IsNullOrEmpty(extensionNames))
             {
-                configuredExtensionNames = Array.Empty<string>();
-                return true;
+                return Array.Empty<string>();
             }
 
-            configuredExtensionNames = extensionNames.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-            return true;
+            return extensionNames.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
         // Internal for testing

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
@@ -268,16 +268,12 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             Item configurationItem, 
             out string[] configuredExtensionNames)
         {
-            if (!configurationItem.Value.TryGetValue(Rules.RazorConfiguration.ExtensionsProperty, out var extensionNames))
-            {
-                configuredExtensionNames = null;
-                return false;
-            }
-
+            // The list of extension names might not be present, because the configuration may not have any.
+            configurationItem.Value.TryGetValue(Rules.RazorConfiguration.ExtensionsProperty, out var extensionNames);
             if (string.IsNullOrEmpty(extensionNames))
             {
-                configuredExtensionNames = null;
-                return false;
+                configuredExtensionNames = Array.Empty<string>();
+                return true;
             }
 
             configuredExtensionNames = extensionNames.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
@@ -290,13 +286,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             IImmutableDictionary<string, IProjectRuleSnapshot> state, 
             out ProjectSystemRazorExtension[] extensions)
         {
-            if (!state.TryGetValue(Rules.RazorExtension.PrimaryDataSourceItemType, out var rule))
-            {
-                extensions = null;
-                return false;
-            }
+            // The list of extensions might not be present, because the configuration may not have any.
+            state.TryGetValue(Rules.RazorExtension.PrimaryDataSourceItemType, out var rule);
 
-            var items = rule.Items;
+            var items = rule?.Items ?? ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty;
             var extensionList = new List<ProjectSystemRazorExtension>();
             foreach (var item in items)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
@@ -77,13 +77,8 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
                 return false;
             }
 
-            if (!TryGetConfiguredExtensionNames(configurationItem, out var configuredExtensionNames))
-            {
-                configuration = null;
-                return false;
-            }
-
-            var extensions = GetExtensions(configuredExtensionNames, projectItems);
+            var extensionNames = GetExtensionNames(configurationItem);
+            var extensions = GetExtensions(extensionNames, projectItems);
             configuration = new ProjectSystemRazorConfiguration(languageVersion, configurationItem.Include, extensions);
             return true;
         }
@@ -140,18 +135,16 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
         }
 
         // Internal for testing
-        internal static bool TryGetConfiguredExtensionNames(IMSBuildItemEvaluated configurationItem, out string[] configuredExtensionNames)
+        internal static string[] GetExtensionNames(IMSBuildItemEvaluated configurationItem)
         {
             var extensionNamesValue = configurationItem.Metadata.GetValue(RazorConfigurationItemTypeExtensionsProperty);
 
             if (string.IsNullOrEmpty(extensionNamesValue))
             {
-                configuredExtensionNames = null;
-                return false;
+                return Array.Empty<string>();
             }
             
-            configuredExtensionNames = extensionNamesValue.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-            return true;
+            return extensionNamesValue.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
         // Internal for testing

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorProjectHostTest.cs
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         }
 
         [Fact]
-        public void TryGetConfiguredExtensionNames_SucceedsWithNoExtensions()
+        public void GetExtensionNames_SucceedsWithNoExtensions()
         {
             // Arrange
             var items = new ItemCollection(Rules.RazorConfiguration.SchemaName);
@@ -304,15 +304,14 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var item = items.ToSnapshot().Items.Single();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetExtensionNames(item, out var configuredExtensionnames);
+            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
 
             // Assert
-            Assert.True(result);
-            Assert.Empty(configuredExtensionnames);
+            Assert.Empty(extensionNames);
         }
 
         [Fact]
-        public void TryGetConfiguredExtensionNames_SucceedsWithEmptyExtensions()
+        public void GetExtensionNames_SucceedsWithEmptyExtensions()
         {
             // Arrange
             var items = new ItemCollection(Rules.RazorConfiguration.SchemaName);
@@ -322,15 +321,14 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var item = items.ToSnapshot().Items.Single();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetExtensionNames(item, out var configuredExtensionNames);
+            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
 
             // Assert
-            Assert.True(result);
-            Assert.Empty(configuredExtensionNames);
+            Assert.Empty(extensionNames);
         }
 
         [Fact]
-        public void TryGetConfiguredExtensionNames_SucceedsIfSingleExtension()
+        public void GetExtensionNames_SucceedsIfSingleExtension()
         {
             // Arrange
             var expectedExtensionName = "SomeExtensionName";
@@ -342,16 +340,15 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var item = items.ToSnapshot().Items.Single();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetExtensionNames(item, out var configuredExtensionNames);
+            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
 
             // Assert
-            Assert.True(result);
-            var extensionName = Assert.Single(configuredExtensionNames);
+            var extensionName = Assert.Single(extensionNames);
             Assert.Equal(expectedExtensionName, extensionName);
         }
 
         [Fact]
-        public void TryGetConfiguredExtensionNames_SucceedsIfMultipleExtensions()
+        public void GetExtensionNames_SucceedsIfMultipleExtensions()
         {
             // Arrange
             var items = new ItemCollection(Rules.RazorConfiguration.SchemaName);
@@ -361,12 +358,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var item = items.ToSnapshot().Items.Single();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetExtensionNames(item, out var configuredExtensionNames);
+            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
 
             // Assert
-            Assert.True(result);
             Assert.Collection(
-                configuredExtensionNames,
+                extensionNames,
                 name => Assert.Equal("SomeExtensionName", name),
                 name => Assert.Equal("SomeOtherExtensionName", name));
         }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorProjectHostTest.cs
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         }
 
         [Fact]
-        public void TryGetConfiguredExtensionNames_FailsIfNoExtensions()
+        public void TryGetConfiguredExtensionNames_SucceedsWithNoExtensions()
         {
             // Arrange
             var items = new ItemCollection(Rules.RazorConfiguration.SchemaName);
@@ -307,12 +307,12 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var result = DefaultRazorProjectHost.TryGetExtensionNames(item, out var configuredExtensionnames);
 
             // Assert
-            Assert.False(result);
-            Assert.Null(configuredExtensionnames);
+            Assert.True(result);
+            Assert.Empty(configuredExtensionnames);
         }
 
         [Fact]
-        public void TryGetConfiguredExtensionNames_FailsIfEmptyExtensions()
+        public void TryGetConfiguredExtensionNames_SucceedsWithEmptyExtensions()
         {
             // Arrange
             var items = new ItemCollection(Rules.RazorConfiguration.SchemaName);
@@ -325,8 +325,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var result = DefaultRazorProjectHost.TryGetExtensionNames(item, out var configuredExtensionNames);
 
             // Assert
-            Assert.False(result);
-            Assert.Null(configuredExtensionNames);
+            Assert.True(result);
+            Assert.Empty(configuredExtensionNames);
         }
 
         [Fact]
@@ -372,7 +372,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         }
 
         [Fact]
-        public void TryGetExtensions_NoExtensions()
+        public void TryGetExtensions_SucceedsWhenExtensionsNotFound()
         {
             // Arrange
             var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
@@ -381,8 +381,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var result = DefaultRazorProjectHost.TryGetExtensions(new[] { "Extension1", "Extension2" }, projectState, out var extensions);
 
             // Assert
-            Assert.False(result);
-            Assert.Null(extensions);
+            Assert.True(result);
+            Assert.Empty(extensions);
         }
 
         [Fact]
@@ -496,7 +496,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         }
 
         [Fact]
-        public void TryGetConfiguration_FailsIfNoConfiguredExtensionNames()
+        public void TryGetConfiguration_SucceedsWithNoConfiguredExtensionNames()
         {
             // Arrange
             var projectState = new Dictionary<string, IProjectRuleSnapshot>()
@@ -505,7 +505,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                     Rules.RazorGeneral.SchemaName,
                     new Dictionary<string, string>()
                     {
-                        [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = "13.37",
+                        [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = "Razor-13.37",
                         [Rules.RazorGeneral.RazorLangVersionProperty] = "1.0",
                     }),
                 [Rules.RazorConfiguration.SchemaName] = TestProjectRuleSnapshot.CreateItems(
@@ -520,12 +520,14 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
 
             // Assert
-            Assert.False(result);
-            Assert.Null(configuration);
+            Assert.True(result);
+            Assert.Equal(RazorLanguageVersion.Version_1_0, configuration.LanguageVersion);
+            Assert.Equal("Razor-13.37", configuration.ConfigurationName);
+            Assert.Empty(configuration.Extensions);
         }
 
         [Fact]
-        public void TryGetConfiguration_FailsIfNoExtensions()
+        public void TryGetConfiguration_IgnoresMissingExtension()
         {
             // Arrange
             var projectState = new Dictionary<string, IProjectRuleSnapshot>()
@@ -541,7 +543,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                     Rules.RazorConfiguration.SchemaName,
                     new Dictionary<string, Dictionary<string, string>>()
                     {
-                        ["SomeExtension"] = new Dictionary<string, string>()
+                        ["13.37"] = new Dictionary<string, string>()
                         {
                             ["Extensions"] = "Razor-13.37"
                         }
@@ -552,8 +554,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
 
             // Assert
-            Assert.False(result);
-            Assert.Null(configuration);
+            Assert.True(result);
+            Assert.Empty(configuration.Extensions);
         }
 
         // This is more of an integration test but is here to test the overall flow/functionality

--- a/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/DefaultRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/DefaultRazorProjectHostTest.cs
@@ -176,36 +176,34 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
         }
 
         [Fact]
-        public void TryGetConfiguredExtensionNames_FailsIfNoExtensions()
+        public void GetExtensionNames_FailsIfNoExtensions()
         {
             // Arrange
             var configurationItem = new TestMSBuildItem("RazorConfiguration");
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfiguredExtensionNames(configurationItem, out var configuredExtensionnames);
+            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(configurationItem);
 
             // Assert
-            Assert.False(result);
-            Assert.Null(configuredExtensionnames);
+            Assert.Empty(extensionNames);
         }
 
         [Fact]
-        public void TryGetConfiguredExtensionNames_FailsIfEmptyExtensions()
+        public void GetExtensionNames_FailsIfEmptyExtensions()
         {
             // Arrange
             var configurationItem = new TestMSBuildItem("RazorConfiguration");
             configurationItem.TestMetadata.SetValue("Extensions", string.Empty);
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfiguredExtensionNames(configurationItem, out var configuredExtensionNames);
+            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(configurationItem);
 
             // Assert
-            Assert.False(result);
-            Assert.Null(configuredExtensionNames);
+            Assert.Empty(extensionNames);
         }
 
         [Fact]
-        public void TryGetConfiguredExtensionNames_SucceedsIfSingleExtension()
+        public void GetExtensionNames_SucceedsIfSingleExtension()
         {
             // Arrange
             var expectedExtensionName = "SomeExtensionName";
@@ -213,28 +211,26 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             configurationItem.TestMetadata.SetValue("Extensions", expectedExtensionName);
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfiguredExtensionNames(configurationItem, out var configuredExtensionNames);
+            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(configurationItem);
 
             // Assert
-            Assert.True(result);
-            var extensionName = Assert.Single(configuredExtensionNames);
+            var extensionName = Assert.Single(extensionNames);
             Assert.Equal(expectedExtensionName, extensionName);
         }
 
         [Fact]
-        public void TryGetConfiguredExtensionNames_SucceedsIfMultipleExtensions()
+        public void GetExtensionNames_SucceedsIfMultipleExtensions()
         {
             // Arrange
             var configurationItem = new TestMSBuildItem("RazorConfiguration");
             configurationItem.TestMetadata.SetValue("Extensions", "SomeExtensionName;SomeOtherExtensionName");
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfiguredExtensionNames(configurationItem, out var configuredExtensionNames);
+            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(configurationItem);
 
             // Assert
-            Assert.True(result);
             Assert.Collection(
-                configuredExtensionNames,
+                extensionNames,
                 name => Assert.Equal("SomeExtensionName", name),
                 name => Assert.Equal("SomeOtherExtensionName", name));
         }
@@ -358,7 +354,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
         }
 
         [Fact]
-        public void TryGetConfiguration_FailsIfNoConfiguredExtensionNames()
+        public void TryGetConfiguration_SucceedsWithoutConfiguredExtensionNames()
         {
             // Arrange
             var projectProperties = new MSBuildPropertyGroup();
@@ -376,8 +372,8 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             var result = DefaultRazorProjectHost.TryGetConfiguration(projectProperties, projectItems, out var configuration);
 
             // Assert
-            Assert.False(result);
-            Assert.Null(configuration);
+            Assert.True(result);
+            Assert.Empty(configuration.Extensions);
         }
 
         // This is more of an integration test but is here to test the overall flow/functionality


### PR DESCRIPTION
This is a configuration that will be used by the SDK for Components
projects without MVC support. In this case there are no extensions. I
also made the system more tolerant in general of missing extensions and
not fail quite so hard.
