### PR TITLE
Onboard with async publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,10 @@ variables:
   value: AspNetCore
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
+- name: _PublishUsingPipelines
+  value: true
+- name: _DotNetArtifactsCategory
+  value: ASPNETCORETOOLING
 
 resources:
   containers:
@@ -25,6 +29,7 @@ jobs:
   parameters:
     enablePublishBuildArtifacts: false
     enablePublishTestResults: false
+    enablePublishUsingPipelines: false
     jobs:
     - job: Code_check
       displayName: Code check
@@ -45,6 +50,7 @@ jobs:
   parameters:
     enablePublishBuildArtifacts: true
     enablePublishTestResults: true
+    enablePublishUsingPipelines: $(_PublishUsingPipelines)
     enableTelemetry: true
     helixRepo: aspnet/AspNetCore-Tooling
     helixType: build.product/
@@ -72,6 +78,8 @@ jobs:
                 /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
                 /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
                 /p:PublishToAzure=true
+                /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                 /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
                 /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
                 /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,6 +1,6 @@
 <Project>
 
-  <Import Project="MPack.props" />
+  <Import Project="MPack.props" Condition="Exists('MPack.props')" />
 
   <!--
     These are third party libraries that we use in this repo. We need to sign them even if they

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,5 +1,11 @@
 <Project>
 
+  <!--
+    The `Condition` in this Import was added because publishing pipelines rely
+    on importing this file but it doesn't import MPack.props.
+    The condition can be removed once this issue is fixed: 
+    https://github.com/dotnet/arcade/issues/2371
+  -->
   <Import Project="MPack.props" Condition="Exists('MPack.props')" />
 
   <!--


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/2443

Goal: mitigate `lock on the feed problem` and add further validations. [More details here.](https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/AsyncPublishing_HowToUse.md)

Test build was here: https://dnceng.visualstudio.com/internal/_build/results?buildId=150761
Test release: https://dnceng.visualstudio.com/internal/_releaseProgress?_a=release-pipeline-progress&releaseId=4484