### PR TITLE
Port remaining VSMac blocker fixes.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -26,7 +26,7 @@
   -->
   <PropertyGroup>
     <VsixVersionPrefix>16.1.0</VsixVersionPrefix>
-    <AddinVersion>7.5</AddinVersion>
+    <AddinVersion>8.0</AddinVersion>
     <AddinVersion Condition="'$(OfficialBuildId)' != ''">$(AddinVersion).$(OfficialBuildId)</AddinVersion>
     <AddinVersion Condition="'$(OfficialBuildId)' == ''">$(AddinVersion).42424242.42</AddinVersion>
   </PropertyGroup>

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundParser.cs
@@ -259,7 +259,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
                 _backgroundThread = new Thread(WorkerLoop)
                 {
-                    Name = "Razor Background Document Parser"
+                    Name = "Razor Background Document Parser",
+                    IsBackground = true,
                 };
                 SetThreadId(_backgroundThread.ManagedThreadId);
             }

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/Documents/VisualStudioMacFileChangeTrackerFactoryFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/Documents/VisualStudioMacFileChangeTrackerFactoryFactory.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.Razor;
 namespace Microsoft.VisualStudio.Editor.Razor.Documents
 {
     [Shared]
-    [ExportWorkspaceService(typeof(FileChangeTrackerFactory), ServiceLayer.Host)]
+    [ExportWorkspaceServiceFactory(typeof(FileChangeTrackerFactory), ServiceLayer.Host)]
     internal class VisualStudioMacFileChangeTrackerFactoryFactory : IWorkspaceServiceFactory
     {
         private readonly ForegroundDispatcher _foregroundDispatcher;

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectBuildChangeTrigger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectBuildChangeTrigger.cs
@@ -88,7 +88,10 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
 
             _projectManager = projectManager;
 
-            IdeApp.ProjectOperations.EndBuild += ProjectOperations_EndBuild;
+            if (IdeApp.ProjectOperations != null)
+            {
+                IdeApp.ProjectOperations.EndBuild += ProjectOperations_EndBuild;
+            }
         }
 
         // Internal for testing

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
@@ -28,11 +28,11 @@
     </AssemblyAttribute>
     <AssemblyAttribute Include="Mono.Addins.AddinDependencyAttribute">
       <_Parameter1>::MonoDevelop.Ide</_Parameter1>
-      <_Parameter2>7.4</_Parameter2>
+      <_Parameter2>8.0</_Parameter2>
     </AssemblyAttribute>
     <AssemblyAttribute Include="Mono.Addins.AddinDependencyAttribute">
       <_Parameter1>::MonoDevelop.Core</_Parameter1>
-      <_Parameter2>7.4</_Parameter2>
+      <_Parameter2>8.0</_Parameter2>
     </AssemblyAttribute>
     </ItemGroup>
 

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
@@ -11,8 +11,8 @@
     <Import assembly="Microsoft.VisualStudio.Mac.LanguageServices.Razor.dll" />
   </Runtime>
   <Dependencies>
-    <Addin id="::MonoDevelop.Core" version="7.5" />
-    <Addin id="::MonoDevelop.Ide" version="7.5" />
+    <Addin id="::MonoDevelop.Core" version="8.0" />
+    <Addin id="::MonoDevelop.Ide" version="8.0" />
   </Dependencies>
   
   <!-- MEF catalog -->

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/RazorAddin.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/RazorAddin.cs
@@ -5,6 +5,6 @@ namespace Microsoft.VisualStudio.Mac.RazorAddin
 {
     public static class RazorAddin
     {
-        public const string Version = "7.5";
+        public const string Version = "8.0";
     }
 }


### PR DESCRIPTION
- Noticed I hadn't ported all of the VSMac fixes to the master branch. This is me pulling the remaining fixes to solve obvious blockers to the VS4Mac Razor experience.
- Note: VS4Mac doesn't work with just these set of changes. These changes simply enable VS4Mac to spin up our side of the Razor world and enable us to start parsing documents as users type. To fix the full Razor VS4Mac experience will require changes from other partner teams.
