### PR TITLE
Do not split warning message across multiple lines

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -802,8 +802,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       '$(_IsTargetingRazor2X)' != 'true'">
     <Warning
        Code="RAZORSDK1004"
-       Text="One or more Razor view or page files were found, but the project is not configured to add Razor support for MVC. The MSBuild property 'AddRazorSupportForMvc' must be set to correctly
- compile Razor files that target MVC. For more information, see https://go.microsoft.com/fwlink/?linkid=868374." />
+       Text="One or more Razor view or page files were found, but the project is not configured to add Razor support for MVC. The MSBuild property 'AddRazorSupportForMvc' must be set to correctly compile Razor files that target MVC. For more information, see https://go.microsoft.com/fwlink/?linkid=868374." />
   </Target>
 
   <Target Name="_CheckForIncorrectComponentsConfiguration"
@@ -814,8 +813,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <Warning
        Code="RAZORSDK1005"
-       Text="One or more Razor component files (.razor) were found, but the project is not configured to compile Razor Components. Configure the project by targeting RazorLangVersion 3.0 or newer.
- For more information, see https://go.microsoft.com/fwlink/?linkid=868374." />
+       Text="One or more Razor component files (.razor) were found, but the project is not configured to compile Razor Components. Configure the project by targeting RazorLangVersion 3.0 or newer. For more information, see https://go.microsoft.com/fwlink/?linkid=868374." />
   </Target>
 
   <Target Name="_ResolveRazorTargetPath">


### PR DESCRIPTION
The newline in the warning messages causes the warning message to appear as two separate warnings in the build output:

```
Microsoft.NET.Sdk.Razor\build\netstandard2.0\Sdk.Razor.CurrentVersion.targets(805,5): warning RAZORSDK1004: One or more Razor view or page files were found, but the project is not configured to add Razor support for MVC. The MSBuild property 'AddRazorSupportForMvc' must be set to correctly
Microsoft.NET.Sdk.Razor\build\netstandard2.0\Sdk.Razor.CurrentVersion.targets(805,5): warning RAZORSDK1004:  compile Razor files that target MVC. For more information, see https://go.microsoft.com/fwlink/?linkid=868374.
```

This change fixes the warning message to appear as a single warning:

```
Microsoft.NET.Sdk.Razor\build\netstandard2.0\Sdk.Razor.CurrentVersion.targets(805,5): warning RAZORSDK1004: One or more Razor view or page files were found, but the project is not configured to add Razor support for MVC. The MSBuild property 'AddRazorSupportForMvc' must be set to correctly compile Razor files that target MVC. For more information, see https://go.microsoft.com/fwlink/?linkid=868374.
```
