### PR TITLE
Dereference Razor document state information in FAR scenarios.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/SourceTextExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/SourceTextExtensions.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using System.Text;
 using Microsoft.AspNetCore.Razor.Language;
 
 namespace Microsoft.CodeAnalysis.Text
@@ -15,9 +17,81 @@ namespace Microsoft.CodeAnalysis.Text
                 throw new ArgumentNullException(nameof(sourceText));
             }
 
-            var content = sourceText.ToString();
+            var sourceDocument = new SourceTextSourceDocument(sourceText, filePath, relativePath);
+            return sourceDocument;
+        }
 
-            return RazorSourceDocument.Create(content, new RazorSourceDocumentProperties(filePath, relativePath));
+        // Internal for testing
+        internal class SourceTextSourceDocument : RazorSourceDocument
+        {
+            private readonly SourceText _sourceText;
+            private byte[] _checksum;
+
+            public SourceTextSourceDocument(
+                SourceText sourceText,
+                string filePath,
+                string relativeFilePath)
+            {
+                _sourceText = sourceText;
+
+                FilePath = filePath;
+                RelativePath = relativeFilePath;
+                Encoding = Encoding.UTF8;
+                Lines = new RazorTextLineCollection(_sourceText.Lines);
+            }
+
+            public override char this[int position] => _sourceText[position];
+
+            public override Encoding Encoding { get; }
+
+            public override string FilePath { get; }
+
+            public override string RelativePath { get; }
+
+            public override int Length => _sourceText.Length;
+
+            public override RazorSourceLineCollection Lines { get; }
+
+            public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
+            {
+                _sourceText.CopyTo(sourceIndex, destination, destinationIndex, count);
+            }
+
+            public override byte[] GetChecksum()
+            {
+                if (_checksum == null)
+                {
+                    _checksum = _sourceText.GetChecksum().ToArray();
+                }
+
+                return _checksum;
+            }
+        }
+
+        private class RazorTextLineCollection : RazorSourceLineCollection
+        {
+            private readonly TextLineCollection _textLineCollection;
+
+            public RazorTextLineCollection(TextLineCollection textLineCollection)
+            {
+                _textLineCollection = textLineCollection;
+            }
+
+            public override int Count => _textLineCollection.Count;
+
+            public override int GetLineLength(int index)
+            {
+                var textLineLength = _textLineCollection[index].SpanIncludingLineBreak.Length;
+                return textLineLength;
+            }
+
+            internal override SourceLocation GetLocation(int position)
+            {
+                var textLine = _textLineCollection.GetLineFromPosition(position);
+                var sourceLocation = new SourceLocation(position, textLine.LineNumber, position - textLine.Start);
+
+                return sourceLocation;
+            }
         }
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/SourceTextExtensionsTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/SourceTextExtensionsTest.cs
@@ -1,0 +1,122 @@
+﻿using System.Text;
+using Microsoft.AspNetCore.Razor.Language;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Text
+{
+    public class SourceTextExtensionsTest
+    {
+        public SourceTextExtensionsTest()
+        {
+            SourceText = SourceText.From(@"
+@addTagHelper *, SomeApplication
+
+<p>The current time is @GetTheTime()</p>
+
+@functions {
+    public DateTime GetTheTime()
+    {
+        return DateTime.Now;
+    }
+}");
+        }
+
+        public SourceText SourceText { get; }
+
+        [Fact]
+        public void GetRazorSourceDocument_BuildsSourceDocumentWithCorrectProperties()
+        {
+            // Arrange
+            var sourceDocumentProperties = RazorSourceDocumentProperties.Default;
+            var stringSourceDocument = new StringSourceDocument(SourceText.ToString(), Encoding.UTF8, sourceDocumentProperties);
+
+            // Act
+            var sourceTextSourceDocument = SourceText.GetRazorSourceDocument(sourceDocumentProperties.FilePath, sourceDocumentProperties.RelativePath);
+
+            // Assert
+            Assert.Equal(stringSourceDocument.Encoding, sourceTextSourceDocument.Encoding);
+            Assert.Equal(stringSourceDocument.FilePath, sourceTextSourceDocument.FilePath);
+            Assert.Equal(stringSourceDocument.RelativePath, sourceTextSourceDocument.RelativePath);
+            Assert.Equal(stringSourceDocument.Length, sourceTextSourceDocument.Length);
+            for (var i = 0; i < stringSourceDocument.Length; i++)
+            {
+                Assert.Equal(stringSourceDocument[i], sourceTextSourceDocument[i]);
+            }
+        }
+
+        [Fact]
+        public void SourceTextSourceDocument_CopyTo_WorksAsExpected()
+        {
+            // Arrange
+            var sourceDocumentProperties = RazorSourceDocumentProperties.Default;
+            var stringSourceDocument = new StringSourceDocument(SourceText.ToString(), Encoding.UTF8, sourceDocumentProperties);
+            var stringDocumentBuffer = new char[stringSourceDocument.Length];
+            stringSourceDocument.CopyTo(0, stringDocumentBuffer, 0, stringDocumentBuffer.Length);
+            var sourceTextSourceDocument = SourceText.GetRazorSourceDocument(sourceDocumentProperties.FilePath, sourceDocumentProperties.RelativePath);
+            var sourceTextDocumentBuffer = new char[sourceTextSourceDocument.Length];
+
+            // Act
+            sourceTextSourceDocument.CopyTo(0, sourceTextDocumentBuffer, 0, sourceTextDocumentBuffer.Length);
+
+            // Assert
+            Assert.Equal(stringDocumentBuffer, sourceTextDocumentBuffer);
+        }
+
+        [Fact]
+        public void SourceTextSourceDocument_GetChecksum_WorksAsExpected()
+        {
+            // Arrange
+            var sourceDocumentProperties = RazorSourceDocumentProperties.Default;
+            var stringSourceDocument = new StringSourceDocument(SourceText.ToString(), Encoding.UTF8, sourceDocumentProperties);
+            var stringSourceDocumentChecksum = stringSourceDocument.GetChecksum();
+            var sourceTextSourceDocument = SourceText.GetRazorSourceDocument(sourceDocumentProperties.FilePath, sourceDocumentProperties.RelativePath);
+
+            // Act
+            var sourceTextSourceDocumentChecksum = sourceTextSourceDocument.GetChecksum();
+
+            // Assert
+            Assert.Equal(stringSourceDocumentChecksum, sourceTextSourceDocumentChecksum);
+        }
+
+        [Fact]
+        public void RazorTextLineCollection_GetLineLength_WorksAsExpected()
+        {
+            // Arrange
+            var sourceDocumentProperties = RazorSourceDocumentProperties.Default;
+            var stringSourceDocument = new StringSourceDocument(SourceText.ToString(), Encoding.UTF8, sourceDocumentProperties);
+            var sourceTextSourceDocument = SourceText.GetRazorSourceDocument(sourceDocumentProperties.FilePath, sourceDocumentProperties.RelativePath);
+            var originalLineCollection = stringSourceDocument.Lines;
+            var newLineCollection = sourceTextSourceDocument.Lines;
+
+            // Act & Assert
+            Assert.Equal(originalLineCollection.Count, newLineCollection.Count);
+            for (var i = 0; i < originalLineCollection.Count; i++)
+            {
+                var originalLineLength = originalLineCollection.GetLineLength(i);
+                var newLineLength = newLineCollection.GetLineLength(i);
+
+                Assert.Equal(originalLineLength, newLineLength);
+            }
+        }
+
+        [Fact]
+        public void RazorTextLineCollection_GetLocation_WorksAsExpected()
+        {
+            // Arrange
+            var sourceDocumentProperties = RazorSourceDocumentProperties.Default;
+            var stringSourceDocument = new StringSourceDocument(SourceText.ToString(), Encoding.UTF8, sourceDocumentProperties);
+            var sourceTextSourceDocument = SourceText.GetRazorSourceDocument(sourceDocumentProperties.FilePath, sourceDocumentProperties.RelativePath);
+            var originalLineCollection = stringSourceDocument.Lines;
+            var newLineCollection = sourceTextSourceDocument.Lines;
+
+            // Act & Assert
+            for (var i = 0; i < SourceText.Length; i++)
+            {
+                var originalLocation = originalLineCollection.GetLocation(i);
+                var newLocation = newLineCollection.GetLocation(i);
+
+                Assert.Equal(originalLocation, newLocation);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- In FAR scenarios with large amounts of Razor documents we generate Razor output for every document in the world and then feed that information to Roslyn to populate a set of C# buffers with Razor's generated C# documents. Prior to this we were holding onto all of the data involved in creating that generated C# document; instead we now dereference that data on the `DocumentSnapshot` to allow for GC to do its job. Also did this for excerpt generation to ensure we don't break scenarios where 1 C# reference would result in X number of Razor documents being re-generated and allocate loads of memory.
- Added lots of comments to raise some of the reasons why we clear state in certain places.
- Added tests to ensure we're clearing data in the correct places.
- Added tests to ensure that the new source text wrapped source documents are 100% equivalent with what was there before.
- Added a skipped test to ensure we get coverage of the excerpt stored state clearing once Roslyn unblocks us.

### Results for a 2200 Razor document project:
|             | Committed Memory | Peak Memory |
|-------------|------------------|-------------|
| Before      | 1.14GB           | 1.38GB      |
| After       | 633MB            | 787MB       |
| Improvement | 44%              | 43%         |

This is going to go into 16.1-preview4. Have a few offline conversations on if this should be serviced or not but so far it's not looking like it should be. 