### PR TITLE
Update dotnet-install.ps1/sh scripts and add more retries

### DIFF
--- a/eng/dotnet-install.sh
+++ b/eng/dotnet-install.sh
@@ -166,6 +166,9 @@ get_current_os_name() {
     if [ "$uname" = "Darwin" ]; then
         echo "osx"
         return 0
+    elif [ "$uname" = "FreeBSD" ]; then
+        echo "freebsd"
+        return 0        
     elif [ "$uname" = "Linux" ]; then
         local linux_platform_name
         linux_platform_name="$(get_linux_platform_name)" || { echo "linux" && return 0 ; }
@@ -661,19 +664,27 @@ download() {
         return $?
     fi
 
-    local failed=false
-    if machine_has "curl"; then
-        downloadcurl "$remote_path" "$out_path" || failed=true
-    elif machine_has "wget"; then
-        downloadwget "$remote_path" "$out_path" || failed=true
-    else
-        failed=true
-    fi
-    if [ "$failed" = true ]; then
-        say_verbose "Download failed: $remote_path"
-        return 1
-    fi
-    return 0
+    local install_retries=3
+    local failed
+    while [ $install_retries -gt 0 ]; do
+        failed=false
+        if machine_has "curl"; then
+            downloadcurl "$remote_path" "$out_path" || failed=true
+        elif machine_has "wget"; then
+            downloadwget "$remote_path" "$out_path" || failed=true
+        else
+            failed=true
+        fi
+        if [ "$failed" = true ]; then
+            let install_retries=install_retries-1
+            say_verbose "Failed to download $remote_path. Retries left: $install_retries."
+            sleep 1
+        else
+            return 0
+        fi
+    done
+    say_verbose "Download failed: $remote_path"
+    return 1
 }
 
 downloadcurl() {
@@ -794,11 +805,16 @@ install_dotnet() {
             say_verbose "Legacy zip path: $zip_path"
             say "Downloading legacy link: $download_link"
             download "$download_link" "$zip_path" 2>&1 || download_failed=true
+
+            if [ "$download_failed" = true ]; then
+                say "Cannot download: $download_link"
+            fi
         fi
     fi
 
     if [ "$download_failed" = true ]; then
-        say_err "Could not download $asset_name version $specific_version"
+        say_err "Could not find/download: \`$asset_name\` with version = $specific_version"
+        say_err "Refer to: https://aka.ms/dotnet-os-lifecycle for information on .NET Core support"
         return 1
     fi
 
@@ -807,7 +823,7 @@ install_dotnet() {
 
     #  Check if the SDK version is now installed; if not, fail the installation.
     if ! is_dotnet_package_installed "$install_root" "$asset_relative_path" "$specific_version"; then
-        say_err "$asset_name version $specific_version failed to install with an unknown error."
+        say_err "\`$asset_name\` with version = $specific_version failed to install with an unknown error."
         return 1
     fi
 


### PR DESCRIPTION
Resolves https://github.com/aspnet/AspNetCore-Internal/issues/2392

This copies improvements from the canonical version of dotnet-install and adds retries to make installing more resilient.