### PR TITLE
React to Roslyn rename of `NullableContextOptions` to `Nullable`.

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Compilation.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Compilation.targets
@@ -153,7 +153,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          NoLogo="$(NoLogo)"
          NoStandardLib="$(NoCompilerStandardLib)"
          NoWin32Manifest="$(NoWin32Manifest)"
-         NullableContextOptions="$(NullableContextOptions)"
+         Nullable="$(Nullable)"
          Optimize="$(Optimize)"
          Deterministic="$(Deterministic)"
          PublicSign="$(PublicSign)"

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Component.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Component.targets
@@ -220,7 +220,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          NoLogo="$(NoLogo)"
          NoStandardLib="$(NoCompilerStandardLib)"
          NoWin32Manifest="$(NoWin32Manifest)"
-         NullableContextOptions="$(NullableContextOptions)"
+         Nullable="$(Nullable)"
          Optimize="$(Optimize)"
          Deterministic="$(Deterministic)"
          PublicSign="$(PublicSign)"

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntegrationTest.cs
@@ -629,7 +629,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         {
             var result = await DotnetMSBuild(
                 "Build",
-                "/p:LangVersion=8.0 /p:NullableContextOptions=enable");
+                "/p:LangVersion=8.0 /p:Nullable=enable");
             var indexFilePath = Path.Combine(RazorIntermediateOutputPath, "Views", "Home", "Index.cshtml.g.cs");
 
             Assert.BuildPassed(result, allowWarnings: true);
@@ -644,7 +644,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         {
             var result = await DotnetMSBuild(
                 "Build",
-                "/p:LangVersion=8.0 /p:NullableContextOptions=enable",
+                "/p:LangVersion=8.0 /p:Nullable=enable",
                 suppressBuildServer: true);
             var indexFilePath = Path.Combine(RazorIntermediateOutputPath, "Views", "Home", "Index.cshtml.g.cs");
 

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerIntegrationTest.cs
@@ -77,6 +77,12 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         [InitializeTestProject(originalProjectName: "SimpleMvc", targetProjectName: "Whitespace in name", baseDirectory: "")]
         public async Task Build_AppWithWhitespaceInName_CanBuildSuccessfully()
         {
+            // We need to separately restore the project in order to ensure this project uses the latest Roslyn. Without this
+            // the Csc task from Roslyn would have already been loaded and any update to it from nuget packages would not have
+            // an effect. This allows us to create our obj/Whitespace in name.csproj.nuget.g.props file (we renamed the project)
+            // and then properly build the project with an appropriate Csc.
+            await DotnetMSBuild("Restore");
+
             var result = await DotnetMSBuild(
                 "Build",
                 "/p:_RazorForceBuildServer=true");

--- a/src/Razor/test/testapps/Directory.Build.props
+++ b/src/Razor/test/testapps/Directory.Build.props
@@ -38,4 +38,26 @@
 
   <Import Project="After.Directory.Build.props" Condition="Exists('After.Directory.Build.props')" />
 
+  <!--
+    NOTE, BELOW
+
+    These bits are a temporary workaround until we're able to get on the latest SDK which includes the latest Roslyn bits.
+    Without them we can't properly publish testapps in a standalone fashion without investing in temporary infrastructure.
+  -->
+  <PropertyGroup>
+    <MicrosoftNetCompilersToolsetPackageVersion>3.3.0-beta2-19365-06</MicrosoftNetCompilersToolsetPackageVersion>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true' ">
+      $(RestoreSources);
+      https://dotnet.myget.org/F/roslyn/api/v3/index.json;
+    </RestoreSources>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset"
+        Version="$(MicrosoftNetCompilersToolsetPackageVersion)"
+        PrivateAssets="all"
+        IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+
 </Project>


### PR DESCRIPTION
- Verified the fix with VS16.2-preview1 + latest CLI with modified `Nullable` entry on disk
- Updated tests.
- Note: This change will not pass the build until we have a new CLI that has an updated Roslyn that understands `Nullable`.

aspnet/AspNetCore#10218