### PR TITLE
Directive attributes part 1: Support parameters in bound attributes

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/BoundAttributeDescriptorBuilderExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/BoundAttributeDescriptorBuilderExtensions.cs
@@ -51,5 +51,35 @@ namespace Microsoft.AspNetCore.Razor.Language
             builder.IndexerAttributeNamePrefix = attributeNamePrefix;
             builder.IndexerValueTypeName = valueTypeName;
         }
+
+        public static void SetPropertyName(this BoundAttributeParameterDescriptorBuilder builder, string propertyName)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (propertyName == null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            builder.Metadata[TagHelperMetadata.Common.PropertyName] = propertyName;
+        }
+
+        public static string GetPropertyName(this BoundAttributeParameterDescriptorBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (builder.Metadata.ContainsKey(TagHelperMetadata.Common.PropertyName))
+            {
+                return builder.Metadata[TagHelperMetadata.Common.PropertyName];
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/BoundAttributeDescriptorBuilderExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/BoundAttributeDescriptorBuilderExtensions.cs
@@ -29,9 +29,9 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            if (builder.Metadata.ContainsKey(TagHelperMetadata.Common.PropertyName))
+            if (builder.Metadata.TryGetValue(TagHelperMetadata.Common.PropertyName, out var value))
             {
-                return builder.Metadata[TagHelperMetadata.Common.PropertyName];
+                return value;
             }
 
             return null;
@@ -74,9 +74,9 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            if (builder.Metadata.ContainsKey(TagHelperMetadata.Common.PropertyName))
+            if (builder.Metadata.TryGetValue(TagHelperMetadata.Common.PropertyName, out var value))
             {
-                return builder.Metadata[TagHelperMetadata.Common.PropertyName];
+                return value;
             }
 
             return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/BoundAttributeDescriptorExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/BoundAttributeDescriptorExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/BoundAttributeDescriptorExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/BoundAttributeDescriptorExtensions.cs
@@ -49,5 +49,26 @@ namespace Microsoft.AspNetCore.Razor.Language
             var isIndexerNameMatch = TagHelperMatchingConventions.SatisfiesBoundAttributeIndexer(name, attribute);
             return isIndexerNameMatch && attribute.IsIndexerBooleanProperty;
         }
+
+        public static bool IsDefaultKind(this BoundAttributeParameterDescriptor parameter)
+        {
+            if (parameter == null)
+            {
+                throw new ArgumentNullException(nameof(parameter));
+            }
+
+            return string.Equals(parameter.Kind, TagHelperConventions.DefaultKind, StringComparison.Ordinal);
+        }
+
+        public static string GetPropertyName(this BoundAttributeParameterDescriptor parameter)
+        {
+            if (parameter == null)
+            {
+                throw new ArgumentNullException(nameof(parameter));
+            }
+
+            parameter.Metadata.TryGetValue(TagHelperMetadata.Common.PropertyName, out var propertyName);
+            return propertyName;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/BoundAttributeParameterDescriptor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/BoundAttributeParameterDescriptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -7,21 +7,14 @@ using System.Linq;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    /// <summary>
-    /// A metadata class describing a tag helper attribute.
-    /// </summary>
-    public abstract class BoundAttributeDescriptor : IEquatable<BoundAttributeDescriptor>
+    public abstract class BoundAttributeParameterDescriptor : IEquatable<BoundAttributeParameterDescriptor>
     {
-        protected BoundAttributeDescriptor(string kind)
+        protected BoundAttributeParameterDescriptor(string kind)
         {
             Kind = kind;
         }
 
         public string Kind { get; }
-
-        public bool IsIndexerStringProperty { get; protected set; }
-
-        public bool IsIndexerBooleanProperty { get; protected set; }
 
         public bool IsEnum { get; protected set; }
 
@@ -31,13 +24,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public string Name { get; protected set; }
 
-        public string IndexerNamePrefix { get; protected set; }
-
         public string TypeName { get; protected set; }
-
-        public string IndexerTypeName { get; protected set; }
-
-        public bool HasIndexer { get; protected set; }
 
         public string Documentation { get; protected set; }
 
@@ -46,8 +33,6 @@ namespace Microsoft.AspNetCore.Razor.Language
         public IReadOnlyList<RazorDiagnostic> Diagnostics { get; protected set; }
 
         public IReadOnlyDictionary<string, string> Metadata { get; protected set; }
-
-        public virtual IReadOnlyList<BoundAttributeParameterDescriptor> BoundAttributeParameters { get; protected set; }
 
         public bool HasErrors
         {
@@ -64,19 +49,19 @@ namespace Microsoft.AspNetCore.Razor.Language
             return DisplayName ?? base.ToString();
         }
 
-        public bool Equals(BoundAttributeDescriptor other)
+        public bool Equals(BoundAttributeParameterDescriptor other)
         {
-            return BoundAttributeDescriptorComparer.Default.Equals(this, other);
+            return BoundAttributeParameterDescriptorComparer.Default.Equals(this, other);
         }
 
         public override bool Equals(object obj)
         {
-            return Equals(obj as BoundAttributeDescriptor);
+            return Equals(obj as BoundAttributeParameterDescriptor);
         }
 
         public override int GetHashCode()
         {
-            return BoundAttributeDescriptorComparer.Default.GetHashCode(this);
+            return BoundAttributeParameterDescriptorComparer.Default.GetHashCode(this);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/BoundAttributeParameterDescriptorBuilder.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/BoundAttributeParameterDescriptorBuilder.cs
@@ -1,24 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    public abstract class BoundAttributeDescriptorBuilder
+    public abstract class BoundAttributeParameterDescriptorBuilder
     {
         public abstract string Name { get; set; }
 
         public abstract string TypeName { get; set; }
 
         public abstract bool IsEnum { get; set; }
-
-        public abstract bool IsDictionary { get; set; }
-
-        public abstract string IndexerAttributeNamePrefix { get; set; }
-
-        public abstract string IndexerValueTypeName { get; set; }
 
         public abstract string Documentation { get; set; }
 
@@ -27,11 +20,5 @@ namespace Microsoft.AspNetCore.Razor.Language
         public abstract IDictionary<string, string> Metadata { get; }
 
         public abstract RazorDiagnosticCollection Diagnostics { get; }
-
-        public virtual IReadOnlyList<BoundAttributeParameterDescriptorBuilder> BoundAttributeParameters { get; }
-
-        public virtual void BindAttributeParameter(Action<BoundAttributeParameterDescriptorBuilder> configure)
-        {
-        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/BoundAttributeParameterDescriptorComparer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/BoundAttributeParameterDescriptorComparer.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class BoundAttributeParameterDescriptorComparer : IEqualityComparer<BoundAttributeParameterDescriptor>
+    {
+        /// <summary>
+        /// A default instance of the <see cref="BoundAttributeParameterDescriptorComparer"/>.
+        /// </summary>
+        public static readonly BoundAttributeParameterDescriptorComparer Default = new BoundAttributeParameterDescriptorComparer();
+
+        /// <summary>
+        /// A default instance of the <see cref="BoundAttributeParameterDescriptorComparer"/> that does case-sensitive comparison.
+        /// </summary>
+        internal static readonly BoundAttributeParameterDescriptorComparer CaseSensitive =
+            new BoundAttributeParameterDescriptorComparer(caseSensitive: true);
+
+        private readonly StringComparer _stringComparer;
+        private readonly StringComparison _stringComparison;
+
+        private BoundAttributeParameterDescriptorComparer(bool caseSensitive = false)
+        {
+            if (caseSensitive)
+            {
+                _stringComparer = StringComparer.Ordinal;
+                _stringComparison = StringComparison.Ordinal;
+            }
+            else
+            {
+                _stringComparer = StringComparer.OrdinalIgnoreCase;
+                _stringComparison = StringComparison.OrdinalIgnoreCase;
+            }
+        }
+
+        public virtual bool Equals(BoundAttributeParameterDescriptor descriptorX, BoundAttributeParameterDescriptor descriptorY)
+        {
+            if (object.ReferenceEquals(descriptorX, descriptorY))
+            {
+                return true;
+            }
+
+            if (descriptorX == null ^ descriptorY == null)
+            {
+                return false;
+            }
+
+            return
+                string.Equals(descriptorX.Kind, descriptorY.Kind, StringComparison.Ordinal) &&
+                descriptorX.IsEnum == descriptorY.IsEnum &&
+                string.Equals(descriptorX.Name, descriptorY.Name, _stringComparison) &&
+                string.Equals(descriptorX.TypeName, descriptorY.TypeName, StringComparison.Ordinal) &&
+                string.Equals(descriptorX.Documentation, descriptorY.Documentation, StringComparison.Ordinal) &&
+                string.Equals(descriptorX.DisplayName, descriptorY.DisplayName, StringComparison.Ordinal) &&
+                Enumerable.SequenceEqual(
+                    descriptorX.Metadata.OrderBy(propertyX => propertyX.Key, StringComparer.Ordinal),
+                    descriptorY.Metadata.OrderBy(propertyY => propertyY.Key, StringComparer.Ordinal));
+        }
+
+        public virtual int GetHashCode(BoundAttributeParameterDescriptor descriptor)
+        {
+            if (descriptor == null)
+            {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+
+            var hash = HashCodeCombiner.Start();
+            hash.Add(descriptor.Kind);
+            hash.Add(descriptor.Name, _stringComparer);
+
+            return hash.CombinedHash;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/ComponentResources.resx
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/ComponentResources.resx
@@ -124,7 +124,7 @@
     <value>Binds the provided expression to the '{0}' attribute and a change event delegate to the '{1}' attribute.</value>
   </data>
   <data name="BindTagHelper_Element_Event_Documentation" xml:space="preserve">
-    <value>Specifies the attribute to which to assign the change event for the value provided by the '{0}' attribute.</value>
+    <value>Specifies the event handler name to attach for change notifications for the value provided by the '{0}' attribute.</value>
   </data>
   <data name="BindTagHelper_Element_Format_Documentation" xml:space="preserve">
     <value>Specifies a format to convert the value specified by the '{0}' attribute. The format string can currently only be used with expressions of type &lt;code&gt;DateTime&lt;/code&gt;.</value>
@@ -133,7 +133,7 @@
     <value>Binds the provided expression to an attribute and a change event, based on the naming of the bind attribute. For example: &lt;code&gt;bind-value="..."&lt;/code&gt; and &lt;code&gt;bind-value:event="onchange"&lt;/code&gt; will assign the current value of the expression to the 'value' attribute, and assign a delegate that attempts to set the value to the 'onchange' attribute.</value>
   </data>
   <data name="BindTagHelper_Fallback_Event_Documentation" xml:space="preserve">
-    <value>Specifies the attribute to which to assign the change event for the value provided by the '{0}' attribute.</value>
+    <value>Specifies the event handler name to attach for change notifications for the value provided by the '{0}' attribute.</value>
   </data>
   <data name="BindTagHelper_Fallback_Format_Documentation" xml:space="preserve">
     <value>Specifies a format to convert the value specified by the corresponding bind attribute. For example: &lt;code&gt;bind-value:format="..."&lt;/code&gt; will apply a format string to the value specified in &lt;code&gt;bind-value="..."&lt;/code&gt;. The format string can currently only be used with expressions of type &lt;code&gt;DateTime&lt;/code&gt;.</value>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/ComponentResources.resx
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/ComponentResources.resx
@@ -123,14 +123,20 @@
   <data name="BindTagHelper_Element_Documentation" xml:space="preserve">
     <value>Binds the provided expression to the '{0}' attribute and a change event delegate to the '{1}' attribute.</value>
   </data>
+  <data name="BindTagHelper_Element_Event_Documentation" xml:space="preserve">
+    <value>Specifies the attribute to which to assign the change event for the value provided by the '{0}' attribute.</value>
+  </data>
   <data name="BindTagHelper_Element_Format_Documentation" xml:space="preserve">
     <value>Specifies a format to convert the value specified by the '{0}' attribute. The format string can currently only be used with expressions of type &lt;code&gt;DateTime&lt;/code&gt;.</value>
   </data>
   <data name="BindTagHelper_Fallback_Documentation" xml:space="preserve">
-    <value>Binds the provided expression to an attribute and a change event, based on the naming of the bind attribute. For example: &lt;code&gt;bind-value-onchange="..."&lt;/code&gt; will assign the current value of the expression to the 'value' attribute, and assign a delegate that attempts to set the value to the 'onchange' attribute.</value>
+    <value>Binds the provided expression to an attribute and a change event, based on the naming of the bind attribute. For example: &lt;code&gt;bind-value="..."&lt;/code&gt; and &lt;code&gt;bind-value:event="onchange"&lt;/code&gt; will assign the current value of the expression to the 'value' attribute, and assign a delegate that attempts to set the value to the 'onchange' attribute.</value>
+  </data>
+  <data name="BindTagHelper_Fallback_Event_Documentation" xml:space="preserve">
+    <value>Specifies the attribute to which to assign the change event for the value provided by the '{0}' attribute.</value>
   </data>
   <data name="BindTagHelper_Fallback_Format_Documentation" xml:space="preserve">
-    <value>Specifies a format to convert the value specified by the corresponding bind attribute. For example: &lt;code&gt;format-value="..."&lt;/code&gt; will apply a format string to the value specified in &lt;code&gt;bind-value-...&lt;/code&gt;. The format string can currently only be used with expressions of type &lt;code&gt;DateTime&lt;/code&gt;.</value>
+    <value>Specifies a format to convert the value specified by the corresponding bind attribute. For example: &lt;code&gt;bind-value:format="..."&lt;/code&gt; will apply a format string to the value specified in &lt;code&gt;bind-value="..."&lt;/code&gt;. The format string can currently only be used with expressions of type &lt;code&gt;DateTime&lt;/code&gt;.</value>
   </data>
   <data name="ChildContentParameterName_Documentation" xml:space="preserve">
     <value>Specifies the parameter name for the '{0}' child content expression.</value>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentBindLoweringPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentBindLoweringPass.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
                 if (node.TagHelper.IsBindTagHelper() && node.AttributeName.StartsWith("bind") && node.IsParameterMatch)
                 {
                     var originalAttributeName = node.AttributeName.Split(':')[0];
-                    if (!bindEntries.ContainsKey(originalAttributeName))
+                    if (!bindEntries.TryGetValue(originalAttributeName, out var entry))
                     {
                         // There is no corresponding bind node. Add a diagnostic and move on.
                         reference.Parent.Diagnostics.Add(ComponentDiagnosticFactory.CreateBindAttributeParameter_MissingBind(
@@ -85,15 +85,16 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
                     }
                     else if (node.BoundAttributeParameter.Name == "event")
                     {
-                        bindEntries[originalAttributeName].BindEventNode = node;
+                        entry.BindEventNode = node;
                     }
                     else if (node.BoundAttributeParameter.Name == "format")
                     {
-                        bindEntries[originalAttributeName].BindFormatNode = node;
+                        entry.BindFormatNode = node;
                     }
                     else
                     {
-                        // Unsupported bind attribute parameter.
+                        // Unsupported bind attribute parameter. This can only happen if bound attribute descriptor
+                        // is configured to expect a parameter other than 'event' and 'format'.
                     }
 
                     // We've extracted what we need from the parameterized bind node. Remove it.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentDiagnosticFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentDiagnosticFactory.cs
@@ -332,5 +332,34 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         {
             return RazorDiagnostic.Create(UnsupportedComponentImportContent, source ?? SourceSpan.Undefined);
         }
+
+        public static readonly RazorDiagnosticDescriptor BindAttributeParameter_MissingBind =
+            new RazorDiagnosticDescriptor(
+            $"{DiagnosticPrefix}10004",
+            () => "Could not find the non-parameterized bind attribute that corresponds to the attribute '{0}'.",
+            RazorDiagnosticSeverity.Error);
+
+        public static RazorDiagnostic CreateBindAttributeParameter_MissingBind(SourceSpan? source, string attribute)
+        {
+            var diagnostic = RazorDiagnostic.Create(
+                BindAttributeParameter_MissingBind,
+                source ?? SourceSpan.Undefined,
+                attribute);
+            return diagnostic;
+        }
+
+        public static readonly RazorDiagnosticDescriptor BindAttribute_UnsupportedFormat =
+            new RazorDiagnosticDescriptor(
+            $"{DiagnosticPrefix}10005",
+            () => "Specifying event handlers in bind attributes are no longer supported. Specify it using the bind:event=... attribute.",
+            RazorDiagnosticSeverity.Warning);
+
+        public static RazorDiagnostic CreateBindAttribute_UnsupportedFormat(SourceSpan? source)
+        {
+            var diagnostic = RazorDiagnostic.Create(
+                BindAttribute_UnsupportedFormat,
+                source ?? SourceSpan.Undefined);
+            return diagnostic;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentDiagnosticFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentDiagnosticFactory.cs
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             new RazorDiagnosticDescriptor(
             $"{DiagnosticPrefix}9991",
             () => "The attribute names could not be inferred from bind attribute '{0}'. Bind attributes should be of the form" +
-                "'bind', 'bind-value' or 'bind-value-change'",
+                "'bind' or 'bind-value' along with their corresponding optional parameters like 'bind-value:event', 'bind:format' etc.",
             RazorDiagnosticSeverity.Error);
 
         public static RazorDiagnostic CreateBindAttribute_InvalidSyntax(SourceSpan? source, string attribute)
@@ -351,13 +351,27 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         public static readonly RazorDiagnosticDescriptor BindAttribute_UnsupportedFormat =
             new RazorDiagnosticDescriptor(
             $"{DiagnosticPrefix}10005",
-            () => "Specifying event handlers in bind attributes are no longer supported. Specify it using the bind:event=... attribute.",
+            () => "Specifying event handlers in bind attributes are no longer supported. Specify it using the bind:event=... attribute instead.",
             RazorDiagnosticSeverity.Warning);
 
         public static RazorDiagnostic CreateBindAttribute_UnsupportedFormat(SourceSpan? source)
         {
             var diagnostic = RazorDiagnostic.Create(
                 BindAttribute_UnsupportedFormat,
+                source ?? SourceSpan.Undefined);
+            return diagnostic;
+        }
+
+        public static readonly RazorDiagnosticDescriptor BindAttribute_FormatNode_Unsupported =
+            new RazorDiagnosticDescriptor(
+            $"{DiagnosticPrefix}10005",
+            () => "Specifying format using 'format-...' attributes are no longer supported. Specify it using the 'bind-...:format=...' attribute instead.",
+            RazorDiagnosticSeverity.Warning);
+
+        public static RazorDiagnostic CreateBindAttribute_FormatNode_Unsupported(SourceSpan? source)
+        {
+            var diagnostic = RazorDiagnostic.Create(
+                BindAttribute_FormatNode_Unsupported,
                 source ?? SourceSpan.Undefined);
             return diagnostic;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultBoundAttributeDescriptorBuilder.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultBoundAttributeDescriptorBuilder.cs
@@ -31,6 +31,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         private readonly DefaultTagHelperDescriptorBuilder _parent;
         private readonly string _kind;
         private readonly Dictionary<string, string> _metadata;
+        private List<DefaultBoundAttributeParameterDescriptorBuilder> _attributeParameterBuilders;
 
         private RazorDiagnosticCollection _diagnostics;
 
@@ -73,6 +74,20 @@ namespace Microsoft.AspNetCore.Razor.Language
             }
         }
 
+        public override void BindAttributeParameter(Action<BoundAttributeParameterDescriptorBuilder> configure)
+        {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            EnsureAttributeParameterBuilders();
+
+            var builder = new DefaultBoundAttributeParameterDescriptorBuilder(this, _kind);
+            configure(builder);
+            _attributeParameterBuilders.Add(builder);
+        }
+
         public BoundAttributeDescriptor Build()
         {
             var validationDiagnostics = Validate();
@@ -80,6 +95,18 @@ namespace Microsoft.AspNetCore.Razor.Language
             if (_diagnostics != null)
             {
                 diagnostics.UnionWith(_diagnostics);
+            }
+
+            var parameters = Array.Empty<BoundAttributeParameterDescriptor>();
+            if (_attributeParameterBuilders != null)
+            {
+                var parameterset = new HashSet<BoundAttributeParameterDescriptor>(BoundAttributeParameterDescriptorComparer.Default);
+                for (var i = 0; i < _attributeParameterBuilders.Count; i++)
+                {
+                    parameterset.Add(_attributeParameterBuilders[i].Build());
+                }
+
+                parameters = parameterset.ToArray();
             }
 
             var descriptor = new DefaultBoundAttributeDescriptor(
@@ -92,6 +119,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 IndexerValueTypeName,
                 Documentation,
                 GetDisplayName(),
+                parameters,
                 new Dictionary<string, string>(Metadata),
                 diagnostics.ToArray());
 
@@ -203,6 +231,14 @@ namespace Microsoft.AspNetCore.Razor.Language
                         }
                     }
                 }
+            }
+        }
+
+        private void EnsureAttributeParameterBuilders()
+        {
+            if (_attributeParameterBuilders == null)
+            {
+                _attributeParameterBuilders = new List<DefaultBoundAttributeParameterDescriptorBuilder>();
             }
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultBoundAttributeDescriptorBuilder.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultBoundAttributeDescriptorBuilder.cs
@@ -100,7 +100,8 @@ namespace Microsoft.AspNetCore.Razor.Language
             var parameters = Array.Empty<BoundAttributeParameterDescriptor>();
             if (_attributeParameterBuilders != null)
             {
-                var parameterset = new HashSet<BoundAttributeParameterDescriptor>(BoundAttributeParameterDescriptorComparer.Default);
+                // Attribute parameters are case-sensitive.
+                var parameterset = new HashSet<BoundAttributeParameterDescriptor>(BoundAttributeParameterDescriptorComparer.CaseSensitive);
                 for (var i = 0; i < _attributeParameterBuilders.Count; i++)
                 {
                     parameterset.Add(_attributeParameterBuilders[i].Build());

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultBoundAttributeParameterDescriptor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultBoundAttributeParameterDescriptor.cs
@@ -1,44 +1,33 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    internal class DefaultBoundAttributeDescriptor : BoundAttributeDescriptor
+    internal class DefaultBoundAttributeParameterDescriptor : BoundAttributeParameterDescriptor
     {
-        public DefaultBoundAttributeDescriptor(
+        public DefaultBoundAttributeParameterDescriptor(
             string kind,
             string name,
             string typeName,
             bool isEnum,
-            bool hasIndexer,
-            string indexerNamePrefix,
-            string indexerTypeName,
             string documentation,
             string displayName,
-            BoundAttributeParameterDescriptor[] parameterDescriptors,
             Dictionary<string, string> metadata,
-            RazorDiagnostic[] diagnostics) 
+            RazorDiagnostic[] diagnostics)
             : base(kind)
         {
             Name = name;
             TypeName = typeName;
             IsEnum = isEnum;
-            HasIndexer = hasIndexer;
-            IndexerNamePrefix = indexerNamePrefix;
-            IndexerTypeName = indexerTypeName;
             Documentation = documentation;
             DisplayName = displayName;
-            BoundAttributeParameters = parameterDescriptors;
 
             Metadata = metadata;
             Diagnostics = diagnostics;
 
-            IsIndexerStringProperty = indexerTypeName == typeof(string).FullName || indexerTypeName == "string";
             IsStringProperty = typeName == typeof(string).FullName || typeName == "string";
-
-            IsIndexerBooleanProperty = indexerTypeName == typeof(bool).FullName || indexerTypeName == "bool";
             IsBooleanProperty = typeName == typeof(bool).FullName || typeName == "bool";
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultBoundAttributeParameterDescriptorBuilder.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultBoundAttributeParameterDescriptorBuilder.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 return DisplayName;
             }
 
-            return $"{_parent.DisplayName}:{Name}";
+            return $":{Name}";
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultBoundAttributeParameterDescriptorBuilder.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultBoundAttributeParameterDescriptorBuilder.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultBoundAttributeParameterDescriptorBuilder : BoundAttributeParameterDescriptorBuilder
+    {
+        private readonly DefaultBoundAttributeDescriptorBuilder _parent;
+        private readonly string _kind;
+        private readonly Dictionary<string, string> _metadata;
+
+        private RazorDiagnosticCollection _diagnostics;
+
+        public DefaultBoundAttributeParameterDescriptorBuilder(DefaultBoundAttributeDescriptorBuilder parent, string kind)
+        {
+            _parent = parent;
+            _kind = kind;
+
+            _metadata = new Dictionary<string, string>();
+        }
+
+        public override string Name { get; set; }
+
+        public override string TypeName { get; set; }
+
+        public override bool IsEnum { get; set; }
+
+        public override string Documentation { get; set; }
+
+        public override string DisplayName { get; set; }
+
+        public override IDictionary<string, string> Metadata => _metadata;
+
+        public override RazorDiagnosticCollection Diagnostics
+        {
+            get
+            {
+                if (_diagnostics == null)
+                {
+                    _diagnostics = new RazorDiagnosticCollection();
+                }
+
+                return _diagnostics;
+            }
+        }
+
+        public BoundAttributeParameterDescriptor Build()
+        {
+            var diagnostics = Array.Empty<RazorDiagnostic>();
+            var descriptor = new DefaultBoundAttributeParameterDescriptor(
+                _kind,
+                Name,
+                TypeName,
+                IsEnum,
+                Documentation,
+                GetDisplayName(),
+                new Dictionary<string, string>(Metadata),
+                diagnostics);
+
+            return descriptor;
+        }
+
+        private string GetDisplayName()
+        {
+            if (DisplayName != null)
+            {
+                return DisplayName;
+            }
+
+            return $"{_parent.DisplayName}:{Name}";
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -1728,14 +1728,21 @@ namespace Microsoft.AspNetCore.Razor.Language
                             return TagHelperMatchingConventions.CanSatisfyBoundAttribute(attributeName, a);
                         });
 
+                        var associatedAttributeParameterDescriptor = associatedAttributeDescriptor.BoundAttributeParameters.FirstOrDefault(p =>
+                        {
+                            return TagHelperMatchingConventions.SatisfiesBoundAttributeParameter(attributeName, associatedAttributeDescriptor, p);
+                        });
+
                         var setTagHelperProperty = new TagHelperPropertyIntermediateNode()
                         {
                             AttributeName = attributeName,
                             BoundAttribute = associatedAttributeDescriptor,
+                            BoundAttributeParameter = associatedAttributeParameterDescriptor,
                             TagHelper = associatedDescriptor,
                             AttributeStructure = node.TagHelperAttributeInfo.AttributeStructure,
                             Source = BuildSourceSpanFromNode(attributeValueNode),
                             IsIndexerNameMatch = TagHelperMatchingConventions.SatisfiesBoundAttributeIndexer(attributeName, associatedAttributeDescriptor),
+                            IsParameterMatch = associatedAttributeParameterDescriptor != null,
                         };
 
                         _builder.Push(setTagHelperProperty);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -1730,7 +1730,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
                         var associatedAttributeParameterDescriptor = associatedAttributeDescriptor.BoundAttributeParameters.FirstOrDefault(p =>
                         {
-                            return TagHelperMatchingConventions.SatisfiesBoundAttributeParameter(attributeName, associatedAttributeDescriptor, p);
+                            return TagHelperMatchingConventions.SatisfiesBoundAttributeWithParameter(attributeName, associatedAttributeDescriptor, p);
                         });
 
                         var setTagHelperProperty = new TagHelperPropertyIntermediateNode()

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -1742,7 +1742,6 @@ namespace Microsoft.AspNetCore.Razor.Language
                             AttributeStructure = node.TagHelperAttributeInfo.AttributeStructure,
                             Source = BuildSourceSpanFromNode(attributeValueNode),
                             IsIndexerNameMatch = TagHelperMatchingConventions.SatisfiesBoundAttributeIndexer(attributeName, associatedAttributeDescriptor),
-                            IsParameterMatch = associatedAttributeParameterDescriptor != null,
                         };
 
                         _builder.Push(setTagHelperProperty);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -1716,6 +1716,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 var descriptors = element.TagHelperInfo.BindingResult.Descriptors;
                 var attributeName = node.Name.GetContent();
                 var attributeValueNode = node.Value;
+
                 var associatedDescriptors = descriptors.Where(descriptor =>
                     descriptor.BoundAttributes.Any(attributeDescriptor => TagHelperMatchingConventions.CanSatisfyBoundAttribute(attributeName, attributeDescriptor)));
 
@@ -1723,30 +1724,47 @@ namespace Microsoft.AspNetCore.Razor.Language
                 {
                     foreach (var associatedDescriptor in associatedDescriptors)
                     {
-                        var associatedAttributeDescriptor = associatedDescriptor.BoundAttributes.First(a =>
+                        if (TagHelperMatchingConventions.TryGetFirstBoundAttributeMatch(
+                            attributeName,
+                            associatedDescriptor,
+                            out var associatedAttributeDescriptor,
+                            out var indexerMatch,
+                            out var parameterMatch,
+                            out var associatedAttributeParameterDescriptor))
                         {
-                            return TagHelperMatchingConventions.CanSatisfyBoundAttribute(attributeName, a);
-                        });
+                            IntermediateNode attributeNode;
+                            if (parameterMatch &&
+                                TagHelperMatchingConventions.TryGetBoundAttributeParameter(attributeName, out var attributeNameWithoutParameter, out var _))
+                            {
+                                attributeNode = new TagHelperAttributeParameterIntermediateNode()
+                                {
+                                    AttributeName = attributeName,
+                                    AttributeNameWithoutParameter = attributeNameWithoutParameter,
+                                    BoundAttributeParameter = associatedAttributeParameterDescriptor,
+                                    BoundAttribute = associatedAttributeDescriptor,
+                                    TagHelper = associatedDescriptor,
+                                    IsIndexerNameMatch = indexerMatch,
+                                    AttributeStructure = node.TagHelperAttributeInfo.AttributeStructure,
+                                    Source = BuildSourceSpanFromNode(attributeValueNode),
+                                };
+                            }
+                            else
+                            {
+                                attributeNode = new TagHelperPropertyIntermediateNode()
+                                {
+                                    AttributeName = attributeName,
+                                    BoundAttribute = associatedAttributeDescriptor,
+                                    TagHelper = associatedDescriptor,
+                                    AttributeStructure = node.TagHelperAttributeInfo.AttributeStructure,
+                                    Source = BuildSourceSpanFromNode(attributeValueNode),
+                                    IsIndexerNameMatch = indexerMatch,
+                                };
+                            }
 
-                        var associatedAttributeParameterDescriptor = associatedAttributeDescriptor.BoundAttributeParameters.FirstOrDefault(p =>
-                        {
-                            return TagHelperMatchingConventions.SatisfiesBoundAttributeWithParameter(attributeName, associatedAttributeDescriptor, p);
-                        });
-
-                        var setTagHelperProperty = new TagHelperPropertyIntermediateNode()
-                        {
-                            AttributeName = attributeName,
-                            BoundAttribute = associatedAttributeDescriptor,
-                            BoundAttributeParameter = associatedAttributeParameterDescriptor,
-                            TagHelper = associatedDescriptor,
-                            AttributeStructure = node.TagHelperAttributeInfo.AttributeStructure,
-                            Source = BuildSourceSpanFromNode(attributeValueNode),
-                            IsIndexerNameMatch = TagHelperMatchingConventions.SatisfiesBoundAttributeIndexer(attributeName, associatedAttributeDescriptor),
-                        };
-
-                        _builder.Push(setTagHelperProperty);
-                        VisitAttributeValue(attributeValueNode);
-                        _builder.Pop();
+                            _builder.Push(attributeNode);
+                            VisitAttributeValue(attributeValueNode);
+                            _builder.Pop();
+                        }
                     }
                 }
                 else

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Intermediate/IntermediateNodeVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Intermediate/IntermediateNodeVisitor.cs
@@ -129,6 +129,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
             VisitDefault(node);
         }
 
+        public virtual void VisitTagHelperAttributeParameter(TagHelperAttributeParameterIntermediateNode node)
+        {
+            VisitDefault(node);
+        }
+
         public virtual void VisitComponent(ComponentIntermediateNode node)
         {
             VisitDefault(node);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Intermediate/TagHelperAttributeParameterIntermediateNode.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Intermediate/TagHelperAttributeParameterIntermediateNode.cs
@@ -1,17 +1,21 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 
 namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 {
-    public sealed class TagHelperPropertyIntermediateNode : IntermediateNode
+    public sealed class TagHelperAttributeParameterIntermediateNode : IntermediateNode
     {
         public override IntermediateNodeCollection Children { get; } = new IntermediateNodeCollection();
 
         public string AttributeName { get; set; }
 
+        public string AttributeNameWithoutParameter { get; set; }
+
         public AttributeStructure AttributeStructure { get; set; }
+
+        public BoundAttributeParameterDescriptor BoundAttributeParameter { get; set; }
 
         public BoundAttributeDescriptor BoundAttribute { get; set; }
 
@@ -26,7 +30,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
                 throw new ArgumentNullException(nameof(visitor));
             }
 
-            visitor.VisitTagHelperProperty(this);
+            visitor.VisitTagHelperAttributeParameter(this);
         }
 
         public override void FormatNode(IntermediateNodeFormatter formatter)
@@ -36,7 +40,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
             formatter.WriteProperty(nameof(AttributeName), AttributeName);
             formatter.WriteProperty(nameof(AttributeStructure), AttributeStructure.ToString());
             formatter.WriteProperty(nameof(BoundAttribute), BoundAttribute?.DisplayName);
-            formatter.WriteProperty(nameof(IsIndexerNameMatch), IsIndexerNameMatch.ToString());
+            formatter.WriteProperty(nameof(BoundAttributeParameter), BoundAttributeParameter?.DisplayName);
             formatter.WriteProperty(nameof(TagHelper), TagHelper?.DisplayName);
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Intermediate/TagHelperPropertyIntermediateNode.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Intermediate/TagHelperPropertyIntermediateNode.cs
@@ -19,6 +19,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
         public bool IsIndexerNameMatch { get; set; }
 
+        public bool IsParameterMatch { get; set; }
+
+        public BoundAttributeParameterDescriptor BoundAttributeParameter { get; set; }
+
         public override void Accept(IntermediateNodeVisitor visitor)
         {
             if (visitor == null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Intermediate/TagHelperPropertyIntermediateNode.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Intermediate/TagHelperPropertyIntermediateNode.cs
@@ -19,9 +19,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
         public bool IsIndexerNameMatch { get; set; }
 
-        public bool IsParameterMatch { get; set; }
-
         public BoundAttributeParameterDescriptor BoundAttributeParameter { get; set; }
+
+        public bool IsParameterMatch => BoundAttributeParameter != null;
 
         public override void Accept(IntermediateNodeVisitor visitor)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperBlockRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperBlockRewriter.cs
@@ -296,7 +296,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             var isBoundAttribute = firstBoundAttribute != null;
             var boundAttributeParameter = firstBoundAttribute?.BoundAttributeParameters.FirstOrDefault(p =>
             {
-                return TagHelperMatchingConventions.SatisfiesBoundAttributeParameter(name, firstBoundAttribute, p);
+                return TagHelperMatchingConventions.SatisfiesBoundAttributeWithParameter(name, firstBoundAttribute, p);
             });
             var isBoundNonStringAttribute = false;
             var isBoundBooleanAttribute = false;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperBlockRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperBlockRewriter.cs
@@ -273,17 +273,22 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         // Determines the full name of the Type of the property corresponding to an attribute with the given name.
         private static string GetPropertyType(string name, IEnumerable<TagHelperDescriptor> descriptors)
         {
-            var firstBoundAttribute = FindFirstBoundAttribute(name, descriptors);
-            var isBoundToIndexer = TagHelperMatchingConventions.SatisfiesBoundAttributeIndexer(name, firstBoundAttribute);
+            foreach (var descriptor in descriptors)
+            {
+                if (TagHelperMatchingConventions.TryGetFirstBoundAttributeMatch(name, descriptor, out var firstBoundAttribute, out var indexerMatch, out var _, out var _))
+                {
+                    if (indexerMatch)
+                    {
+                        return firstBoundAttribute.IndexerTypeName;
+                    }
+                    else
+                    {
+                        return firstBoundAttribute.TypeName;
+                    }
+                }
+            }
 
-            if (isBoundToIndexer)
-            {
-                return firstBoundAttribute?.IndexerTypeName;
-            }
-            else
-            {
-                return firstBoundAttribute?.TypeName;
-            }
+            return null;
         }
 
         // Create a TryParseResult for given name, filling in binding details.
@@ -292,30 +297,37 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             IEnumerable<TagHelperDescriptor> descriptors,
             HashSet<string> processedBoundAttributeNames)
         {
-            var firstBoundAttribute = FindFirstBoundAttribute(name, descriptors);
-            var isBoundAttribute = firstBoundAttribute != null;
-            var boundAttributeParameter = firstBoundAttribute?.BoundAttributeParameters.FirstOrDefault(p =>
-            {
-                return TagHelperMatchingConventions.SatisfiesBoundAttributeWithParameter(name, firstBoundAttribute, p);
-            });
+            var isBoundAttribute = false;
             var isBoundNonStringAttribute = false;
             var isBoundBooleanAttribute = false;
             var isMissingDictionaryKey = false;
 
-            if (isBoundAttribute)
+            foreach (var descriptor in descriptors)
             {
-                if (boundAttributeParameter != null)
+                if (TagHelperMatchingConventions.TryGetFirstBoundAttributeMatch(
+                    name,
+                    descriptor,
+                    out var firstBoundAttribute,
+                    out var indexerMatch,
+                    out var parameterMatch,
+                    out var boundAttributeParameter))
                 {
-                    isBoundNonStringAttribute = !boundAttributeParameter.IsStringProperty;
-                    isBoundBooleanAttribute = boundAttributeParameter.IsBooleanProperty;
-                    isMissingDictionaryKey = false;
-                }
-                else
-                {
-                    isBoundNonStringAttribute = !firstBoundAttribute.ExpectsStringValue(name);
-                    isBoundBooleanAttribute = firstBoundAttribute.ExpectsBooleanValue(name);
-                    isMissingDictionaryKey = firstBoundAttribute.IndexerNamePrefix != null &&
-                        name.Length == firstBoundAttribute.IndexerNamePrefix.Length;
+                    isBoundAttribute = true;
+                    if (parameterMatch)
+                    {
+                        isBoundNonStringAttribute = !boundAttributeParameter.IsStringProperty;
+                        isBoundBooleanAttribute = boundAttributeParameter.IsBooleanProperty;
+                        isMissingDictionaryKey = false;
+                    }
+                    else
+                    {
+                        isBoundNonStringAttribute = !firstBoundAttribute.ExpectsStringValue(name);
+                        isBoundBooleanAttribute = firstBoundAttribute.ExpectsBooleanValue(name);
+                        isMissingDictionaryKey = firstBoundAttribute.IndexerNamePrefix != null &&
+                            name.Length == firstBoundAttribute.IndexerNamePrefix.Length;
+                    }
+
+                    break;
                 }
             }
 
@@ -335,18 +347,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 IsMissingDictionaryKey = isMissingDictionaryKey,
                 IsDuplicateAttribute = isDuplicateAttribute
             };
-        }
-
-        // Finds first TagHelperAttributeDescriptor matching given name.
-        private static BoundAttributeDescriptor FindFirstBoundAttribute(
-            string name,
-            IEnumerable<TagHelperDescriptor> descriptors)
-        {
-            var firstBoundAttribute = descriptors
-                .SelectMany(descriptor => descriptor.BoundAttributes)
-                .FirstOrDefault(attributeDescriptor => TagHelperMatchingConventions.CanSatisfyBoundAttribute(name, attributeDescriptor));
-
-            return firstBoundAttribute;
         }
 
         private static string GetAttributeValueContent(RazorSyntaxNode attributeBlock)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/RazorDiagnosticFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/RazorDiagnosticFactory.cs
@@ -779,6 +779,41 @@ namespace Microsoft.AspNetCore.Razor.Language
             return diagnostic;
         }
 
+        internal static readonly RazorDiagnosticDescriptor TagHelper_InvalidBoundAttributeParameterNullOrWhitespace =
+            new RazorDiagnosticDescriptor(
+                $"{DiagnosticPrefix}3013",
+                () => Resources.TagHelper_InvalidBoundAttributeParameterNullOrWhitespace,
+                RazorDiagnosticSeverity.Error);
+        public static RazorDiagnostic CreateTagHelper_InvalidBoundAttributeParameterNullOrWhitespace(string attributeName)
+        {
+            var diagnostic = RazorDiagnostic.Create(
+                TagHelper_InvalidBoundAttributeParameterNullOrWhitespace,
+                new SourceSpan(SourceLocation.Undefined, contentLength: 0),
+                attributeName);
+
+            return diagnostic;
+        }
+
+        internal static readonly RazorDiagnosticDescriptor TagHelper_InvalidBoundAttributeParameterName =
+            new RazorDiagnosticDescriptor(
+                $"{DiagnosticPrefix}3014",
+                () => Resources.TagHelper_InvalidBoundAttributeParameterName,
+                RazorDiagnosticSeverity.Error);
+        public static RazorDiagnostic CreateTagHelper_InvalidBoundAttributeParameterName(
+            string attributeName,
+            string invalidName,
+            char invalidCharacter)
+        {
+            var diagnostic = RazorDiagnostic.Create(
+                TagHelper_InvalidBoundAttributeParameterName,
+                new SourceSpan(SourceLocation.Undefined, contentLength: 0),
+                attributeName,
+                invalidName,
+                invalidCharacter);
+
+            return diagnostic;
+        }
+
         #endregion
 
         #region Rewriter Errors

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/RazorDiagnosticSeverity.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/RazorDiagnosticSeverity.cs
@@ -6,6 +6,7 @@ namespace Microsoft.AspNetCore.Razor.Language
     public enum RazorDiagnosticSeverity
     {
         // Purposely using the same value as Roslyn here.
+        Warning = 2,
         Error = 3,
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
@@ -541,4 +541,10 @@
   <data name="NamespaceDirective_NamespaceToken_Name" xml:space="preserve">
     <value>Namespace</value>
   </data>
+  <data name="TagHelper_InvalidBoundAttributeParameterName" xml:space="preserve">
+    <value>Invalid tag helper bound attribute parameter '{1}' on bound attribute '{0}'. Tag helpers cannot bind to HTML attribute parameters with name '{1}' because the name contains a '{3}' character.</value>
+  </data>
+  <data name="TagHelper_InvalidBoundAttributeParameterNullOrWhitespace" xml:space="preserve">
+    <value>Invalid tag helper bound attribute parameter '{0}'. Tag helpers cannot bind to HTML attribute parameters with a null or empty name.</value>
+  </data>
 </root>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/TagHelperMatchingConventions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/TagHelperMatchingConventions.cs
@@ -128,7 +128,9 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public static bool CanSatisfyBoundAttribute(string name, BoundAttributeDescriptor descriptor)
         {
-            return SatisfiesBoundAttributeName(name, descriptor) || SatisfiesBoundAttributeIndexer(name, descriptor);
+            return SatisfiesBoundAttributeName(name, descriptor) ||
+                SatisfiesBoundAttributeIndexer(name, descriptor) ||
+                descriptor.BoundAttributeParameters.Any(p => SatisfiesBoundAttributeParameter(name, descriptor, p));
         }
 
         public static bool SatisfiesBoundAttributeIndexer(string name, BoundAttributeDescriptor descriptor)
@@ -136,6 +138,18 @@ namespace Microsoft.AspNetCore.Razor.Language
             return descriptor.IndexerNamePrefix != null &&
                 !SatisfiesBoundAttributeName(name, descriptor) &&
                 name.StartsWith(descriptor.IndexerNamePrefix, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool SatisfiesBoundAttributeParameter(string name, BoundAttributeDescriptor parent, BoundAttributeParameterDescriptor descriptor)
+        {
+            if (name != null && name.IndexOf(':') != -1)
+            {
+                var segments = name.Split(':');
+                return (SatisfiesBoundAttributeName(segments[0], parent) || SatisfiesBoundAttributeIndexer(segments[0], parent)) &&
+                    string.Equals(descriptor.Name, segments[1], StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
         }
 
         private static bool SatisfiesBoundAttributeName(string name, BoundAttributeDescriptor descriptor)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/TagHelperMatchingConventions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/TagHelperMatchingConventions.cs
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             return SatisfiesBoundAttributeName(name, descriptor) ||
                 SatisfiesBoundAttributeIndexer(name, descriptor) ||
-                descriptor.BoundAttributeParameters.Any(p => SatisfiesBoundAttributeParameter(name, descriptor, p));
+                descriptor.BoundAttributeParameters.Any(p => SatisfiesBoundAttributeWithParameter(name, descriptor, p));
         }
 
         public static bool SatisfiesBoundAttributeIndexer(string name, BoundAttributeDescriptor descriptor)
@@ -140,13 +140,15 @@ namespace Microsoft.AspNetCore.Razor.Language
                 name.StartsWith(descriptor.IndexerNamePrefix, StringComparison.OrdinalIgnoreCase);
         }
 
-        public static bool SatisfiesBoundAttributeParameter(string name, BoundAttributeDescriptor parent, BoundAttributeParameterDescriptor descriptor)
+        public static bool SatisfiesBoundAttributeWithParameter(string name, BoundAttributeDescriptor parent, BoundAttributeParameterDescriptor descriptor)
         {
             if (name != null && name.IndexOf(':') != -1)
             {
                 var segments = name.Split(':');
-                return (SatisfiesBoundAttributeName(segments[0], parent) || SatisfiesBoundAttributeIndexer(segments[0], parent)) &&
-                    string.Equals(descriptor.Name, segments[1], StringComparison.OrdinalIgnoreCase);
+                var satisfiesBoundAttributeName = SatisfiesBoundAttributeName(segments[0], parent);
+                var satisfiesBoundAttributeIndexer = SatisfiesBoundAttributeIndexer(segments[0], parent);
+                var matchesParameter = string.Equals(descriptor.Name, segments[1], StringComparison.OrdinalIgnoreCase);
+                return (satisfiesBoundAttributeName || satisfiesBoundAttributeIndexer) && matchesParameter;
             }
 
             return false;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/TagHelperMatchingConventions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/TagHelperMatchingConventions.cs
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             {
                 var satisfiesBoundAttributeName = SatisfiesBoundAttributeName(attributeName, parent);
                 var satisfiesBoundAttributeIndexer = SatisfiesBoundAttributeIndexer(attributeName, parent);
-                var matchesParameter = string.Equals(descriptor.Name, parameterName, StringComparison.OrdinalIgnoreCase);
+                var matchesParameter = string.Equals(descriptor.Name, parameterName, StringComparison.Ordinal);
                 return (satisfiesBoundAttributeName || satisfiesBoundAttributeIndexer) && matchesParameter;
             }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Razor
                 throw new ArgumentNullException(nameof(engine));
             }
 
-            var providers = engine.Engine.Features.OfType<ITagHelperDescriptorProvider>().ToArray();
+            var providers = engine.Engine.Features.OfType<ITagHelperDescriptorProvider>().OrderBy(f => f.Order).ToArray();
             if (providers.Length == 0)
             {
                 return TagHelperResolutionResult.Empty;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/BindTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/BindTagHelperDescriptorProvider.cs
@@ -150,6 +150,24 @@ namespace Microsoft.CodeAnalysis.Razor
                 // a C# property will crash trying to create the toolips.
                 attribute.SetPropertyName("Bind");
                 attribute.TypeName = "System.Collections.Generic.Dictionary<string, object>";
+
+                attribute.BindAttributeParameter(parameter =>
+                {
+                    parameter.Name = "format";
+                    parameter.TypeName = typeof(string).FullName;
+                    parameter.Documentation = ComponentResources.BindTagHelper_Fallback_Format_Documentation;
+
+                    parameter.SetPropertyName("Format");
+                });
+
+                attribute.BindAttributeParameter(parameter =>
+                {
+                    parameter.Name = "event";
+                    parameter.TypeName = typeof(string).FullName;
+                    parameter.Documentation = "Fallback Event documentation";
+
+                    parameter.SetPropertyName("Event");
+                });
             });
 
             builder.BindAttribute(attribute =>
@@ -237,6 +255,7 @@ namespace Microsoft.CodeAnalysis.Razor
 
             return results;
         }
+
         private List<TagHelperDescriptor> CreateElementBindTagHelpers(List<ElementBindData> data)
         {
             var results = new List<TagHelperDescriptor>();
@@ -250,6 +269,8 @@ namespace Microsoft.CodeAnalysis.Razor
 
                 var formatName = entry.Suffix == null ? "Format_" + entry.ValueAttribute : "Format_" + entry.Suffix;
                 var formatAttributeName = entry.Suffix == null ? "format-" + entry.ValueAttribute : "format-" + entry.Suffix;
+
+                var eventName = entry.Suffix == null ? "Event_" + entry.ValueAttribute : "Event_" + entry.Suffix;
 
                 var builder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Bind.TagHelperKind, name, ComponentsApi.AssemblyName);
                 builder.Documentation = string.Format(
@@ -315,6 +336,24 @@ namespace Microsoft.CodeAnalysis.Razor
                     // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
                     // a C# property will crash trying to create the toolips.
                     a.SetPropertyName(name);
+
+                    a.BindAttributeParameter(parameter =>
+                    {
+                        parameter.Name = "format";
+                        parameter.TypeName = typeof(string).FullName;
+                        parameter.Documentation = ComponentResources.BindTagHelper_Element_Format_Documentation;
+
+                        parameter.SetPropertyName(formatName);
+                    });
+
+                    a.BindAttributeParameter(parameter =>
+                    {
+                        parameter.Name = "event";
+                        parameter.TypeName = typeof(string).FullName;
+                        parameter.Documentation = "Element Event documentation";
+
+                        parameter.SetPropertyName(eventName);
+                    });
                 });
 
                 builder.BindAttribute(attribute =>
@@ -376,7 +415,6 @@ namespace Microsoft.CodeAnalysis.Razor
                         if (tagHelper.BoundAttributes[j].Name == valueAttributeName)
                         {
                             valueAttribute = tagHelper.BoundAttributes[j];
-                            
                         }
 
                         if (tagHelper.BoundAttributes[j].Name == expressionAttributeName)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/BindTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/BindTagHelperDescriptorProvider.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Razor
             //
             // We handle a few different cases here:
             //
-            //  1.  When given an attribute like **anywhere**'bind-value-onchange="@FirstName"' we will
+            //  1.  When given an attribute like **anywhere**'bind-value="@FirstName"' and 'bind-value:event="onchange"' we will
             //      generate the 'value' attribute and 'onchange' attribute. 
             //
             //      We don't do any transformation or inference for this case, because the developer has
@@ -143,7 +143,8 @@ namespace Microsoft.CodeAnalysis.Razor
             {
                 attribute.Documentation = ComponentResources.BindTagHelper_Fallback_Documentation;
 
-                attribute.Name = "bind-...";
+                var attributeName = "bind-...";
+                attribute.Name = attributeName;
                 attribute.AsDictionary("bind-", typeof(object).FullName);
 
                 // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
@@ -164,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Razor
                 {
                     parameter.Name = "event";
                     parameter.TypeName = typeof(string).FullName;
-                    parameter.Documentation = "Fallback Event documentation";
+                    parameter.Documentation = string.Format(ComponentResources.BindTagHelper_Fallback_Event_Documentation, attributeName);
 
                     parameter.SetPropertyName("Event");
                 });
@@ -341,7 +342,7 @@ namespace Microsoft.CodeAnalysis.Razor
                     {
                         parameter.Name = "format";
                         parameter.TypeName = typeof(string).FullName;
-                        parameter.Documentation = ComponentResources.BindTagHelper_Element_Format_Documentation;
+                        parameter.Documentation = string.Format(ComponentResources.BindTagHelper_Element_Format_Documentation, attributeName);
 
                         parameter.SetPropertyName(formatName);
                     });
@@ -350,7 +351,7 @@ namespace Microsoft.CodeAnalysis.Razor
                     {
                         parameter.Name = "event";
                         parameter.TypeName = typeof(string).FullName;
-                        parameter.Documentation = "Element Event documentation";
+                        parameter.Documentation = string.Format(ComponentResources.BindTagHelper_Element_Event_Documentation, attributeName);
 
                         parameter.SetPropertyName(eventName);
                     });
@@ -358,7 +359,7 @@ namespace Microsoft.CodeAnalysis.Razor
 
                 builder.BindAttribute(attribute =>
                 {
-                    attribute.Documentation = string.Format(ComponentResources.BindTagHelper_Element_Format_Documentation, attributeName);
+                    attribute.Documentation = 
 
                     attribute.Name = formatAttributeName;
                     attribute.TypeName = "System.String";

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/BindTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/BindTagHelperDescriptorProvider.cs
@@ -171,6 +171,7 @@ namespace Microsoft.CodeAnalysis.Razor
                 });
             });
 
+            // This is no longer supported. This is just here so we can add a diagnostic later on when this matches.
             builder.BindAttribute(attribute =>
             {
                 attribute.Documentation = ComponentResources.BindTagHelper_Fallback_Format_Documentation;
@@ -357,6 +358,7 @@ namespace Microsoft.CodeAnalysis.Razor
                     });
                 });
 
+                // This is no longer supported. This is just here so we can add a diagnostic later on when this matches.
                 builder.BindAttribute(attribute =>
                 {
                     attribute.Documentation = 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/BindTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/BindTagHelperDescriptorProvider.cs
@@ -361,10 +361,9 @@ namespace Microsoft.CodeAnalysis.Razor
                 // This is no longer supported. This is just here so we can add a diagnostic later on when this matches.
                 builder.BindAttribute(attribute =>
                 {
-                    attribute.Documentation = 
-
                     attribute.Name = formatAttributeName;
                     attribute.TypeName = "System.String";
+                    attribute.Documentation = string.Format(ComponentResources.BindTagHelper_Element_Format_Documentation, attributeName);
 
                     // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
                     // a C# property will crash trying to create the toolips.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/IntermediateNodeWriter.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/IntermediateNodeWriter.cs
@@ -128,6 +128,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             WriteContentNode(node, node.AttributeName, string.Format("HtmlAttributeValueStyle.{0}", node.AttributeStructure));
         }
 
+        public override void VisitTagHelperAttributeParameter(TagHelperAttributeParameterIntermediateNode node)
+        {
+            WriteContentNode(node, node.AttributeName, string.Format("HtmlAttributeValueStyle.{0}", node.AttributeStructure));
+        }
+
         public override void VisitComponent(ComponentIntermediateNode node)
         {
             WriteContentNode(node, node.TagName);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/BindTagHelperDescriptorProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/BindTagHelperDescriptorProviderTest.cs
@@ -395,33 +395,28 @@ namespace Test
             Assert.False(attribute.IsBooleanProperty);
             Assert.False(attribute.IsEnum);
 
-            attribute = Assert.Single(bind.BoundAttributes, a => a.Name.StartsWith("format"));
+            var parameter = Assert.Single(attribute.BoundAttributeParameters, a => a.Name.Equals("format"));
 
             // Invariants
-            Assert.Empty(attribute.Diagnostics);
-            Assert.False(attribute.HasErrors);
-            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, attribute.Kind);
-            Assert.False(attribute.IsDefaultKind());
-            Assert.False(attribute.HasIndexer);
-            Assert.Null(attribute.IndexerNamePrefix);
-            Assert.Null(attribute.IndexerTypeName);
-            Assert.False(attribute.IsIndexerBooleanProperty);
-            Assert.False(attribute.IsIndexerStringProperty);
+            Assert.Empty(parameter.Diagnostics);
+            Assert.False(parameter.HasErrors);
+            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Kind);
+            Assert.False(parameter.IsDefaultKind());
 
             Assert.Equal(
                 "Specifies a format to convert the value specified by the 'bind' attribute. " + 
                 "The format string can currently only be used with expressions of type <code>DateTime</code>.",
-                attribute.Documentation);
+                parameter.Documentation);
 
-            Assert.Equal("format-myprop", attribute.Name);
-            Assert.Equal("Format_myprop", attribute.GetPropertyName());
-            Assert.Equal("string Test.BindAttributes.Format_myprop", attribute.DisplayName);
+            Assert.Equal("format", parameter.Name);
+            Assert.Equal("Format_myprop", parameter.GetPropertyName());
+            Assert.Equal(":format", parameter.DisplayName);
 
             // Defined from the property type
-            Assert.Equal("System.String", attribute.TypeName);
-            Assert.True(attribute.IsStringProperty);
-            Assert.False(attribute.IsBooleanProperty);
-            Assert.False(attribute.IsEnum);
+            Assert.Equal("System.String", parameter.TypeName);
+            Assert.True(parameter.IsStringProperty);
+            Assert.False(parameter.IsBooleanProperty);
+            Assert.False(parameter.IsEnum);
         }
 
         [Fact]
@@ -529,10 +524,10 @@ namespace Test
             Assert.Equal("Bind", attribute.GetPropertyName());
             Assert.Equal("object Test.BindAttributes.Bind", attribute.DisplayName);
 
-            attribute = Assert.Single(bind.BoundAttributes, a => a.Name.StartsWith("format"));
-            Assert.Equal("format-myprop", attribute.Name);
-            Assert.Equal("Format_myprop", attribute.GetPropertyName());
-            Assert.Equal("string Test.BindAttributes.Format_myprop", attribute.DisplayName);
+            var parameter = Assert.Single(attribute.BoundAttributeParameters, a => a.Name.Equals("format"));
+            Assert.Equal("format", parameter.Name);
+            Assert.Equal("Format_myprop", parameter.GetPropertyName());
+            Assert.Equal(":format", parameter.DisplayName);
         }
 
         [Fact]
@@ -597,10 +592,10 @@ namespace Test
             Assert.Equal("Bind", attribute.GetPropertyName());
             Assert.Equal("object Test.BindAttributes.Bind", attribute.DisplayName);
 
-            attribute = Assert.Single(bind.BoundAttributes, a => a.Name.StartsWith("format"));
-            Assert.Equal("format-myprop", attribute.Name);
-            Assert.Equal("Format_myprop", attribute.GetPropertyName());
-            Assert.Equal("string Test.BindAttributes.Format_myprop", attribute.DisplayName);
+            var parameter = Assert.Single(attribute.BoundAttributeParameters, a => a.Name.Equals("format"));
+            Assert.Equal("format", parameter.Name);
+            Assert.Equal("Format_myprop", parameter.GetPropertyName());
+            Assert.Equal(":format", parameter.DisplayName);
         }
 
         [Fact]
@@ -665,10 +660,10 @@ namespace Test
             Assert.Equal("Bind_somevalue", attribute.GetPropertyName());
             Assert.Equal("object Test.BindAttributes.Bind_somevalue", attribute.DisplayName);
 
-            attribute = Assert.Single(bind.BoundAttributes, a => a.Name.StartsWith("format"));
-            Assert.Equal("format-somevalue", attribute.Name);
-            Assert.Equal("Format_somevalue", attribute.GetPropertyName());
-            Assert.Equal("string Test.BindAttributes.Format_somevalue", attribute.DisplayName);
+            var parameter = Assert.Single(attribute.BoundAttributeParameters, a => a.Name.Equals("format"));
+            Assert.Equal("format", parameter.Name);
+            Assert.Equal("Format_somevalue", parameter.GetPropertyName());
+            Assert.Equal(":format", parameter.DisplayName);
         }
 
         [Fact]
@@ -710,7 +705,7 @@ namespace Test
 
             Assert.Equal(
                 "Binds the provided expression to an attribute and a change event, based on the naming of " +
-                    "the bind attribute. For example: <code>bind-value-onchange=\"...\"</code> will assign the " +
+                    "the bind attribute. For example: <code>bind-value=\"...\"</code> and <code>bind-value:event=\"onchange\"</code> will assign the " +
                     "current value of the expression to the 'value' attribute, and assign a delegate that attempts " +
                     "to set the value to the 'onchange' attribute.",
                 bind.Documentation);
@@ -753,7 +748,7 @@ namespace Test
 
             Assert.Equal(
                 "Binds the provided expression to an attribute and a change event, based on the naming of " +
-                    "the bind attribute. For example: <code>bind-value-onchange=\"...\"</code> will assign the " +
+                    "the bind attribute. For example: <code>bind-value=\"...\"</code> and <code>bind-value:event=\"onchange\"</code> will assign the " +
                     "current value of the expression to the 'value' attribute, and assign a delegate that attempts " +
                     "to set the value to the 'onchange' attribute.",
                 attribute.Documentation);
@@ -770,37 +765,30 @@ namespace Test
             Assert.False(attribute.IsBooleanProperty);
             Assert.False(attribute.IsEnum);
 
-            attribute = Assert.Single(bind.BoundAttributes, a => a.Name.StartsWith("format"));
+            var parameter = Assert.Single(attribute.BoundAttributeParameters, a => a.Name.Equals("format"));
 
             // Invariants
-            Assert.Empty(attribute.Diagnostics);
-            Assert.False(attribute.HasErrors);
-            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, attribute.Kind);
-            Assert.False(attribute.IsDefaultKind());
-            Assert.True(attribute.HasIndexer);
-            Assert.Equal("format-", attribute.IndexerNamePrefix);
-            Assert.Equal("System.String", attribute.IndexerTypeName);
-            Assert.False(attribute.IsIndexerBooleanProperty);
-            Assert.True(attribute.IsIndexerStringProperty);
+            Assert.Empty(parameter.Diagnostics);
+            Assert.False(parameter.HasErrors);
+            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Kind);
+            Assert.False(parameter.IsDefaultKind());
 
             Assert.Equal(
                 "Specifies a format to convert the value specified by the corresponding bind attribute. " +
-                    "For example: <code>format-value=\"...\"</code> will apply a format string to the value " +
-                    "specified in <code>bind-value-...</code>. The format string can currently only be used with " +
+                    "For example: <code>bind-value:format=\"...\"</code> will apply a format string to the value " +
+                    "specified in <code>bind-value=\"...\"</code>. The format string can currently only be used with " +
                     "expressions of type <code>DateTime</code>.",
-                attribute.Documentation);
+                parameter.Documentation);
 
-            Assert.Equal("format-...", attribute.Name);
-            Assert.Equal("Format", attribute.GetPropertyName());
-            Assert.Equal(
-                "System.Collections.Generic.Dictionary<string, string> Microsoft.AspNetCore.Components.Bind.Format",
-                attribute.DisplayName);
+            Assert.Equal("format", parameter.Name);
+            Assert.Equal("Format", parameter.GetPropertyName());
+            Assert.Equal(":format", parameter.DisplayName);
 
             // Defined from the property type
-            Assert.Equal("System.Collections.Generic.Dictionary<string, string>", attribute.TypeName);
-            Assert.False(attribute.IsStringProperty);
-            Assert.False(attribute.IsBooleanProperty);
-            Assert.False(attribute.IsEnum);
+            Assert.Equal("System.String", parameter.TypeName);
+            Assert.True(parameter.IsStringProperty);
+            Assert.False(parameter.IsBooleanProperty);
+            Assert.False(parameter.IsEnum);
         }
 
 

--- a/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -644,7 +644,7 @@ namespace Test
 }"));
             // Act
             var generated = CompileToCSharp(@"
-<MyComponent bind-Value-OnChanged=""ParentValue"" />
+<MyComponent bind-Value=""ParentValue"" bind-Value:event=""OnChanged"" />
 @code {
     public int ParentValue { get; set; } = 42;
 }");
@@ -674,7 +674,7 @@ namespace Test
 }"));
 
             var generated = CompileToCSharp(@"
-<MyComponent bind-Value-OnChanged=""ParentValue"" />
+<MyComponent bind-Value=""ParentValue"" bind-Value:event=""OnChanged"" />
 @code {
     public int ParentValue { get; set; } = 42;
 }");
@@ -982,7 +982,7 @@ namespace Test
 
             // Act
             var generated = CompileToCSharp(@"
-<input type=""text"" bind=""@CurrentDate"" format-value=""MM/dd/yyyy""/>
+<input type=""text"" bind=""@CurrentDate"" bind:format=""MM/dd/yyyy""/>
 @code {
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 }");
@@ -1000,7 +1000,7 @@ namespace Test
 
             // Act
             var generated = CompileToCSharp(@"
-<input type=""text"" bind=""@CurrentDate"" format-value=""@Format""/>
+<input type=""text"" bind=""@CurrentDate"" bind:format=""@Format""/>
 @code {
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 
@@ -1056,7 +1056,7 @@ namespace Test
 
             // Act
             var generated = CompileToCSharp(@"
-<input type=""text"" bind-value-onchange=""@ParentValue"" />
+<input type=""text"" bind-value=""@ParentValue"" bind-value:event=""onchange"" />
 @code {
     public int ParentValue { get; set; } = 42;
 }");
@@ -1074,7 +1074,7 @@ namespace Test
 
             // Act
             var generated = CompileToCSharp(@"
-<input type=""text"" bind-value-onchange=""@CurrentDate"" format-value=""MM/dd"" />
+<input type=""text"" bind-value=""@CurrentDate"" bind-value:event=""onchange"" bind-value:format=""MM/dd"" />
 @code {
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 }");

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
             __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                   ParentValue
+                         ParentValue
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
@@ -14,16 +14,16 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                Component - (0:0,0 [50] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
-                    ComponentAttribute - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
+                Component - (0:0,0 [69] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
+                    ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
-                            IntermediateToken - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
+                            IntermediateToken - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
-                    ComponentAttribute - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - OnChanged - AttributeStructure.DoubleQuotes
+                    ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - OnChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => ParentValue = __value
-                HtmlContent - (50:0,50 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (50:0,50 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-            CSharpCode - (59:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (59:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public int ParentValue { get; set; } = 42;\n
+                HtmlContent - (69:0,69 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (69:0,69 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (78:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (78:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public int ParentValue { get; set; } = 42;\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
-Source Location: (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1022:25,35 [11] )
+Generated Location: (1012:25,25 [11] )
 |ParentValue|
 
-Source Location: (59:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (78:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1627:47,7 [50] )
+Generated Location: (1617:47,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                   ParentValue
+                         ParentValue
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
@@ -14,16 +14,16 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                Component - (0:0,0 [50] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
-                    ComponentAttribute - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
+                Component - (0:0,0 [69] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
+                    ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
-                            IntermediateToken - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
+                            IntermediateToken - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
-                    ComponentAttribute - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - OnChanged - AttributeStructure.DoubleQuotes
+                    ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - OnChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue)
-                HtmlContent - (50:0,50 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (50:0,50 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-            CSharpCode - (59:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (59:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public int ParentValue { get; set; } = 42;\n
+                HtmlContent - (69:0,69 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (69:0,69 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (78:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (78:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public int ParentValue { get; set; } = 42;\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
-Source Location: (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (951:25,35 [11] )
+Generated Location: (941:25,25 [11] )
 |ParentValue|
 
-Source Location: (59:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (78:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1595:46,7 [50] )
+Generated Location: (1585:46,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                         CurrentDate
+                                CurrentDate
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -14,21 +14,21 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                MarkupElement - (0:0,0 [77] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                MarkupElement - (0:0,0 [101] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
-                    HtmlAttribute - (40:0,40 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
+                    HtmlAttribute - (31:0,31 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
-                            IntermediateToken - (41:0,41 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
+                            IntermediateToken - (32:0,32 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , 
                             IntermediateToken -  - CSharp - "MM/dd"
                             IntermediateToken -  - CSharp - )
-                    HtmlAttribute - (40:0,40 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "
+                    HtmlAttribute - (31:0,31 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => CurrentDate = __value, CurrentDate, "MM/dd")
-                HtmlContent - (77:0,77 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (77:0,77 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-            CSharpCode - (86:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (86:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);\n
+                HtmlContent - (101:0,101 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (101:0,101 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (110:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (110:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
-Source Location: (41:0,41 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (32:0,32 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (957:25,41 [11] )
+Generated Location: (948:25,32 [11] )
 |CurrentDate|
 
-Source Location: (86:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (110:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1320:36,7 [77] )
+Generated Location: (1311:36,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
             __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                         ParentValue
+                                ParentValue
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
@@ -14,19 +14,19 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                MarkupElement - (0:0,0 [56] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                MarkupElement - (0:0,0 [75] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
-                    HtmlAttribute - (40:0,40 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
+                    HtmlAttribute - (31:0,31 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
-                            IntermediateToken - (41:0,41 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
+                            IntermediateToken - (32:0,32 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
-                    HtmlAttribute - (40:0,40 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "
+                    HtmlAttribute - (31:0,31 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue)
-                HtmlContent - (56:0,56 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (56:0,56 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-            CSharpCode - (65:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (65:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public int ParentValue { get; set; } = 42;\n
+                HtmlContent - (75:0,75 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (75:0,75 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public int ParentValue { get; set; } = 42;\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
-Source Location: (41:0,41 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (32:0,32 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (957:25,41 [11] )
+Generated Location: (948:25,32 [11] )
 |ParentValue|
 
-Source Location: (65:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1302:36,7 [50] )
+Generated Location: (1293:36,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
@@ -31,7 +31,7 @@ namespace Test
             , 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                                      Format
+                                                     Format
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
@@ -14,7 +14,7 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                MarkupElement - (0:0,0 [63] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                MarkupElement - (0:0,0 [62] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
@@ -23,12 +23,12 @@ Document -
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , 
-                            IntermediateToken - (54:0,54 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Format
+                            IntermediateToken - (53:0,53 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Format
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (25:0,25 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => CurrentDate = __value, CurrentDate, Format)
-                HtmlContent - (63:0,63 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (63:0,63 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-            CSharpCode - (72:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (72:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);\n\n    public string Format { get; set; } = "MM/dd/yyyy";\n
+                HtmlContent - (62:0,62 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (62:0,62 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (71:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (71:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);\n\n    public string Format { get; set; } = "MM/dd/yyyy";\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
@@ -3,18 +3,18 @@ Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (942:25,26 [11] )
 |CurrentDate|
 
-Source Location: (54:0,54 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (53:0,53 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |Format|
-Generated Location: (1145:33,54 [6] )
+Generated Location: (1144:33,53 [6] )
 |Format|
 
-Source Location: (72:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (71:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 
     public string Format { get; set; } = "MM/dd/yyyy";
 |
-Generated Location: (1493:44,7 [135] )
+Generated Location: (1492:44,7 [135] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -14,7 +14,7 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                MarkupElement - (0:0,0 [66] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                MarkupElement - (0:0,0 [65] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
@@ -28,7 +28,7 @@ Document -
                     HtmlAttribute - (25:0,25 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => CurrentDate = __value, CurrentDate, "MM/dd/yyyy")
-                HtmlContent - (66:0,66 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (66:0,66 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-            CSharpCode - (75:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (75:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);\n
+                HtmlContent - (65:0,65 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (65:0,65 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (74:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (74:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -3,7 +3,7 @@ Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (942:25,26 [11] )
 |CurrentDate|
 
-Source Location: (75:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (74:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
@@ -17,7 +17,7 @@ namespace Test
             builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                   ParentValue
+                         ParentValue
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
@@ -7,14 +7,14 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                Component - (0:0,0 [50] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
-                    ComponentAttribute - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
+                Component - (0:0,0 [69] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
+                    ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
-                            IntermediateToken - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
+                            IntermediateToken - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
-                    ComponentAttribute - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - OnChanged - AttributeStructure.DoubleQuotes
+                    ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - OnChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => ParentValue = __value
-            CSharpCode - (59:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (59:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public int ParentValue { get; set; } = 42;\n
+            CSharpCode - (78:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (78:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public int ParentValue { get; set; } = 42;\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,8 +1,8 @@
-Source Location: (59:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (78:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1202:31,7 [50] )
+Generated Location: (1192:31,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -17,7 +17,7 @@ namespace Test
             builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                   ParentValue
+                         ParentValue
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
@@ -7,14 +7,14 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                Component - (0:0,0 [50] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
-                    ComponentAttribute - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
+                Component - (0:0,0 [69] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
+                    ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
-                            IntermediateToken - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
+                            IntermediateToken - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
-                    ComponentAttribute - (35:0,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - OnChanged - AttributeStructure.DoubleQuotes
+                    ComponentAttribute - (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml) - OnChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue)
-            CSharpCode - (59:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (59:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public int ParentValue { get; set; } = 42;\n
+            CSharpCode - (78:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (78:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public int ParentValue { get; set; } = 42;\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -1,8 +1,8 @@
-Source Location: (59:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (78:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1184:31,7 [50] )
+Generated Location: (1174:31,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -18,7 +18,7 @@ namespace Test
             builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                         CurrentDate
+                                CurrentDate
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -7,19 +7,19 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                MarkupElement - (0:0,0 [77] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                MarkupElement - (0:0,0 [101] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
-                    HtmlAttribute - (40:0,40 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
+                    HtmlAttribute - (31:0,31 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
-                            IntermediateToken - (41:0,41 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
+                            IntermediateToken - (32:0,32 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , 
                             IntermediateToken -  - CSharp - "MM/dd"
                             IntermediateToken -  - CSharp - )
-                    HtmlAttribute - (40:0,40 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "
+                    HtmlAttribute - (31:0,31 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => CurrentDate = __value, CurrentDate, "MM/dd")
-            CSharpCode - (86:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (86:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);\n
+            CSharpCode - (110:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (110:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -1,8 +1,8 @@
-Source Location: (86:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (110:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1248:32,7 [77] )
+Generated Location: (1239:32,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
@@ -18,7 +18,7 @@ namespace Test
             builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                         ParentValue
+                                ParentValue
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
@@ -7,17 +7,17 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                MarkupElement - (0:0,0 [56] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                MarkupElement - (0:0,0 [75] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
-                    HtmlAttribute - (40:0,40 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
+                    HtmlAttribute - (31:0,31 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
-                            IntermediateToken - (41:0,41 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
+                            IntermediateToken - (32:0,32 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
-                    HtmlAttribute - (40:0,40 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "
+                    HtmlAttribute - (31:0,31 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue)
-            CSharpCode - (65:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (65:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public int ParentValue { get; set; } = 42;\n
+            CSharpCode - (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public int ParentValue { get; set; } = 42;\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
@@ -1,8 +1,8 @@
-Source Location: (65:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1230:32,7 [50] )
+Generated Location: (1221:32,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
@@ -26,7 +26,7 @@ namespace Test
             , 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                                      Format
+                                                     Format
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
@@ -7,7 +7,7 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                MarkupElement - (0:0,0 [63] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                MarkupElement - (0:0,0 [62] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
@@ -16,10 +16,10 @@ Document -
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , 
-                            IntermediateToken - (54:0,54 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Format
+                            IntermediateToken - (53:0,53 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Format
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (25:0,25 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => CurrentDate = __value, CurrentDate, Format)
-            CSharpCode - (72:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (72:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);\n\n    public string Format { get; set; } = "MM/dd/yyyy";\n
+            CSharpCode - (71:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (71:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);\n\n    public string Format { get; set; } = "MM/dd/yyyy";\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
-Source Location: (72:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (71:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 
     public string Format { get; set; } = "MM/dd/yyyy";
 |
-Generated Location: (1421:40,7 [135] )
+Generated Location: (1420:40,7 [135] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -7,7 +7,7 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                MarkupElement - (0:0,0 [66] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                MarkupElement - (0:0,0 [65] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute -  - type=" - "
                         HtmlAttributeValue - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
@@ -21,5 +21,5 @@ Document -
                     HtmlAttribute - (25:0,25 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => CurrentDate = __value, CurrentDate, "MM/dd/yyyy")
-            CSharpCode - (75:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (75:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);\n
+            CSharpCode - (74:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (74:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -1,4 +1,4 @@
-Source Location: (75:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (74:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |


### PR DESCRIPTION
Part of https://github.com/aspnet/AspNetCore/issues/6364

This PR introduces support for things like the following,
```cshtml
 <input type="text" bind="Message" /> 
 <input type="text" bind="Message" bind:event="oninput" /> 
 <input type="text" bind="MyDate" bind:format="asdf" /> 
 <input type="text" bind-custom="Message" bind-custom:event="oninput" bind-custom2="Message" bind-custom2:event="onchanged" /> 
```

- Introduced `BoundAttributeParameterDescriptor` to represent bind`:event` etc portion of the bound attribute
- `TagHelperBlockRewriter` and `IntermediateLoweringPass` now respects bound attributes with parameters
- Updated `BindTagHelperDescriptorProvider` to bind attributes to `event` and `format` parameters
- Updated `TagHelperDescriptorJsonConverter`
- Added diagnostics for cases that are no longer supported
- Updated code gen tests