### PR TITLE
Render more TagHelper code at design time.

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
@@ -13,6 +13,11 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ModelExpressionTagHelper : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<DateTime>
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::InputTestTagHelper __InputTestTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -52,6 +57,7 @@ __InputTestTagHelper.For = ModelExpressionProvider.CreateModelExpression(ViewDat
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __InputTestTagHelper = CreateTagHelper<global::InputTestTagHelper>();
 #nullable restore
 #line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml"
@@ -60,6 +66,7 @@ __InputTestTagHelper.For = ModelExpressionProvider.CreateModelExpression(ViewDat
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
         [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (7:0,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |DateTime|
-Generated Location: (870:21,0 [8] )
+Generated Location: (1278:26,0 [8] )
 |DateTime|
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (1180:31,37 [29] )
+Generated Location: (1588:36,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (83:4,17 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Date|
-Generated Location: (1897:49,102 [4] )
+Generated Location: (2305:54,102 [4] )
 |Date|
 
 Source Location: (111:5,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Model|
-Generated Location: (2251:57,94 [5] )
+Generated Location: (2735:63,94 [5] )
 |Model|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_Runtime.codegen.cs
@@ -16,11 +16,13 @@ namespace AspNetCore
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ModelExpressionTagHelper : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<DateTime>
     {
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
@@ -20,6 +20,11 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 #nullable disable
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RazorPagesWithoutModel : global::Microsoft.AspNetCore.Mvc.RazorPages.Page
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::DivTagHelper __DivTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -42,6 +47,7 @@ global::System.Object __typeHelper = "*, AppCode";
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #nullable restore
 #line 25 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml"
                                          __o = Name;
@@ -50,9 +56,13 @@ global::System.Object __typeHelper = "*, AppCode";
 #line hidden
 #nullable disable
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.mappings.txt
@@ -5,12 +5,12 @@ Generated Location: (506:15,0 [41] )
 
 Source Location: (23:2,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
 |"*, AppCode"|
-Generated Location: (1092:28,37 [12] )
+Generated Location: (1500:33,37 [12] )
 |"*, AppCode"|
 
 Source Location: (566:24,47 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
 |Name|
-Generated Location: (1724:46,47 [4] )
+Generated Location: (2208:52,47 [4] )
 |Name|
 
 Source Location: (95:5,12 [283] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
@@ -28,7 +28,7 @@ Source Location: (95:5,12 [283] TestFiles/IntegrationTests/CodeGenerationIntegra
         public string Name { get; set; }
     }
 |
-Generated Location: (2243:59,12 [283] )
+Generated Location: (3031:69,12 [283] )
 |
     public IActionResult OnPost(Customer customer)
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_Runtime.codegen.cs
@@ -27,11 +27,13 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("form-group"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("col-md-offset-2 col-md-10"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
@@ -20,6 +20,11 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 #nullable disable
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RazorPages : global::Microsoft.AspNetCore.Mvc.RazorPages.Page
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::DivTagHelper __DivTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -52,6 +57,7 @@ global::System.Object __typeHelper = "*, AppCode";
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #nullable restore
 #line 29 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml"
                                          __o = Model.Name;
@@ -60,9 +66,13 @@ global::System.Object __typeHelper = "*, AppCode";
 #line hidden
 #nullable disable
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
@@ -5,17 +5,17 @@ Generated Location: (494:15,0 [41] )
 
 Source Location: (16:2,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |NewModel|
-Generated Location: (1019:28,0 [8] )
+Generated Location: (1427:33,0 [8] )
 |NewModel|
 
 Source Location: (40:3,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |"*, AppCode"|
-Generated Location: (1315:38,37 [12] )
+Generated Location: (1723:43,37 [12] )
 |"*, AppCode"|
 
 Source Location: (661:28,47 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |Model.Name|
-Generated Location: (1935:56,47 [10] )
+Generated Location: (2419:62,47 [10] )
 |Model.Name|
 
 Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
@@ -36,7 +36,7 @@ Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegr
         public string Name { get; set; }
     }
 |
-Generated Location: (2448:69,12 [360] )
+Generated Location: (3236:79,12 [360] )
 |
     public class NewModel : PageModel
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_Runtime.codegen.cs
@@ -27,11 +27,13 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("form-group"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("col-md-offset-2 col-md-10"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
@@ -13,6 +13,11 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Sections : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<DateTime>
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::InputTestTagHelper __InputTestTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -71,6 +76,7 @@ __InputTestTagHelper.For = ModelExpressionProvider.CreateModelExpression(ViewDat
 #line default
 #line hidden
 #nullable disable
+                await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             }
             );
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
@@ -1,29 +1,29 @@
 Source Location: (7:0,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |DateTime|
-Generated Location: (838:21,0 [8] )
+Generated Location: (1246:26,0 [8] )
 |DateTime|
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (1132:31,37 [29] )
+Generated Location: (1540:36,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (152:10,9 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Section1|
-Generated Location: (1400:41,22 [8] )
+Generated Location: (1808:46,22 [8] )
 |Section1|
 
 Source Location: (68:4,2 [46] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
-Generated Location: (1904:58,2 [46] )
+Generated Location: (2312:63,2 [46] )
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
 
 Source Location: (222:12,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Date|
-Generated Location: (2367:68,102 [4] )
+Generated Location: (2775:73,102 [4] )
 |Date|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_Runtime.codegen.cs
@@ -16,11 +16,13 @@ namespace AspNetCore
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Sections : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<DateTime>
     {
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
@@ -13,6 +13,11 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ViewComponentTagHelper : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::AllTagHelper __AllTagHelper;
         private global::AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ViewComponentTagHelper.__Generated__TestViewComponentTagHelper __TestViewComponentTagHelper;
         #pragma warning disable 219
@@ -54,6 +59,7 @@ global::System.Object __typeHelper = "*, AppCode";
 #nullable disable
             __TestViewComponentTagHelper.firstName = string.Empty;
             __AllTagHelper.Bar = " World";
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
         [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.mappings.txt
@@ -1,19 +1,19 @@
 Source Location: (14:0,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |"*, AppCode"|
-Generated Location: (1076:22,37 [12] )
+Generated Location: (1484:27,37 [12] )
 |"*, AppCode"|
 
 Source Location: (30:1,2 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |
     var foo = "Hello";
 |
-Generated Location: (1591:39,2 [26] )
+Generated Location: (1999:44,2 [26] )
 |
     var foo = "Hello";
 |
 
 Source Location: (83:5,22 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |foo|
-Generated Location: (2080:49,22 [3] )
+Generated Location: (2488:54,22 [3] )
 |foo|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_Runtime.codegen.cs
@@ -18,11 +18,13 @@ namespace AspNetCore
         private global::AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ViewComponentTagHelper.__Generated__TestViewComponentTagHelper __TestViewComponentTagHelper;
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("bar", " World", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
@@ -13,6 +13,11 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ModelExpressionTagHelper : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<DateTime>
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::InputTestTagHelper __InputTestTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -46,12 +51,14 @@ __InputTestTagHelper.For = ModelExpressionProvider.CreateModelExpression(ViewDat
 
 #line default
 #line hidden
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __InputTestTagHelper = CreateTagHelper<global::InputTestTagHelper>();
 #line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml"
 __InputTestTagHelper.For = ModelExpressionProvider.CreateModelExpression(ViewData, __model => Model);
 
 #line default
 #line hidden
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
         [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (7:0,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |DateTime|
-Generated Location: (851:20,0 [8] )
+Generated Location: (1259:25,0 [8] )
 |DateTime|
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (1123:28,37 [29] )
+Generated Location: (1531:33,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (83:4,17 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Date|
-Generated Location: (1802:44,102 [4] )
+Generated Location: (2210:49,102 [4] )
 |Date|
 
 Source Location: (111:5,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Model|
-Generated Location: (2118:50,94 [5] )
+Generated Location: (2602:56,94 [5] )
 |Model|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
@@ -13,6 +13,11 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Sections : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<DateTime>
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::InputTestTagHelper __InputTestTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -61,6 +66,7 @@ __InputTestTagHelper.For = ModelExpressionProvider.CreateModelExpression(ViewDat
 
 #line default
 #line hidden
+                await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             }
             );
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
@@ -1,29 +1,29 @@
 Source Location: (7:0,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |DateTime|
-Generated Location: (819:20,0 [8] )
+Generated Location: (1227:25,0 [8] )
 |DateTime|
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (1075:28,37 [29] )
+Generated Location: (1483:33,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (152:10,9 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Section1|
-Generated Location: (1305:36,22 [8] )
+Generated Location: (1713:41,22 [8] )
 |Section1|
 
 Source Location: (68:4,2 [46] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
-Generated Location: (1771:51,2 [46] )
+Generated Location: (2179:56,2 [46] )
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
 
 Source Location: (222:12,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Date|
-Generated Location: (2196:59,102 [4] )
+Generated Location: (2604:64,102 [4] )
 |Date|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
@@ -13,6 +13,11 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ViewComponentTagHelper : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::AllTagHelper __AllTagHelper;
         private global::AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ViewComponentTagHelper.__Generated__TestViewComponentTagHelper __TestViewComponentTagHelper;
         #pragma warning disable 219
@@ -48,6 +53,7 @@ global::System.Object __typeHelper = "*, AppCode";
 #line hidden
             __TestViewComponentTagHelper.firstName = string.Empty;
             __AllTagHelper.Bar = " World";
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
         [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.mappings.txt
@@ -1,19 +1,19 @@
 Source Location: (14:0,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |"*, AppCode"|
-Generated Location: (1057:21,37 [12] )
+Generated Location: (1465:26,37 [12] )
 |"*, AppCode"|
 
 Source Location: (30:1,2 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |
     var foo = "Hello";
 |
-Generated Location: (1534:36,2 [26] )
+Generated Location: (1942:41,2 [26] )
 |
     var foo = "Hello";
 |
 
 Source Location: (83:5,22 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |foo|
-Generated Location: (1985:44,22 [3] )
+Generated Location: (2393:49,22 [3] )
 |foo|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
@@ -13,6 +13,11 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ModelExpressionTagHelper : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<DateTime>
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::InputTestTagHelper __InputTestTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -46,12 +51,14 @@ __InputTestTagHelper.For = ModelExpressionProvider.CreateModelExpression(ViewDat
 
 #line default
 #line hidden
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __InputTestTagHelper = CreateTagHelper<global::InputTestTagHelper>();
 #line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml"
 __InputTestTagHelper.For = ModelExpressionProvider.CreateModelExpression(ViewData, __model => Model);
 
 #line default
 #line hidden
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
         [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (7:0,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |DateTime|
-Generated Location: (851:20,0 [8] )
+Generated Location: (1259:25,0 [8] )
 |DateTime|
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (1123:28,37 [29] )
+Generated Location: (1531:33,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (83:4,17 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Date|
-Generated Location: (1802:44,102 [4] )
+Generated Location: (2210:49,102 [4] )
 |Date|
 
 Source Location: (111:5,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Model|
-Generated Location: (2118:50,94 [5] )
+Generated Location: (2602:56,94 [5] )
 |Model|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_Runtime.codegen.cs
@@ -17,11 +17,13 @@ namespace AspNetCore
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ModelExpressionTagHelper : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<DateTime>
     {
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
@@ -18,6 +18,11 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RazorPagesWithoutModel : global::Microsoft.AspNetCore.Mvc.RazorPages.Page
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::DivTagHelper __DivTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -38,15 +43,20 @@ global::System.Object __typeHelper = "*, AppCode";
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #line 25 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml"
                                          __o = Name;
 
 #line default
 #line hidden
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
 #line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.mappings.txt
@@ -5,12 +5,12 @@ Generated Location: (487:14,0 [41] )
 
 Source Location: (23:2,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
 |"*, AppCode"|
-Generated Location: (1035:25,37 [12] )
+Generated Location: (1443:30,37 [12] )
 |"*, AppCode"|
 
 Source Location: (566:24,47 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
 |Name|
-Generated Location: (1629:41,47 [4] )
+Generated Location: (2113:47,47 [4] )
 |Name|
 
 Source Location: (95:5,12 [283] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
@@ -28,7 +28,7 @@ Source Location: (95:5,12 [283] TestFiles/IntegrationTests/CodeGenerationIntegra
         public string Name { get; set; }
     }
 |
-Generated Location: (2110:52,12 [283] )
+Generated Location: (2898:62,12 [283] )
 |
     public IActionResult OnPost(Customer customer)
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_Runtime.codegen.cs
@@ -26,11 +26,13 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("form-group"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("col-md-offset-2 col-md-10"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
@@ -18,6 +18,11 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RazorPages : global::Microsoft.AspNetCore.Mvc.RazorPages.Page
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::DivTagHelper __DivTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -46,15 +51,20 @@ global::System.Object __typeHelper = "*, AppCode";
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #line 29 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml"
                                          __o = Model.Name;
 
 #line default
 #line hidden
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
 #line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml"

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
@@ -5,17 +5,17 @@ Generated Location: (475:14,0 [41] )
 
 Source Location: (16:2,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |NewModel|
-Generated Location: (962:25,0 [8] )
+Generated Location: (1370:30,0 [8] )
 |NewModel|
 
 Source Location: (40:3,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |"*, AppCode"|
-Generated Location: (1220:33,37 [12] )
+Generated Location: (1628:38,37 [12] )
 |"*, AppCode"|
 
 Source Location: (661:28,47 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |Model.Name|
-Generated Location: (1802:49,47 [10] )
+Generated Location: (2286:55,47 [10] )
 |Model.Name|
 
 Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
@@ -36,7 +36,7 @@ Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegr
         public string Name { get; set; }
     }
 |
-Generated Location: (2277:60,12 [360] )
+Generated Location: (3065:70,12 [360] )
 |
     public class NewModel : PageModel
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_Runtime.codegen.cs
@@ -26,11 +26,13 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("form-group"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("col-md-offset-2 col-md-10"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
@@ -13,6 +13,11 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Sections : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<DateTime>
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::InputTestTagHelper __InputTestTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -61,6 +66,7 @@ __InputTestTagHelper.For = ModelExpressionProvider.CreateModelExpression(ViewDat
 
 #line default
 #line hidden
+                await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             }
             );
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
@@ -1,29 +1,29 @@
 Source Location: (7:0,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |DateTime|
-Generated Location: (819:20,0 [8] )
+Generated Location: (1227:25,0 [8] )
 |DateTime|
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (1075:28,37 [29] )
+Generated Location: (1483:33,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (152:10,9 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Section1|
-Generated Location: (1305:36,22 [8] )
+Generated Location: (1713:41,22 [8] )
 |Section1|
 
 Source Location: (68:4,2 [46] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
-Generated Location: (1771:51,2 [46] )
+Generated Location: (2179:56,2 [46] )
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
 
 Source Location: (222:12,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Date|
-Generated Location: (2196:59,102 [4] )
+Generated Location: (2604:64,102 [4] )
 |Date|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_Runtime.codegen.cs
@@ -17,11 +17,13 @@ namespace AspNetCore
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Sections : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<DateTime>
     {
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
@@ -13,6 +13,11 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ViewComponentTagHelper : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::AllTagHelper __AllTagHelper;
         private global::AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ViewComponentTagHelper.__Generated__TestViewComponentTagHelper __TestViewComponentTagHelper;
         #pragma warning disable 219
@@ -48,6 +53,7 @@ global::System.Object __typeHelper = "*, AppCode";
 #line hidden
             __TestViewComponentTagHelper.firstName = string.Empty;
             __AllTagHelper.Bar = " World";
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
         [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.mappings.txt
@@ -1,19 +1,19 @@
 Source Location: (14:0,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |"*, AppCode"|
-Generated Location: (1057:21,37 [12] )
+Generated Location: (1465:26,37 [12] )
 |"*, AppCode"|
 
 Source Location: (30:1,2 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |
     var foo = "Hello";
 |
-Generated Location: (1534:36,2 [26] )
+Generated Location: (1942:41,2 [26] )
 |
     var foo = "Hello";
 |
 
 Source Location: (83:5,22 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |foo|
-Generated Location: (1985:44,22 [3] )
+Generated Location: (2393:49,22 [3] )
 |foo|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_Runtime.codegen.cs
@@ -19,11 +19,13 @@ namespace AspNetCore
         private global::AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ViewComponentTagHelper.__Generated__TestViewComponentTagHelper __TestViewComponentTagHelper;
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("bar", " World", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.codegen.cs
@@ -20,11 +20,13 @@ namespace AspNetCore
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("text"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlString("foo"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/Extensions/DefaultTagHelperTargetExtensionTest.cs
+++ b/src/Razor/test/RazorLanguage.Test/Extensions/DefaultTagHelperTargetExtensionTest.cs
@@ -189,7 +189,7 @@ __tagHelperExecutionContext.Add(__TestNamespace_MyTagHelper);
         }
 
         [Fact]
-        public void WriteTagHelperExecute_DesignTime_WritesNothing()
+        public void WriteTagHelperExecute_DesignTime_RendersAsyncCode()
         {
             // Arrange
             var extension = new DefaultTagHelperTargetExtension();
@@ -206,7 +206,8 @@ __tagHelperExecutionContext.Add(__TestNamespace_MyTagHelper);
             // Assert
             var csharp = context.CodeWriter.GenerateCode();
             Assert.Equal(
-                @"",
+                @"await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+",
                 csharp,
                 ignoreLineEndingDifferences: true);
         }
@@ -1077,7 +1078,7 @@ __tagHelperExecutionContext.AddTagHelperAttribute(""foo-bound"", __InputTagHelpe
         }
 
         [Fact]
-        public void WriteTagHelperRuntime_DesignTime_WritesNothing()
+        public void WriteTagHelperRuntime_DesignTime_RendersPreRequisites()
         {
             // Arrange
             var extension = new DefaultTagHelperTargetExtension();
@@ -1091,7 +1092,12 @@ __tagHelperExecutionContext.AddTagHelperAttribute(""foo-bound"", __InputTagHelpe
             // Assert
             var csharp = context.CodeWriter.GenerateCode();
             Assert.Equal(
-                @"",
+                @"#line hidden
+#pragma warning disable 0649
+private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+#pragma warning restore 0649
+private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
+",
                 csharp,
                 ignoreLineEndingDifferences: true);
         }
@@ -1112,11 +1118,13 @@ __tagHelperExecutionContext.AddTagHelperAttribute(""foo-bound"", __InputTagHelpe
             var csharp = context.CodeWriter.GenerateCode();
             Assert.Equal(
 @"#line hidden
+#pragma warning disable 0649
+private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+#pragma warning restore 0649
+private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
 #pragma warning disable 0169
 private string __tagHelperStringValueBuffer;
 #pragma warning restore 0169
-private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
 private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
 private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
 {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_AttributeTargetingTagHelpers_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper;
         private global::TestNamespace.CatchAllTagHelper __TestNamespace_CatchAllTagHelper;
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper;
@@ -30,6 +35,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __TestNamespace_InputTagHelper.Type = "checkbox";
@@ -41,6 +47,7 @@ __TestNamespace_InputTagHelper2.Checked = true;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
@@ -53,7 +60,9 @@ __TestNamespace_InputTagHelper2.Checked = true;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (902:16,38 [15] )
+Generated Location: (1310:21,38 [15] )
 |*, TestAssembly|
 
 Source Location: (187:5,36 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers.cshtml)
 |true|
-Generated Location: (1919:38,42 [4] )
+Generated Location: (2403:44,42 [4] )
 |true|
 
 Source Location: (233:6,36 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers.cshtml)
 |true|
-Generated Location: (2610:50,42 [4] )
+Generated Location: (3170:57,42 [4] )
 |true|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_Runtime.codegen.cs
@@ -12,11 +12,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "checkbox", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("btn"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicTagHelpers_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper;
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2;
@@ -29,6 +34,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
 #nullable restore
@@ -40,6 +46,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #nullable disable
             __TestNamespace_InputTagHelper.Type = "text";
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __TestNamespace_InputTagHelper.Type = "checkbox";
@@ -51,7 +58,9 @@ __TestNamespace_InputTagHelper2.Checked = true;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (783:15,37 [17] )
+Generated Location: (1191:20,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (220:5,38 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml)
 |ViewBag.DefaultInterval|
-Generated Location: (1618:35,38 [23] )
+Generated Location: (2102:41,38 [23] )
 |ViewBag.DefaultInterval|
 
 Source Location: (303:6,40 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml)
 |true|
-Generated Location: (2354:48,42 [4] )
+Generated Location: (2914:55,42 [4] )
 |true|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicTagHelpers_Prefixed_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper;
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2;
@@ -49,7 +54,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (17:0,17 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed.cshtml)
 |"THS"|
-Generated Location: (801:15,37 [5] )
+Generated Location: (1209:20,37 [5] )
 |"THS"|
 
 Source Location: (38:1,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed.cshtml)
 |"*, TestAssembly"|
-Generated Location: (1075:25,37 [17] )
+Generated Location: (1483:30,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (226:7,43 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed.cshtml)
 |true|
-Generated Location: (1981:46,43 [4] )
+Generated Location: (2389:51,43 [4] )
 |true|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.codegen.cs
@@ -11,11 +11,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "checkbox", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_RemoveTagHelper_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_RemoveTagHelper_Runtime.codegen.cs
@@ -12,11 +12,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "checkbox", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Runtime.codegen.cs
@@ -14,11 +14,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-delay", new global::Microsoft.AspNetCore.Html.HtmlString("1000"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ComplexTagHelpers_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper;
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2;
@@ -47,6 +52,7 @@ __TestNamespace_PTagHelper.Age = @@(1+2);
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #nullable restore
 #line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
              if (false)
@@ -60,7 +66,9 @@ __TestNamespace_PTagHelper.Age = @@(1+2);
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __TestNamespace_InputTagHelper.Type = "text";
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #nullable restore
 #line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                                                                                                    
@@ -90,7 +98,9 @@ __TestNamespace_PTagHelper.Age = @@(1+2);
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #nullable restore
 #line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                                                                           
@@ -110,6 +120,7 @@ __TestNamespace_PTagHelper.Age = @@(1+2);
 #nullable disable
             __TestNamespace_InputTagHelper.Type = string.Empty;
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #nullable restore
 #line 18 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                                                                   
@@ -143,6 +154,7 @@ __TestNamespace_PTagHelper.Age = @@(1+2);
 #nullable disable
             __TestNamespace_InputTagHelper.Type = string.Empty;
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #nullable restore
 #line 19 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                                                                                                  
@@ -159,6 +171,7 @@ __TestNamespace_PTagHelper.Age = @@(1+2);
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #nullable restore
 #line 23 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                var @object = false;
@@ -175,6 +188,7 @@ __TestNamespace_InputTagHelper2.Checked = (@object);
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
 #nullable restore
 #line 22 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
@@ -183,6 +197,7 @@ __TestNamespace_InputTagHelper2.Checked = (@object);
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
 #nullable restore
@@ -192,6 +207,7 @@ __TestNamespace_InputTagHelper2.Checked = (@object);
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
 #nullable restore
 #line 26 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
@@ -200,6 +216,7 @@ __TestNamespace_PTagHelper.Age = -1970 + @DateTimeOffset.Now.Year;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
 #nullable restore
@@ -209,6 +226,7 @@ __TestNamespace_InputTagHelper2.Checked = DateTimeOffset.Now.Year > 2014;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
 #nullable restore
 #line 29 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
@@ -217,6 +235,7 @@ __TestNamespace_PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
 #nullable restore
@@ -226,6 +245,7 @@ __TestNamespace_InputTagHelper2.Checked =    @(  DateTimeOffset.Now.Year  ) > 20
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
 #nullable restore
 #line 32 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
@@ -234,6 +254,7 @@ __TestNamespace_PTagHelper.Age = ("My age is this long.".Length);
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #nullable restore
 #line 35 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
    __o = someMethod(item => new Template(async(__razor_template_writer) => {
@@ -246,6 +267,7 @@ __TestNamespace_PTagHelper.Age = ("My age is this long.".Length);
 #line default
 #line hidden
 #nullable disable
+    await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
     __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
 #nullable restore
 #line 35 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
@@ -254,6 +276,7 @@ __TestNamespace_PTagHelper.Age = 123;
 #line default
 #line hidden
 #nullable disable
+    await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 }
 ));
 
@@ -268,6 +291,7 @@ __TestNamespace_PTagHelper.Age = ;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #nullable restore
 #line 37 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
           

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (787:15,37 [17] )
+Generated Location: (1195:20,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (36:2,1 [52] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
@@ -9,7 +9,7 @@ Source Location: (36:2,1 [52] TestFiles/IntegrationTests/CodeGenerationIntegrati
     var checkbox = "checkbox";
 
     |
-Generated Location: (1284:32,1 [52] )
+Generated Location: (1692:37,1 [52] )
 |if (true)
 {
     var checkbox = "checkbox";
@@ -18,39 +18,39 @@ Generated Location: (1284:32,1 [52] )
 
 Source Location: (147:7,16 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (1628:44,33 [1] )
+Generated Location: (2036:49,33 [1] )
 |@|
 
 Source Location: (149:7,18 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 ||
-Generated Location: (1629:44,34 [0] )
+Generated Location: (2037:49,34 [0] )
 ||
 
 Source Location: (149:7,18 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (1629:44,34 [1] )
+Generated Location: (2037:49,34 [1] )
 |@|
 
 Source Location: (150:7,19 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (1630:44,35 [1] )
+Generated Location: (2038:49,35 [1] )
 |(|
 
 Source Location: (151:7,20 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |1+2|
-Generated Location: (1631:44,36 [3] )
+Generated Location: (2039:49,36 [3] )
 |1+2|
 
 Source Location: (154:7,23 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (1634:44,39 [1] )
+Generated Location: (2042:49,39 [1] )
 |)|
 
 Source Location: (273:10,13 [43] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |if (false)
             {
                 |
-Generated Location: (1814:51,13 [43] )
+Generated Location: (2298:57,13 [43] )
 |if (false)
             {
                 |
@@ -61,7 +61,7 @@ Source Location: (399:12,99 [66] TestFiles/IntegrationTests/CodeGenerationIntegr
             else
             {
                 |
-Generated Location: (2572:65,99 [66] )
+Generated Location: (3208:73,99 [66] )
 |
             }
             else
@@ -70,224 +70,224 @@ Generated Location: (2572:65,99 [66] )
 
 Source Location: (495:16,46 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |checkbox|
-Generated Location: (3057:78,46 [8] )
+Generated Location: (3693:86,46 [8] )
 |checkbox|
 
 Source Location: (512:16,63 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |true|
-Generated Location: (3448:87,63 [4] )
+Generated Location: (4084:95,63 [4] )
 |true|
 
 Source Location: (523:16,74 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
                 |
-Generated Location: (3787:95,74 [18] )
+Generated Location: (4575:105,74 [18] )
 |
                 |
 
 Source Location: (556:17,31 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |true ? "checkbox" : "anything"|
-Generated Location: (4209:105,31 [30] )
+Generated Location: (4997:115,31 [30] )
 |true ? "checkbox" : "anything"|
 
 Source Location: (591:17,66 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
                 |
-Generated Location: (4625:114,66 [18] )
+Generated Location: (5489:125,66 [18] )
 |
                 |
 
 Source Location: (623:18,30 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |if(true) { |
-Generated Location: (5046:124,30 [11] )
+Generated Location: (5910:135,30 [11] )
 |if(true) { |
 
 Source Location: (655:18,62 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | } else { |
-Generated Location: (5284:131,62 [10] )
+Generated Location: (6148:142,62 [10] )
 | } else { |
 
 Source Location: (686:18,93 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | }|
-Generated Location: (5552:138,93 [2] )
+Generated Location: (6416:149,93 [2] )
 | }|
 
 Source Location: (690:18,97 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
             }|
-Generated Location: (5970:147,97 [15] )
+Generated Location: (6910:159,97 [15] )
 |
             }|
 
 Source Location: (212:8,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (6276:156,32 [12] )
+Generated Location: (7216:168,32 [12] )
 |DateTime.Now|
 
 Source Location: (832:22,14 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | var @object = false;|
-Generated Location: (6468:163,14 [21] )
+Generated Location: (7484:176,14 [21] )
 | var @object = false;|
 
 Source Location: (885:23,29 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (6904:172,42 [1] )
+Generated Location: (7920:185,42 [1] )
 |(|
 
 Source Location: (886:23,30 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@object|
-Generated Location: (6905:172,43 [7] )
+Generated Location: (7921:185,43 [7] )
 |@object|
 
 Source Location: (893:23,37 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (6912:172,50 [1] )
+Generated Location: (7928:185,50 [1] )
 |)|
 
 Source Location: (760:21,39 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year|
-Generated Location: (7212:180,38 [23] )
+Generated Location: (8304:194,38 [23] )
 |DateTimeOffset.Now.Year|
 
 Source Location: (783:21,62 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | -|
-Generated Location: (7235:180,61 [2] )
+Generated Location: (8327:194,61 [2] )
 | -|
 
 Source Location: (785:21,64 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | 1970|
-Generated Location: (7237:180,63 [5] )
+Generated Location: (8329:194,63 [5] )
 | 1970|
 
 Source Location: (1025:26,61 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (7676:189,60 [1] )
+Generated Location: (8844:204,60 [1] )
 |(|
 
 Source Location: (1026:26,62 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year > 2014|
-Generated Location: (7677:189,61 [30] )
+Generated Location: (8845:204,61 [30] )
 |DateTimeOffset.Now.Year > 2014|
 
 Source Location: (1056:26,92 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (7707:189,91 [1] )
+Generated Location: (8875:204,91 [1] )
 |)|
 
 Source Location: (928:25,16 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |-1970|
-Generated Location: (8002:197,33 [5] )
+Generated Location: (9246:213,33 [5] )
 |-1970|
 
 Source Location: (933:25,21 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | +|
-Generated Location: (8007:197,38 [2] )
+Generated Location: (9251:213,38 [2] )
 | +|
 
 Source Location: (935:25,23 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | |
-Generated Location: (8009:197,40 [1] )
+Generated Location: (9253:213,40 [1] )
 | |
 
 Source Location: (936:25,24 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (8010:197,41 [1] )
+Generated Location: (9254:213,41 [1] )
 |@|
 
 Source Location: (937:25,25 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year|
-Generated Location: (8011:197,42 [23] )
+Generated Location: (9255:213,42 [23] )
 |DateTimeOffset.Now.Year|
 
 Source Location: (1155:29,28 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year > 2014|
-Generated Location: (8450:206,42 [30] )
+Generated Location: (9770:223,42 [30] )
 |DateTimeOffset.Now.Year > 2014|
 
 Source Location: (1093:28,16 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year - 1970|
-Generated Location: (8774:214,33 [30] )
+Generated Location: (10170:232,33 [30] )
 |DateTimeOffset.Now.Year - 1970|
 
 Source Location: (1283:32,28 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |   |
-Generated Location: (9220:223,42 [3] )
+Generated Location: (10692:242,42 [3] )
 |   |
 
 Source Location: (1286:32,31 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (9223:223,45 [1] )
+Generated Location: (10695:242,45 [1] )
 |@|
 
 Source Location: (1287:32,32 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (9224:223,46 [1] )
+Generated Location: (10696:242,46 [1] )
 |(|
 
 Source Location: (1288:32,33 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |  DateTimeOffset.Now.Year  |
-Generated Location: (9225:223,47 [27] )
+Generated Location: (10697:242,47 [27] )
 |  DateTimeOffset.Now.Year  |
 
 Source Location: (1315:32,60 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (9252:223,74 [1] )
+Generated Location: (10724:242,74 [1] )
 |)|
 
 Source Location: (1316:32,61 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | >|
-Generated Location: (9253:223,75 [2] )
+Generated Location: (10725:242,75 [2] )
 | >|
 
 Source Location: (1318:32,63 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | 2014|
-Generated Location: (9255:223,77 [5] )
+Generated Location: (10727:242,77 [5] )
 | 2014|
 
 Source Location: (1323:32,68 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |   |
-Generated Location: (9260:223,82 [3] )
+Generated Location: (10732:242,82 [3] )
 |   |
 
 Source Location: (1220:31,17 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (9557:231,33 [1] )
+Generated Location: (11105:251,33 [1] )
 |(|
 
 Source Location: (1221:31,18 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |"My age is this long.".Length|
-Generated Location: (9558:231,34 [29] )
+Generated Location: (11106:251,34 [29] )
 |"My age is this long.".Length|
 
 Source Location: (1250:31,47 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (9587:231,63 [1] )
+Generated Location: (11135:251,63 [1] )
 |)|
 
 Source Location: (1355:34,9 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |someMethod(|
-Generated Location: (9763:238,9 [11] )
+Generated Location: (11387:259,9 [11] )
 |someMethod(|
 
 Source Location: (1410:34,64 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |checked|
-Generated Location: (10200:243,63 [7] )
+Generated Location: (11824:264,63 [7] )
 |checked|
 
 Source Location: (1375:34,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |123|
-Generated Location: (10493:251,33 [3] )
+Generated Location: (12185:273,33 [3] )
 |123|
 
 Source Location: (1424:34,78 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (10553:257,1 [1] )
+Generated Location: (12313:280,1 [1] )
 |)|
 
 Source Location: (1469:36,10 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
 }|
-Generated Location: (11024:272,10 [3] )
+Generated Location: (12860:296,10 [3] )
 |
 }|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.codegen.cs
@@ -17,11 +17,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_6 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlString("world"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_7 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("hello"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CssSelectorTagHelperAttributes_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CssSelectorTagHelperAttributes_Runtime.codegen.cs
@@ -18,11 +18,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_7 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "checkbox", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_8 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("value", new global::Microsoft.AspNetCore.Html.HtmlString("2 TagHelper"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DuplicateAttributeTagHelpers_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper;
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2;
@@ -32,6 +37,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __TestNamespace_InputTagHelper.Type = "button";
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __TestNamespace_InputTagHelper.Type = "button";
@@ -43,6 +49,7 @@ __TestNamespace_InputTagHelper2.Checked = true;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __TestNamespace_InputTagHelper.Type = "button";
@@ -54,6 +61,7 @@ __TestNamespace_InputTagHelper2.Checked = true;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
 #nullable restore
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml"
@@ -62,6 +70,7 @@ __TestNamespace_PTagHelper.Age = 3;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (809:15,37 [17] )
+Generated Location: (1217:20,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (146:4,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |true|
-Generated Location: (2074:40,42 [4] )
+Generated Location: (2558:46,42 [4] )
 |true|
 
 Source Location: (222:5,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |true|
-Generated Location: (2654:51,42 [4] )
+Generated Location: (3214:58,42 [4] )
 |true|
 
 Source Location: (43:2,8 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |3|
-Generated Location: (2962:59,33 [1] )
+Generated Location: (3598:67,33 [1] )
 |3|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_Runtime.codegen.cs
@@ -18,11 +18,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_7 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("AGE", new global::Microsoft.AspNetCore.Html.HtmlString("40"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_8 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("Age", new global::Microsoft.AspNetCore.Html.HtmlString("500"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DuplicateTargetTagHelper_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper;
         private global::TestNamespace.CatchAllTagHelper __TestNamespace_CatchAllTagHelper;
         #pragma warning disable 219
@@ -39,6 +44,7 @@ __TestNamespace_InputTagHelper.Checked = true;
 #line hidden
 #nullable disable
             __TestNamespace_CatchAllTagHelper.Checked = __TestNamespace_InputTagHelper.Checked;
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper.cshtml)
 |"*, TestAssembly"|
-Generated Location: (727:14,37 [17] )
+Generated Location: (1135:19,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (67:2,32 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper.cshtml)
 |true|
-Generated Location: (1637:35,41 [4] )
+Generated Location: (2045:40,41 [4] )
 |true|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_Runtime.codegen.cs
@@ -10,11 +10,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "checkbox", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DynamicAttributeTagHelpers_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -34,6 +39,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
 #nullable restore
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml"
@@ -70,6 +76,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
 #nullable restore
 #line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml"
@@ -86,6 +93,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
 #nullable restore
 #line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml"
@@ -186,6 +194,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
 #nullable restore
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml"
@@ -208,6 +217,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
 #nullable restore
 #line 14 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml"
@@ -244,6 +254,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,155 +1,155 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (639:13,37 [17] )
+Generated Location: (1047:18,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (59:2,24 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (1271:31,24 [12] )
+Generated Location: (1679:36,24 [12] )
 |DateTime.Now|
 
 Source Location: (96:4,17 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (1577:39,17 [12] )
+Generated Location: (2061:45,17 [12] )
 |if (true) { |
 
 Source Location: (109:4,30 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (1792:46,30 [12] )
+Generated Location: (2276:52,30 [12] )
 |string.Empty|
 
 Source Location: (121:4,42 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (2020:53,42 [10] )
+Generated Location: (2504:59,42 [10] )
 | } else { |
 
 Source Location: (132:4,53 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (2256:60,53 [5] )
+Generated Location: (2740:66,53 [5] )
 |false|
 
 Source Location: (137:4,58 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (2493:67,58 [2] )
+Generated Location: (2977:73,58 [2] )
 | }|
 
 Source Location: (176:6,22 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (2793:75,22 [12] )
+Generated Location: (3353:82,22 [12] )
 |DateTime.Now|
 
 Source Location: (214:6,60 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (3105:83,60 [12] )
+Generated Location: (3665:90,60 [12] )
 |DateTime.Now|
 
 Source Location: (256:8,15 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |long.MinValue|
-Generated Location: (3409:91,15 [13] )
+Generated Location: (4045:99,15 [13] )
 |long.MinValue|
 
 Source Location: (271:8,30 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (3626:98,30 [12] )
+Generated Location: (4262:106,30 [12] )
 |if (true) { |
 
 Source Location: (284:8,43 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (3854:105,43 [12] )
+Generated Location: (4490:113,43 [12] )
 |string.Empty|
 
 Source Location: (296:8,55 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (4095:112,55 [10] )
+Generated Location: (4731:120,55 [10] )
 | } else { |
 
 Source Location: (307:8,66 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (4344:119,66 [5] )
+Generated Location: (4980:127,66 [5] )
 |false|
 
 Source Location: (312:8,71 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (4594:126,71 [2] )
+Generated Location: (5230:134,71 [2] )
 | }|
 
 Source Location: (316:8,75 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |int.MaxValue|
-Generated Location: (4844:133,75 [12] )
+Generated Location: (5480:141,75 [12] )
 |int.MaxValue|
 
 Source Location: (348:9,17 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |long.MinValue|
-Generated Location: (5114:141,17 [13] )
+Generated Location: (5750:149,17 [13] )
 |long.MinValue|
 
 Source Location: (363:9,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (5334:148,32 [12] )
+Generated Location: (5970:156,32 [12] )
 |if (true) { |
 
 Source Location: (376:9,45 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (5565:155,45 [12] )
+Generated Location: (6201:163,45 [12] )
 |string.Empty|
 
 Source Location: (388:9,57 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (5809:162,57 [10] )
+Generated Location: (6445:170,57 [10] )
 | } else { |
 
 Source Location: (399:9,68 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (6061:169,68 [5] )
+Generated Location: (6697:177,68 [5] )
 |false|
 
 Source Location: (404:9,73 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (6314:176,73 [2] )
+Generated Location: (6950:184,73 [2] )
 | }|
 
 Source Location: (408:9,77 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |int.MaxValue|
-Generated Location: (6567:183,77 [12] )
+Generated Location: (7203:191,77 [12] )
 |int.MaxValue|
 
 Source Location: (445:11,17 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |long.MinValue|
-Generated Location: (6874:191,17 [13] )
+Generated Location: (7586:200,17 [13] )
 |long.MinValue|
 
 Source Location: (460:11,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (7094:198,32 [12] )
+Generated Location: (7806:207,32 [12] )
 |DateTime.Now|
 
 Source Location: (492:11,64 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |int.MaxValue|
-Generated Location: (7345:205,64 [12] )
+Generated Location: (8057:214,64 [12] )
 |int.MaxValue|
 
 Source Location: (529:13,17 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (7652:213,17 [12] )
+Generated Location: (8440:223,17 [12] )
 |if (true) { |
 
 Source Location: (542:13,30 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (7868:220,30 [12] )
+Generated Location: (8656:230,30 [12] )
 |string.Empty|
 
 Source Location: (554:13,42 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (8097:227,42 [10] )
+Generated Location: (8885:237,42 [10] )
 | } else { |
 
 Source Location: (565:13,53 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (8334:234,53 [5] )
+Generated Location: (9122:244,53 [5] )
 |false|
 
 Source Location: (570:13,58 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (8572:241,58 [2] )
+Generated Location: (9360:251,58 [2] )
 | }|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_Runtime.codegen.cs
@@ -9,11 +9,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DynamicAttributeTagHelpers_Runtime
     {
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyAttributeTagHelpers_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2;
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper;
@@ -39,6 +44,7 @@ __TestNamespace_InputTagHelper2.Checked = ;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __TestNamespace_InputTagHelper.Type = "";
@@ -50,6 +56,7 @@ __TestNamespace_InputTagHelper2.Checked = ;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
 #nullable restore
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml"
@@ -58,6 +65,7 @@ __TestNamespace_PTagHelper.Age = ;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (802:15,38 [15] )
+Generated Location: (1210:20,38 [15] )
 |*, TestAssembly|
 
 Source Location: (66:3,26 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 ||
-Generated Location: (1698:36,42 [0] )
+Generated Location: (2106:41,42 [0] )
 ||
 
 Source Location: (126:5,30 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 ||
-Generated Location: (2264:47,42 [0] )
+Generated Location: (2748:53,42 [0] )
 ||
 
 Source Location: (92:4,12 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 ||
-Generated Location: (2564:55,33 [0] )
+Generated Location: (3124:62,33 [0] )
 ||
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.codegen.cs
@@ -11,11 +11,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString(""), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EnumTagHelpers_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper;
         private global::TestNamespace.CatchAllTagHelper __TestNamespace_CatchAllTagHelper;
         #pragma warning disable 219
@@ -44,6 +49,7 @@ __TestNamespace_InputTagHelper.Value = MyEnum.MyValue;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
 #nullable restore
@@ -53,6 +59,7 @@ __TestNamespace_InputTagHelper.Value = MyEnum.MyValue;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
 #nullable restore
@@ -62,6 +69,7 @@ __TestNamespace_InputTagHelper.Value = global::Microsoft.AspNetCore.Razor.Langua
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
 #nullable restore
@@ -78,6 +86,7 @@ __TestNamespace_CatchAllTagHelper.CatchAll = global::Microsoft.AspNetCore.Razor.
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
 #nullable restore
@@ -94,6 +103,7 @@ __TestNamespace_CatchAllTagHelper.CatchAll = enumValue;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.mappings.txt
@@ -1,49 +1,49 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (707:14,37 [17] )
+Generated Location: (1115:19,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (37:2,2 [39] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |
     var enumValue = MyEnum.MyValue;
 |
-Generated Location: (1202:31,2 [39] )
+Generated Location: (1610:36,2 [39] )
 |
     var enumValue = MyEnum.MyValue;
 |
 
 Source Location: (96:6,15 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyEnum.MyValue|
-Generated Location: (1651:41,39 [14] )
+Generated Location: (2059:46,39 [14] )
 |MyEnum.MyValue|
 
 Source Location: (131:7,15 [20] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyEnum.MySecondValue|
-Generated Location: (2054:50,15 [20] )
+Generated Location: (2538:56,15 [20] )
 |MyEnum.MySecondValue|
 
 Source Location: (171:8,14 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyValue|
-Generated Location: (2580:59,132 [7] )
+Generated Location: (3140:66,132 [7] )
 |MyValue|
 
 Source Location: (198:9,14 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MySecondValue|
-Generated Location: (3094:68,132 [13] )
+Generated Location: (3730:76,132 [13] )
 |MySecondValue|
 
 Source Location: (224:9,40 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyValue|
-Generated Location: (3408:75,138 [7] )
+Generated Location: (4044:83,138 [7] )
 |MyValue|
 
 Source Location: (251:10,15 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |enumValue|
-Generated Location: (3829:84,39 [9] )
+Generated Location: (4541:93,39 [9] )
 |enumValue|
 
 Source Location: (274:10,38 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |enumValue|
-Generated Location: (4046:91,45 [9] )
+Generated Location: (4758:100,45 [9] )
 |enumValue|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_Runtime.codegen.cs
@@ -9,11 +9,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EnumTagHelpers_Runtime
     {
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EscapedTagHelpers_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2;
         #pragma warning disable 219
@@ -52,6 +57,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (710:14,38 [15] )
+Generated Location: (1118:19,38 [15] )
 |*, TestAssembly|
 
 Source Location: (106:3,29 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (1234:31,29 [12] )
+Generated Location: (1642:36,29 [12] )
 |DateTime.Now|
 
 Source Location: (204:5,51 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (1670:40,51 [12] )
+Generated Location: (2078:45,51 [12] )
 |DateTime.Now|
 
 Source Location: (227:5,74 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |true|
-Generated Location: (2075:49,74 [4] )
+Generated Location: (2483:54,74 [4] )
 |true|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.codegen.cs
@@ -9,11 +9,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EscapedTagHelpers_Runtime
     {
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteTagHelper_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -27,6 +32,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper.cshtml)
 |"*, TestAssembly"|
-Generated Location: (617:13,37 [17] )
+Generated Location: (1025:18,37 [17] )
 |"*, TestAssembly"|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_Runtime.codegen.cs
@@ -10,11 +10,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString(""), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Markup_InCodeBlocksWithTagHelper_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::DivTagHelper __DivTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -49,6 +54,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line hidden
 #nullable disable
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #nullable restore
 #line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper.cshtml"
                                
@@ -92,6 +98,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line hidden
 #nullable disable
         __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+        await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #nullable restore
 #line 23 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper.cshtml"
               

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper.cshtml)
 |"*, TestAssembly"|
-Generated Location: (619:13,37 [17] )
+Generated Location: (1027:18,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (35:1,2 [154] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper.cshtml)
@@ -13,7 +13,7 @@ Source Location: (35:1,2 [154] TestFiles/IntegrationTests/CodeGenerationIntegrat
     void PrintName(Person person)
     {
         |
-Generated Location: (1132:30,2 [154] )
+Generated Location: (1540:35,2 [154] )
 |
     var people = new Person[]
     {
@@ -26,26 +26,26 @@ Generated Location: (1132:30,2 [154] )
 
 Source Location: (195:9,14 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper.cshtml)
 |person.Name|
-Generated Location: (1480:45,14 [11] )
+Generated Location: (1888:50,14 [11] )
 |person.Name|
 
 Source Location: (212:9,31 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper.cshtml)
 |
     }
 |
-Generated Location: (1774:53,31 [9] )
+Generated Location: (2258:59,31 [9] )
 |
     }
 |
 
 Source Location: (228:13,2 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper.cshtml)
 | PrintName(people[0]); |
-Generated Location: (1963:61,2 [23] )
+Generated Location: (2447:67,2 [23] )
 | PrintName(people[0]); |
 
 Source Location: (256:14,2 [36] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper.cshtml)
 | await AnnounceBirthday(people[0]); |
-Generated Location: (2168:68,2 [36] )
+Generated Location: (2652:74,2 [36] )
 | await AnnounceBirthday(people[0]); |
 
 Source Location: (309:16,12 [106] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper.cshtml)
@@ -54,7 +54,7 @@ Source Location: (309:16,12 [106] TestFiles/IntegrationTests/CodeGenerationInteg
     {
         var formatted = $"Mr. {person.Name}";
         |
-Generated Location: (2445:77,12 [106] )
+Generated Location: (2929:83,12 [106] )
 |
     Task AnnounceBirthday(Person person)
     {
@@ -63,14 +63,14 @@ Generated Location: (2445:77,12 [106] )
 
 Source Location: (455:21,33 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper.cshtml)
 |formatted|
-Generated Location: (2764:88,33 [9] )
+Generated Location: (3248:94,33 [9] )
 |formatted|
 
 Source Location: (487:22,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper.cshtml)
 |
 
         |
-Generated Location: (3035:96,14 [12] )
+Generated Location: (3591:103,14 [12] )
 |
 
         |
@@ -79,20 +79,20 @@ Source Location: (514:25,9 [66] TestFiles/IntegrationTests/CodeGenerationIntegra
 |for (var i = 0; i < person.Age / 10; i++)
         {
             |
-Generated Location: (3236:105,9 [66] )
+Generated Location: (3792:112,9 [66] )
 |for (var i = 0; i < person.Age / 10; i++)
         {
             |
 
 Source Location: (586:27,18 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper.cshtml)
 |i|
-Generated Location: (3500:114,18 [1] )
+Generated Location: (4056:121,18 [1] )
 |i|
 
 Source Location: (609:27,41 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper.cshtml)
 |
         }|
-Generated Location: (3723:121,41 [11] )
+Generated Location: (4279:128,41 [11] )
 |
         }|
 
@@ -105,7 +105,7 @@ Source Location: (635:29,13 [106] TestFiles/IntegrationTests/CodeGenerationInteg
         }
 
         |
-Generated Location: (3927:129,13 [106] )
+Generated Location: (4483:136,13 [106] )
 |
 
         if (person.Age < 20)
@@ -127,7 +127,7 @@ Source Location: (764:36,31 [161] TestFiles/IntegrationTests/CodeGenerationInteg
         public int Age { get; set; }
     }
 |
-Generated Location: (4244:143,31 [161] )
+Generated Location: (4800:150,31 [161] )
 |
         return Task.CompletedTask;
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Markup_InCodeBlocksWithTagHelper_Runtime.codegen.cs
@@ -9,11 +9,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Markup_InCodeBlocksWithTagHelper_Runtime
     {
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MinimizedTagHelpers_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.CatchAllTagHelper __TestNamespace_CatchAllTagHelper;
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper;
         private global::DivTagHelper __DivTagHelper;
@@ -29,21 +34,28 @@ global::System.Object __typeHelper = "*, TestAssembly";
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __TestNamespace_InputTagHelper.BoundRequiredString = "hello";
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __TestNamespace_CatchAllTagHelper.BoundRequiredString = "world";
             __TestNamespace_InputTagHelper.BoundRequiredString = "hello2";
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __TestNamespace_InputTagHelper.BoundRequiredString = "world";
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
             __DivTagHelper.BoundBoolProp = true;
             __DivTagHelper.BoolDictProp["key"] = true;
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (771:15,37 [17] )
+Generated Location: (1179:20,37 [17] )
 |"*, TestAssembly"|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_Runtime.codegen.cs
@@ -16,11 +16,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_5 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("input-unbound-required", new global::Microsoft.AspNetCore.Html.HtmlString("hello2"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_6 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("input-bound-required-string", "world", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedScriptTagTagHelpers_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper;
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2;
@@ -54,6 +59,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #nullable restore
 #line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml"
                          
@@ -63,6 +69,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line hidden
 #nullable disable
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.mappings.txt
@@ -1,29 +1,29 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (803:15,37 [17] )
+Generated Location: (1211:20,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (195:5,13 [46] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |for(var i = 0; i < 5; i++) {
                 |
-Generated Location: (1320:32,13 [46] )
+Generated Location: (1728:37,13 [46] )
 |for(var i = 0; i < 5; i++) {
                 |
 
 Source Location: (339:7,50 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |ViewBag.DefaultInterval|
-Generated Location: (1796:42,50 [23] )
+Generated Location: (2204:47,50 [23] )
 |ViewBag.DefaultInterval|
 
 Source Location: (389:7,100 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |true|
-Generated Location: (2240:51,100 [4] )
+Generated Location: (2648:56,100 [4] )
 |true|
 
 Source Location: (422:8,25 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |
             }|
-Generated Location: (2442:58,25 [15] )
+Generated Location: (2926:64,25 [15] )
 |
             }|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.codegen.cs
@@ -12,11 +12,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-delay", new global::Microsoft.AspNetCore.Html.HtmlString("1000"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedTagHelpers_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::SpanTagHelper __SpanTagHelper;
         private global::DivTagHelper __DivTagHelper;
         private global::InputTagHelper __InputTagHelper;
@@ -29,9 +34,12 @@ global::System.Object __typeHelper = "*, TestAssembly";
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
             __SpanTagHelper = CreateTagHelper<global::SpanTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __InputTagHelper = CreateTagHelper<global::InputTagHelper>();
             __InputTagHelper.FooProp = "Hello";
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (702:15,38 [15] )
+Generated Location: (1110:20,38 [15] )
 |*, TestAssembly|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_Runtime.codegen.cs
@@ -12,11 +12,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("text"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlString("foo"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_PrefixedAttributeTagHelpers_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.InputTagHelper1 __TestNamespace_InputTagHelper1;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2;
         #pragma warning disable 219
@@ -61,6 +66,7 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty = intDictionary;
 #line hidden
 #nullable disable
             __TestNamespace_InputTagHelper2.StringDictionaryProperty = __TestNamespace_InputTagHelper1.StringDictionaryProperty;
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper1 = CreateTagHelper<global::TestNamespace.InputTagHelper1>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
 #nullable restore
@@ -87,6 +93,7 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty = intDictionary;
 #line hidden
 #nullable disable
             __TestNamespace_InputTagHelper2.IntDictionaryProperty["grabber"] = __TestNamespace_InputTagHelper1.IntProperty;
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper1 = CreateTagHelper<global::TestNamespace.InputTagHelper1>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
 #nullable restore
@@ -126,6 +133,7 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty["salt"] = 37;
 #nullable disable
             __TestNamespace_InputTagHelper1.StringDictionaryProperty["cumin"] = string.Empty;
             __TestNamespace_InputTagHelper2.StringDictionaryProperty["cumin"] = __TestNamespace_InputTagHelper1.StringDictionaryProperty["cumin"];
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper1 = CreateTagHelper<global::TestNamespace.InputTagHelper1>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
 #nullable restore
@@ -138,6 +146,7 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty["value"] = 37;
             __TestNamespace_InputTagHelper2.IntDictionaryProperty["value"] = __TestNamespace_InputTagHelper1.IntDictionaryProperty["value"];
             __TestNamespace_InputTagHelper1.StringDictionaryProperty["thyme"] = "string";
             __TestNamespace_InputTagHelper2.StringDictionaryProperty["thyme"] = __TestNamespace_InputTagHelper1.StringDictionaryProperty["thyme"];
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (731:14,37 [17] )
+Generated Location: (1139:19,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (37:2,2 [242] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
@@ -15,7 +15,7 @@ Source Location: (37:2,2 [242] TestFiles/IntegrationTests/CodeGenerationIntegrat
         { "name", "value" },
     };
 |
-Generated Location: (1239:31,2 [242] )
+Generated Location: (1647:36,2 [242] )
 |
     var literate = "or illiterate";
     var intDictionary = new Dictionary<string, int>
@@ -30,51 +30,51 @@ Generated Location: (1239:31,2 [242] )
 
 Source Location: (370:15,43 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |intDictionary|
-Generated Location: (1920:49,56 [13] )
+Generated Location: (2328:54,56 [13] )
 |intDictionary|
 
 Source Location: (404:15,77 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |stringDictionary|
-Generated Location: (2310:57,77 [16] )
+Generated Location: (2718:62,77 [16] )
 |stringDictionary|
 
 Source Location: (468:16,43 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |intDictionary|
-Generated Location: (2898:67,56 [13] )
+Generated Location: (3382:73,56 [13] )
 |intDictionary|
 
 Source Location: (502:16,77 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |37|
-Generated Location: (3288:75,77 [2] )
+Generated Location: (3772:81,77 [2] )
 |37|
 
 Source Location: (526:16,101 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |42|
-Generated Location: (3711:83,101 [2] )
+Generated Location: (4195:89,101 [2] )
 |42|
 
 Source Location: (590:18,31 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |42|
-Generated Location: (4270:93,46 [2] )
+Generated Location: (4830:100,46 [2] )
 |42|
 
 Source Location: (611:18,52 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |37|
-Generated Location: (4637:101,64 [2] )
+Generated Location: (5197:108,64 [2] )
 |37|
 
 Source Location: (634:18,75 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |98|
-Generated Location: (5030:109,75 [2] )
+Generated Location: (5590:116,75 [2] )
 |98|
 
 Source Location: (783:20,42 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |literate|
-Generated Location: (5850:121,42 [8] )
+Generated Location: (6410:128,42 [8] )
 |literate|
 
 Source Location: (826:21,29 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |37|
-Generated Location: (6552:132,65 [2] )
+Generated Location: (7188:140,65 [2] )
 |37|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_Runtime.codegen.cs
@@ -16,11 +16,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_5 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("string-prefix-paprika", "another string", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_6 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("string-prefix-thyme", "string", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SimpleTagHelpers_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::InputTagHelper __InputTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -28,6 +33,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
         {
             __InputTagHelper = CreateTagHelper<global::InputTagHelper>();
             __InputTagHelper.FooProp = "Hello";
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (592:13,38 [15] )
+Generated Location: (1000:18,38 [15] )
 |*, TestAssembly|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_Runtime.codegen.cs
@@ -11,11 +11,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("value", "Hello", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("text"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SingleTagHelperWithNewlineBeforeAttributes_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -34,6 +39,7 @@ __TestNamespace_PTagHelper.Age = 1337;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes.cshtml)
 |"*, TestAssembly"|
-Generated Location: (663:13,37 [17] )
+Generated Location: (1071:18,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (67:3,28 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes.cshtml)
 |1337|
-Generated Location: (1312:31,33 [4] )
+Generated Location: (1720:36,33 [4] )
 |1337|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_Runtime.codegen.cs
@@ -10,11 +10,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SingleTagHelper_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -34,6 +39,7 @@ __TestNamespace_PTagHelper.Age = 1337;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper.cshtml)
 |"*, TestAssembly"|
-Generated Location: (609:13,37 [17] )
+Generated Location: (1017:18,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (63:2,28 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper.cshtml)
 |1337|
-Generated Location: (1231:31,33 [4] )
+Generated Location: (1639:36,33 [4] )
 |1337|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_Runtime.codegen.cs
@@ -10,11 +10,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SymbolBoundAttributes_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.CatchAllTagHelper __TestNamespace_CatchAllTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -34,6 +39,7 @@ __TestNamespace_CatchAllTagHelper.ListItems = items;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
 #nullable restore
 #line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml"
@@ -42,6 +48,7 @@ __TestNamespace_CatchAllTagHelper.ArrayItems = items;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
 #nullable restore
 #line 14 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml"
@@ -50,6 +57,7 @@ __TestNamespace_CatchAllTagHelper.Event1 = doSomething();
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
 #nullable restore
 #line 15 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml"
@@ -58,11 +66,15 @@ __TestNamespace_CatchAllTagHelper.Event2 = doSomething();
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __TestNamespace_CatchAllTagHelper.StringProperty1 = "value";
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __TestNamespace_CatchAllTagHelper.StringProperty2 = "value";
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.mappings.txt
@@ -1,25 +1,25 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |*, TestAssembly|
-Generated Location: (636:13,38 [15] )
+Generated Location: (1044:18,38 [15] )
 |*, TestAssembly|
 
 Source Location: (302:11,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |items|
-Generated Location: (1291:31,46 [5] )
+Generated Location: (1699:36,46 [5] )
 |items|
 
 Source Location: (351:12,20 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |items|
-Generated Location: (1622:39,47 [5] )
+Generated Location: (2106:45,47 [5] )
 |items|
 
 Source Location: (405:13,23 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |doSomething()|
-Generated Location: (1949:47,43 [13] )
+Generated Location: (2509:54,43 [13] )
 |doSomething()|
 
 Source Location: (487:14,24 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |doSomething()|
-Generated Location: (2284:55,43 [13] )
+Generated Location: (2920:63,43 [13] )
 |doSomething()|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_Runtime.codegen.cs
@@ -17,11 +17,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_6 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("#local", "value", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_7 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("#local", new global::Microsoft.AspNetCore.Html.HtmlString("value"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersInSection_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.MyTagHelper __TestNamespace_MyTagHelper;
         private global::TestNamespace.NestedTagHelper __TestNamespace_NestedTagHelper;
         #pragma warning disable 219
@@ -64,6 +69,7 @@ global::System.Object nestedsection = null;
 #line hidden
 #nullable disable
                 __TestNamespace_NestedTagHelper = CreateTagHelper<global::TestNamespace.NestedTagHelper>();
+                await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 __TestNamespace_MyTagHelper = CreateTagHelper<global::TestNamespace.MyTagHelper>();
 #nullable restore
 #line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml"
@@ -80,7 +86,9 @@ global::System.Object nestedsection = null;
 #line default
 #line hidden
 #nullable disable
+                await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 __TestNamespace_NestedTagHelper = CreateTagHelper<global::TestNamespace.NestedTagHelper>();
+                await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             }
             );
         }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_DesignTime.mappings.txt
@@ -1,39 +1,39 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml)
 |"*, TestAssembly"|
-Generated Location: (707:14,37 [17] )
+Generated Location: (1115:19,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (82:6,9 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml)
 |MySection|
-Generated Location: (973:24,22 [9] )
+Generated Location: (1381:29,22 [9] )
 |MySection|
 
 Source Location: (388:14,13 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml)
 |nestedsection|
-Generated Location: (1239:34,22 [13] )
+Generated Location: (1647:39,22 [13] )
 |nestedsection|
 
 Source Location: (37:2,2 [31] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml)
 |
     var code = "some code";
 |
-Generated Location: (1742:51,2 [31] )
+Generated Location: (2150:56,2 [31] )
 |
     var code = "some code";
 |
 
 Source Location: (313:10,56 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml)
 |code|
-Generated Location: (2069:60,56 [4] )
+Generated Location: (2477:65,56 [4] )
 |code|
 
 Source Location: (157:8,51 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml)
 |DateTime.Now|
-Generated Location: (2501:69,51 [12] )
+Generated Location: (2989:75,51 [12] )
 |DateTime.Now|
 
 Source Location: (203:8,97 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml)
 |DateTime.Now|
-Generated Location: (2852:77,97 [12] )
+Generated Location: (3340:83,97 [12] )
 |DateTime.Now|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_Runtime.codegen.cs
@@ -9,11 +9,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersInSection_Runtime
     {
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithBoundAttributes_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::InputTagHelper __InputTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -35,6 +40,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line hidden
 #nullable disable
             __InputTagHelper.BoundProp = string.Empty;
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes.cshtml)
 |*, TestAssembly|
-Generated Location: (618:13,38 [15] )
+Generated Location: (1026:18,38 [15] )
 |*, TestAssembly|
 
 Source Location: (57:2,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes.cshtml)
 |Hello|
-Generated Location: (1218:31,18 [5] )
+Generated Location: (1626:36,18 [5] )
 |Hello|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_Runtime.codegen.cs
@@ -10,11 +10,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("text"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithDataDashAttributes_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithDataDashAttributes_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithDataDashAttributes_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::InputTagHelper __InputTagHelper;
         private global::DivTagHelper __DivTagHelper;
         #pragma warning disable 219
@@ -29,6 +34,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
         {
             __InputTagHelper = CreateTagHelper<global::InputTagHelper>();
             __InputTagHelper.BoundProp = "hello";
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
 #nullable restore
 #line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithDataDashAttributes.cshtml"
@@ -44,6 +50,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
 #nullable restore
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithDataDashAttributes.cshtml"
                                                        __o = foo;

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithDataDashAttributes_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithDataDashAttributes_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithDataDashAttributes.cshtml)
 |*, TestAssembly|
-Generated Location: (678:14,38 [15] )
+Generated Location: (1086:19,38 [15] )
 |*, TestAssembly|
 
 Source Location: (111:3,15 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithDataDashAttributes.cshtml)
 |foo|
-Generated Location: (1400:34,15 [3] )
+Generated Location: (1884:40,15 [3] )
 |foo|
 
 Source Location: (126:3,30 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithDataDashAttributes.cshtml)
 |bar|
-Generated Location: (1613:41,30 [3] )
+Generated Location: (2097:47,30 [3] )
 |bar|
 
 Source Location: (225:4,61 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithDataDashAttributes.cshtml)
 |foo|
-Generated Location: (1857:48,61 [3] )
+Generated Location: (2417:55,61 [3] )
 |foo|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithDataDashAttributes_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithDataDashAttributes_Runtime.codegen.cs
@@ -14,11 +14,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-three", new global::Microsoft.AspNetCore.Html.HtmlString(""), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-four", new global::Microsoft.AspNetCore.Html.HtmlString(""), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithPrefix_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::InputTagHelper __InputTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -45,6 +50,7 @@ global::System.Object __typeHelper = "cool:";
 #line hidden
 #nullable disable
             __InputTagHelper.BoundProp = string.Empty;
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml)
 |*, TestAssembly|
-Generated Location: (600:13,38 [15] )
+Generated Location: (1008:18,38 [15] )
 |*, TestAssembly|
 
 Source Location: (48:1,17 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml)
 |cool:|
-Generated Location: (882:23,38 [5] )
+Generated Location: (1290:28,38 [5] )
 |cool:|
 
 Source Location: (86:3,23 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml)
 |Hello|
-Generated Location: (1468:41,23 [5] )
+Generated Location: (1876:46,23 [5] )
 |Hello|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_Runtime.codegen.cs
@@ -10,11 +10,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("text"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithTemplate_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::DivTagHelper __DivTagHelper;
         private global::InputTagHelper __InputTagHelper;
         #pragma warning disable 219
@@ -46,7 +51,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line hidden
 #nullable disable
                 __InputTagHelper = CreateTagHelper<global::InputTagHelper>();
+                await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+                await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             }
             )
 #nullable restore
@@ -58,6 +65,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line hidden
 #nullable disable
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
 |"*, TestAssembly"|
-Generated Location: (657:14,37 [17] )
+Generated Location: (1065:19,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (333:12,6 [66] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
@@ -8,7 +8,7 @@ Source Location: (333:12,6 [66] TestFiles/IntegrationTests/CodeGenerationIntegra
         RenderTemplate(
             "Template: ",
             |
-Generated Location: (1165:31,6 [66] )
+Generated Location: (1573:36,6 [66] )
 |
         RenderTemplate(
             "Template: ",
@@ -16,13 +16,13 @@ Generated Location: (1165:31,6 [66] )
 
 Source Location: (427:15,40 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
 |item|
-Generated Location: (1511:42,40 [4] )
+Generated Location: (1919:47,40 [4] )
 |item|
 
 Source Location: (482:15,95 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
 |);
     |
-Generated Location: (1965:53,95 [8] )
+Generated Location: (2533:60,95 [8] )
 |);
     |
 
@@ -35,7 +35,7 @@ Source Location: (47:2,12 [268] TestFiles/IntegrationTests/CodeGenerationIntegra
         helperResult.WriteTo(Output, HtmlEncoder);
     }
 |
-Generated Location: (2274:64,12 [268] )
+Generated Location: (2918:72,12 [268] )
 |
     public void RenderTemplate(string title, Func<string, HelperResult> template)
     {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.codegen.cs
@@ -12,11 +12,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("checked", new global::Microsoft.AspNetCore.Html.HtmlString("true"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("condition", new global::Microsoft.AspNetCore.Html.HtmlString("true"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithWeirdlySpacedAttributes_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper;
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2;
@@ -43,10 +48,12 @@ __TestNamespace_PTagHelper.Age = 1337;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __TestNamespace_InputTagHelper.Type = "text";
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
 #nullable restore
 #line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml"
@@ -55,10 +62,12 @@ __TestNamespace_PTagHelper.Age = 1234;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __TestNamespace_InputTagHelper.Type = "password";
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |"*, TestAssembly"|
-Generated Location: (827:15,37 [17] )
+Generated Location: (1235:20,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (74:5,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |1337|
-Generated Location: (1471:33,33 [4] )
+Generated Location: (1879:38,33 [4] )
 |1337|
 
 Source Location: (99:6,19 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |true|
-Generated Location: (1679:40,19 [4] )
+Generated Location: (2087:45,19 [4] )
 |true|
 
 Source Location: (186:10,11 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |1234|
-Generated Location: (2353:52,33 [4] )
+Generated Location: (2913:59,33 [4] )
 |1234|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_Runtime.codegen.cs
@@ -15,11 +15,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "password", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_5 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-content", new global::Microsoft.AspNetCore.Html.HtmlString("blah"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.codegen.cs
@@ -5,6 +5,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TransitionsInTagHelperAttributes_DesignTime
     {
+        #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -43,6 +48,7 @@ __TestNamespace_PTagHelper.Age = 1337;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
 #nullable restore
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml"
@@ -58,6 +64,7 @@ __TestNamespace_PTagHelper.Age = 42;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
 #nullable restore
 #line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml"
@@ -66,6 +73,7 @@ __TestNamespace_PTagHelper.Age = 42 + @int;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
 #nullable restore
 #line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml"
@@ -74,6 +82,7 @@ __TestNamespace_PTagHelper.Age = int;
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
 #nullable restore
 #line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml"
@@ -82,6 +91,7 @@ __TestNamespace_PTagHelper.Age = (@int);
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
 #nullable restore
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml"
@@ -97,6 +107,7 @@ __TestNamespace_PTagHelper.Age = 4 * @(@int + 2);
 #line default
 #line hidden
 #nullable disable
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |"*, TestAssembly"|
-Generated Location: (643:13,37 [17] )
+Generated Location: (1051:18,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (35:1,2 [59] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
@@ -8,7 +8,7 @@ Source Location: (35:1,2 [59] TestFiles/IntegrationTests/CodeGenerationIntegrati
     var @class = "container-fluid";
     var @int = 1;
 |
-Generated Location: (1156:30,2 [59] )
+Generated Location: (1564:35,2 [59] )
 | 
     var @class = "container-fluid";
     var @int = 1;
@@ -16,101 +16,101 @@ Generated Location: (1156:30,2 [59] )
 
 Source Location: (122:6,23 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |1337|
-Generated Location: (1520:40,33 [4] )
+Generated Location: (1928:45,33 [4] )
 |1337|
 
 Source Location: (157:7,12 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@class|
-Generated Location: (1811:48,12 [6] )
+Generated Location: (2295:54,12 [6] )
 |@class|
 
 Source Location: (171:7,26 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |42|
-Generated Location: (2030:55,33 [2] )
+Generated Location: (2514:61,33 [2] )
 |42|
 
 Source Location: (202:8,21 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |42|
-Generated Location: (2340:63,33 [2] )
+Generated Location: (2900:70,33 [2] )
 |42|
 
 Source Location: (204:8,23 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | +|
-Generated Location: (2342:63,35 [2] )
+Generated Location: (2902:70,35 [2] )
 | +|
 
 Source Location: (206:8,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | |
-Generated Location: (2344:63,37 [1] )
+Generated Location: (2904:70,37 [1] )
 | |
 
 Source Location: (207:8,26 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@|
-Generated Location: (2345:63,38 [1] )
+Generated Location: (2905:70,38 [1] )
 |@|
 
 Source Location: (208:8,27 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |int|
-Generated Location: (2346:63,39 [3] )
+Generated Location: (2906:70,39 [3] )
 |int|
 
 Source Location: (241:9,22 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |int|
-Generated Location: (2658:71,33 [3] )
+Generated Location: (3294:79,33 [3] )
 |int|
 
 Source Location: (274:10,22 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |(|
-Generated Location: (2970:79,33 [1] )
+Generated Location: (3682:88,33 [1] )
 |(|
 
 Source Location: (275:10,23 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@int|
-Generated Location: (2971:79,34 [4] )
+Generated Location: (3683:88,34 [4] )
 |@int|
 
 Source Location: (279:10,27 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |)|
-Generated Location: (2975:79,38 [1] )
+Generated Location: (3687:88,38 [1] )
 |)|
 
 Source Location: (307:11,19 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@class|
-Generated Location: (3271:87,19 [6] )
+Generated Location: (4059:97,19 [6] )
 |@class|
 
 Source Location: (321:11,33 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |4|
-Generated Location: (3491:94,33 [1] )
+Generated Location: (4279:104,33 [1] )
 |4|
 
 Source Location: (322:11,34 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | *|
-Generated Location: (3492:94,34 [2] )
+Generated Location: (4280:104,34 [2] )
 | *|
 
 Source Location: (324:11,36 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | |
-Generated Location: (3494:94,36 [1] )
+Generated Location: (4282:104,36 [1] )
 | |
 
 Source Location: (325:11,37 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@|
-Generated Location: (3495:94,37 [1] )
+Generated Location: (4283:104,37 [1] )
 |@|
 
 Source Location: (326:11,38 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |(|
-Generated Location: (3496:94,38 [1] )
+Generated Location: (4284:104,38 [1] )
 |(|
 
 Source Location: (327:11,39 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@int + 2|
-Generated Location: (3497:94,39 [8] )
+Generated Location: (4285:104,39 [8] )
 |@int + 2|
 
 Source Location: (335:11,47 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |)|
-Generated Location: (3505:94,47 [1] )
+Generated Location: (4293:104,47 [1] )
 |)|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_Runtime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_Runtime.codegen.cs
@@ -10,11 +10,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("test"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
+        #pragma warning disable 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
+        #pragma warning restore 0649
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
         #pragma warning restore 0169
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
-        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
         {


### PR DESCRIPTION
- This is a pre-requisite to properly warnings users about TagHelpers in code blocks. With this change VS indicates that there's an asynchronous operation happening in a code block but because the code is auto-generated it happens behind the scenes and therefore always gets logged as a line 1 error (unusable). Therefore, to fix this issue there will be a partner PR that will go out in AspNetCore that adds analyzer errors for cases where `__tagHelperRunner.RunAsync` exists in code blocks that do not return `Task` and are not marked with `async` properly.
- Updated test files to reflect the new TagHelper codegen at design time.
- Note: This doesn't solve the `~/` case that will be in a follow up PR.

![image](https://user-images.githubusercontent.com/2008729/57801719-35a61a80-7709-11e9-8397-4904b6066354.png)

aspnet/AspNetCore#8630

