### PR TITLE
Fixed destructive property assignment bug for GetCopyToOutputDirectoryItems task

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -151,7 +151,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <GetCopyToOutputDirectoryItemsDependsOn>
       _RazorGetCopyToOutputDirectoryItems;
-      $(GetCopyToOutputDirectoryItems)
+      $(GetCopyToOutputDirectoryItemsDependsOn)
     </GetCopyToOutputDirectoryItemsDependsOn>
 
   </PropertyGroup>


### PR DESCRIPTION
The content of `$(GetCopyToOutputDirectoryItemsDependsOn)` was being erroneously overwritten by a typo in the assignment.

The intention by the original contributor would have been to add to the existing GetCopyToOutputDirectoryItemsDependsOn property, defined in Microsoft.Common.Targets. Instead what was happening is that it was being completely overwitten with the _RazorGetCopyToOutputDirectoryItems entry, given that $(GetCopyToOutputDirectoryItems) doesn't exist as a property and must have been a typo (it exists as a task, not a property).

An effect of this bug was that the `AssignTargetPaths` target is not always executed before the `GetCopyToOutputDirectoryItems` target, which should explicitly depend on it. `AssignTargetPaths` is responsible for populating the `ContentWithTargetPath` itemgroup. Left empty, it appears to `GetCopyToOutputDirectoryItems` task that there are no Content files to copy to the final output directory, when in fact there are.
