### PR TITLE
Fix bug in bind lowering logic

### DIFF
--- a/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -2573,6 +2573,7 @@ namespace Test
             // Act
             var generated = CompileToCSharp(@"
 <MyComponent bind-Item=Value/>
+<MyComponent bind-Item=Value/>
 @code {
     string Value;
 }");

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.codegen.cs
@@ -37,10 +37,27 @@ __o = typeof(MyComponent<>);
 #line default
 #line hidden
 #nullable disable
+            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_1(builder, -1, -1, Microsoft.AspNetCore.Components.BindMethods.GetValue(
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                       Value
+
+#line default
+#line hidden
+#nullable disable
+            ), -1, 
+            __value => Value = __value);
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+__o = typeof(MyComponent<>);
+
+#line default
+#line hidden
+#nullable disable
         }
         #pragma warning restore 1998
 #nullable restore
-#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+#line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
        
     string Value;
 
@@ -55,6 +72,13 @@ namespace __Blazor.Test.TestComponent
     internal static class TypeInference
     {
         public static void CreateMyComponent_0<TItem>(global::Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int seq, int __seq0, TItem __arg0, int __seq1, global::System.Action<TItem> __arg1)
+        {
+        builder.OpenComponent<global::Test.MyComponent<TItem>>(seq);
+        builder.AddAttribute(__seq0, "Item", __arg0);
+        builder.AddAttribute(__seq1, "ItemChanged", __arg1);
+        builder.CloseComponent();
+        }
+        public static void CreateMyComponent_1<TItem>(global::Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int seq, int __seq0, TItem __arg0, int __seq1, global::System.Action<TItem> __arg1)
         {
         builder.OpenComponent<global::Test.MyComponent<TItem>>(seq);
         builder.AddAttribute(__seq0, "Item", __arg0);

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.ir.txt
@@ -25,8 +25,20 @@ Document -
                             IntermediateToken -  - CSharp - __value => Value = __value
                 HtmlContent - (30:0,30 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (30:0,30 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-            CSharpCode - (39:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (39:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    string Value;\n
+                Component - (32:1,0 [30] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
+                    ComponentAttribute - (55:1,23 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
+                        CSharpExpression - 
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken - (55:1,23 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
+                            IntermediateToken -  - CSharp - )
+                    ComponentAttribute - (55:1,23 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes
+                        CSharpExpression - 
+                            IntermediateToken -  - CSharp - __value => Value = __value
+                HtmlContent - (62:1,30 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (62:1,30 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (71:2,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (71:2,7 [21] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    string Value;\n
     NamespaceDeclaration -  - __Blazor.Test.TestComponent
         ClassDeclaration -  - internal static - TypeInference -  - 
             ComponentTypeInferenceMethod -  - __Blazor.Test.TestComponent.TypeInference - CreateMyComponent_0
+            ComponentTypeInferenceMethod -  - __Blazor.Test.TestComponent.TypeInference - CreateMyComponent_1

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.mappings.txt
@@ -3,11 +3,16 @@ Source Location: (23:0,23 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1012:25,23 [5] )
 |Value|
 
-Source Location: (39:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (55:1,23 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1521:42,23 [5] )
+|Value|
+
+Source Location: (71:2,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1408:43,7 [21] )
+Generated Location: (1917:60,7 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.codegen.cs
@@ -22,10 +22,20 @@ namespace Test
 #line hidden
 #nullable disable
             ), 2, __value => Value = __value);
+            builder.AddMarkupContent(3, "\r\n");
+            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_1(builder, 4, 5, Microsoft.AspNetCore.Components.BindMethods.GetValue(
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                       Value
+
+#line default
+#line hidden
+#nullable disable
+            ), 6, __value => Value = __value);
         }
         #pragma warning restore 1998
 #nullable restore
-#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+#line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
        
     string Value;
 
@@ -40,6 +50,13 @@ namespace __Blazor.Test.TestComponent
     internal static class TypeInference
     {
         public static void CreateMyComponent_0<TItem>(global::Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int seq, int __seq0, TItem __arg0, int __seq1, global::System.Action<TItem> __arg1)
+        {
+        builder.OpenComponent<global::Test.MyComponent<TItem>>(seq);
+        builder.AddAttribute(__seq0, "Item", __arg0);
+        builder.AddAttribute(__seq1, "ItemChanged", __arg1);
+        builder.CloseComponent();
+        }
+        public static void CreateMyComponent_1<TItem>(global::Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int seq, int __seq0, TItem __arg0, int __seq1, global::System.Action<TItem> __arg1)
         {
         builder.OpenComponent<global::Test.MyComponent<TItem>>(seq);
         builder.AddAttribute(__seq0, "Item", __arg0);

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.ir.txt
@@ -16,8 +16,20 @@ Document -
                     ComponentAttribute - (23:0,23 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => Value = __value
-            CSharpCode - (39:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (39:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    string Value;\n
+                HtmlContent - (30:0,30 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (30:0,30 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+                Component - (32:1,0 [30] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
+                    ComponentAttribute - (55:1,23 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
+                        CSharpExpression - 
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken - (55:1,23 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
+                            IntermediateToken -  - CSharp - )
+                    ComponentAttribute - (55:1,23 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes
+                        CSharpExpression - 
+                            IntermediateToken -  - CSharp - __value => Value = __value
+            CSharpCode - (71:2,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (71:2,7 [21] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    string Value;\n
     NamespaceDeclaration -  - __Blazor.Test.TestComponent
         ClassDeclaration -  - internal static - TypeInference -  - 
             ComponentTypeInferenceMethod -  - __Blazor.Test.TestComponent.TypeInference - CreateMyComponent_0
+            ComponentTypeInferenceMethod -  - __Blazor.Test.TestComponent.TypeInference - CreateMyComponent_1

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.mappings.txt
@@ -1,8 +1,8 @@
-Source Location: (39:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (71:2,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (973:28,7 [21] )
+Generated Location: (1365:38,7 [21] )
 |
     string Value;
 |


### PR DESCRIPTION
Unblocks https://github.com/aspnet/AspNetCore/pull/10434

Before this I was not differentiating attributes with the same name in two different elements when collecting bind and bind:parameter attributes.