### PR TITLE
Update completion facts service to use providers.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    [Shared]
+    [Export(typeof(RazorCompletionItemProvider))]
+    internal class DirectiveCompletionItemProvider : RazorCompletionItemProvider
+    {
+        private static readonly IEnumerable<DirectiveDescriptor> DefaultDirectives = new[]
+        {
+            CSharpCodeParser.AddTagHelperDirectiveDescriptor,
+            CSharpCodeParser.RemoveTagHelperDirectiveDescriptor,
+            CSharpCodeParser.TagHelperPrefixDirectiveDescriptor,
+        };
+
+        public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorSyntaxTree syntaxTree, TagHelperDocumentContext tagHelperDocumentContext, SourceSpan location)
+        {
+            if (syntaxTree is null)
+            {
+                throw new ArgumentNullException(nameof(syntaxTree));
+            }
+
+            var completions = new List<RazorCompletionItem>();
+            if (AtDirectiveCompletionPoint(syntaxTree, location))
+            {
+                var directiveCompletions = GetDirectiveCompletionItems(syntaxTree);
+                completions.AddRange(directiveCompletions);
+            }
+
+            return completions;
+        }
+
+        // Internal for testing
+        internal static bool AtDirectiveCompletionPoint(RazorSyntaxTree syntaxTree, SourceSpan location)
+        {
+            if (syntaxTree == null)
+            {
+                return false;
+            }
+
+            var change = new SourceChange(location, string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(change);
+
+            if (owner == null)
+            {
+                return false;
+            }
+
+            // Do not provide IntelliSense for explicit expressions. Explicit expressions will usually look like:
+            // [@] [(] [DateTime.Now] [)]
+            var isImplicitExpression = owner.FirstAncestorOrSelf<CSharpImplicitExpressionSyntax>() != null;
+            if (isImplicitExpression &&
+                owner.ChildNodes().All(n => n.IsToken && IsDirectiveCompletableToken((AspNetCore.Razor.Language.Syntax.SyntaxToken)n)))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        // Internal for testing
+        internal static List<RazorCompletionItem> GetDirectiveCompletionItems(RazorSyntaxTree syntaxTree)
+        {
+            var defaultDirectives = FileKinds.IsComponent(syntaxTree.Options.FileKind) ? Array.Empty<DirectiveDescriptor>() : DefaultDirectives;
+            var directives = syntaxTree.Options.Directives.Concat(defaultDirectives);
+            var completionItems = new List<RazorCompletionItem>();
+            foreach (var directive in directives)
+            {
+                var completionDisplayText = directive.DisplayName ?? directive.Directive;
+                var completionItem = new RazorCompletionItem(
+                    completionDisplayText,
+                    directive.Directive,
+                    directive.Description,
+                    RazorCompletionItemKind.Directive);
+                completionItems.Add(completionItem);
+            }
+
+            return completionItems;
+        }
+
+        // Internal for testing
+        internal static bool IsDirectiveCompletableToken(AspNetCore.Razor.Language.Syntax.SyntaxToken token)
+        {
+            return token.Kind == SyntaxKind.Identifier ||
+                // Marker symbol
+                token.Kind == SyntaxKind.Marker;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
@@ -2,10 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion
 {
-    internal sealed class RazorCompletionItem
+    internal sealed class RazorCompletionItem : IEquatable<RazorCompletionItem>
     {
         public RazorCompletionItem(
             string displayText, 
@@ -41,5 +42,51 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public string Description { get; }
 
         public RazorCompletionItemKind Kind { get; }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as RazorCompletionItem);
+        }
+
+        public bool Equals(RazorCompletionItem other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (!string.Equals(DisplayText, other.DisplayText, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (!string.Equals(InsertText, other.InsertText, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (!string.Equals(Description, other.Description, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (Kind != other.Kind)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCodeCombiner = HashCodeCombiner.Start();
+            hashCodeCombiner.Add(DisplayText);
+            hashCodeCombiner.Add(InsertText);
+            hashCodeCombiner.Add(Description);
+            hashCodeCombiner.Add(Kind);
+
+            return hashCodeCombiner.CombinedHash;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemProvider.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    internal abstract class RazorCompletionItemProvider
+    {
+        public abstract IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorSyntaxTree syntaxTree, TagHelperDocumentContext tagHelperDocumentContext, SourceSpan location);
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
@@ -1,257 +1,32 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
-using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Moq;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion
 {
     public class DefaultRazorCompletionFactsServiceTest
     {
-        private static readonly IReadOnlyList<DirectiveDescriptor> DefaultDirectives = new[]
-        {
-            CSharpCodeParser.AddTagHelperDirectiveDescriptor,
-            CSharpCodeParser.RemoveTagHelperDirectiveDescriptor,
-            CSharpCodeParser.TagHelperPrefixDirectiveDescriptor,
-        };
-
         [Fact]
-        public void GetDirectiveCompletionItems_ReturnsDefaultDirectivesAsCompletionItems()
+        public void GetDirectiveCompletionItems_AllProvidersCompletionItems()
         {
             // Arrange
-            var syntaxTree = CreateSyntaxTree("@addTag");
+            var syntaxTree = RazorSyntaxTree.Parse(TestRazorSourceDocument.Create());
+            var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: null, Enumerable.Empty<TagHelperDescriptor>());
+            var completionItem1 = new RazorCompletionItem("displayText1", "insertText1", "description1", RazorCompletionItemKind.Directive);
+            var provider1 = Mock.Of<RazorCompletionItemProvider>(p => p.GetCompletionItems(syntaxTree, tagHelperDocumentContext, default) == new[] { completionItem1 });
+            var completionItem2 = new RazorCompletionItem("displayText2", "insertText2", "description2", RazorCompletionItemKind.Directive);
+            var provider2 = Mock.Of<RazorCompletionItemProvider>(p => p.GetCompletionItems(syntaxTree, tagHelperDocumentContext, default) == new[] { completionItem2 });
+            var completionFactsService = new DefaultRazorCompletionFactsService(new[] { provider1, provider2 });
 
             // Act
-            var completionItems = DefaultRazorCompletionFactsService.GetDirectiveCompletionItems(syntaxTree);
+            var completionItems = completionFactsService.GetCompletionItems(syntaxTree, tagHelperDocumentContext, default);
 
             // Assert
-            Assert.Collection(
-                completionItems,
-                item => AssertRazorCompletionItem(DefaultDirectives[0], item),
-                item => AssertRazorCompletionItem(DefaultDirectives[1], item),
-                item => AssertRazorCompletionItem(DefaultDirectives[2], item));
-        }
-
-        [Fact]
-        public void GetDirectiveCompletionItems_ReturnsCustomDirectivesAsCompletionItems()
-        {
-            // Arrange
-            var customDirective = DirectiveDescriptor.CreateSingleLineDirective("custom", builder =>
-            {
-                builder.Description = "My Custom Directive.";
-            });
-            var syntaxTree = CreateSyntaxTree("@addTag", customDirective);
-
-            // Act
-            var completionItems = DefaultRazorCompletionFactsService.GetDirectiveCompletionItems(syntaxTree);
-
-            // Assert
-            Assert.Collection(
-                completionItems,
-                item => AssertRazorCompletionItem(customDirective, item),
-                item => AssertRazorCompletionItem(DefaultDirectives[0], item),
-                item => AssertRazorCompletionItem(DefaultDirectives[1], item),
-                item => AssertRazorCompletionItem(DefaultDirectives[2], item));
-        }
-
-        [Fact]
-        public void GetDirectiveCompletionItems_UsesDisplayNamesWhenNotNull()
-        {
-            // Arrange
-            var customDirective = DirectiveDescriptor.CreateSingleLineDirective("custom", builder =>
-            {
-                builder.DisplayName = "different";
-                builder.Description = "My Custom Directive.";
-            });
-            var syntaxTree = CreateSyntaxTree("@addTag", customDirective);
-
-            // Act
-            var completionItems = DefaultRazorCompletionFactsService.GetDirectiveCompletionItems(syntaxTree);
-
-            // Assert
-            Assert.Collection(
-                completionItems,
-                item => AssertRazorCompletionItem("different", customDirective, item),
-                item => AssertRazorCompletionItem(DefaultDirectives[0], item),
-                item => AssertRazorCompletionItem(DefaultDirectives[1], item),
-                item => AssertRazorCompletionItem(DefaultDirectives[2], item));
-        }
-
-        [Fact]
-        public void GetDirectiveCompletionItems_ComponentDocument_DoesNotReturnsDefaultDirectivesAsCompletionItems()
-        {
-            // Arrange
-            var syntaxTree = CreateSyntaxTree("@addTag", FileKinds.Component);
-
-            // Act
-            var completionItems = DefaultRazorCompletionFactsService.GetDirectiveCompletionItems(syntaxTree);
-
-            // Assert
-            Assert.Empty(completionItems);
-        }
-
-        [Fact]
-        public void AtDirectiveCompletionPoint_ReturnsFalseIfSyntaxTreeNull()
-        {
-            // Act
-            var result = DefaultRazorCompletionFactsService.AtDirectiveCompletionPoint(syntaxTree: null, location: new SourceSpan(0, 0));
-
-            // Assert
-            Assert.False(result);
-        }
-
-        [Fact]
-        public void AtDirectiveCompletionPoint_ReturnsFalseIfNoOwner()
-        {
-            // Arrange
-            var syntaxTree = CreateSyntaxTree("@");
-            var location = new SourceSpan(2, 0);
-
-            // Act
-            var result = DefaultRazorCompletionFactsService.AtDirectiveCompletionPoint(syntaxTree, location);
-
-            // Assert
-            Assert.False(result);
-        }
-
-        [Fact]
-        public void AtDirectiveCompletionPoint_ReturnsFalseWhenOwnerIsNotExpression()
-        {
-            // Arrange
-            var syntaxTree = CreateSyntaxTree("@{");
-            var location = new SourceSpan(2, 0);
-
-            // Act
-            var result = DefaultRazorCompletionFactsService.AtDirectiveCompletionPoint(syntaxTree, location);
-
-            // Assert
-            Assert.False(result);
-        }
-
-        [Fact]
-        public void AtDirectiveCompletionPoint_ReturnsFalseWhenOwnerIsComplexExpression()
-        {
-            // Arrange
-            var syntaxTree = CreateSyntaxTree("@DateTime.Now");
-            var location = new SourceSpan(2, 0);
-
-            // Act
-            var result = DefaultRazorCompletionFactsService.AtDirectiveCompletionPoint(syntaxTree, location);
-
-            // Assert
-            Assert.False(result);
-        }
-
-        [Fact]
-        public void AtDirectiveCompletionPoint_ReturnsFalseWhenOwnerIsExplicitExpression()
-        {
-            // Arrange
-            var syntaxTree = CreateSyntaxTree("@(something)");
-            var location = new SourceSpan(4, 0);
-
-            // Act
-            var result = DefaultRazorCompletionFactsService.AtDirectiveCompletionPoint(syntaxTree, location);
-
-            // Assert
-            Assert.False(result);
-        }
-
-        [Fact]
-        public void AtDirectiveCompletionPoint_ReturnsTrueForSimpleImplicitExpressions()
-        {
-            // Arrange
-            var syntaxTree = CreateSyntaxTree("@mod");
-            var location = new SourceSpan(2, 0);
-
-            // Act
-            var result = DefaultRazorCompletionFactsService.AtDirectiveCompletionPoint(syntaxTree, location);
-
-            // Assert
-            Assert.True(result);
-        }
-
-        [Fact]
-        public void IsDirectiveCompletableToken_ReturnsTrueForCSharpIdentifiers()
-        {
-            // Arrange
-            var csharpToken = SyntaxFactory.Token(SyntaxKind.Identifier, "model");
-
-            // Act
-            var result = DefaultRazorCompletionFactsService.IsDirectiveCompletableToken(csharpToken);
-
-            // Assert
-            Assert.True(result);
-        }
-
-        [Fact]
-        public void IsDirectiveCompletableToken_ReturnsTrueForCSharpMarkerTokens()
-        {
-            // Arrange
-            var csharpToken = SyntaxFactory.Token(SyntaxKind.Marker, string.Empty);
-
-            // Act
-            var result = DefaultRazorCompletionFactsService.IsDirectiveCompletableToken(csharpToken);
-
-            // Assert
-            Assert.True(result);
-        }
-
-        [Fact]
-        public void IsDirectiveCompletableToken_ReturnsFalseForNonCSharpTokens()
-        {
-            // Arrange
-            var token = SyntaxFactory.Token(SyntaxKind.Text, string.Empty);
-
-            // Act
-            var result = DefaultRazorCompletionFactsService.IsDirectiveCompletableToken(token);
-
-            // Assert
-            Assert.False(result);
-        }
-
-        [Fact]
-        public void IsDirectiveCompletableToken_ReturnsFalseForInvalidCSharpTokens()
-        {
-            // Arrange
-            var csharpToken = SyntaxFactory.Token(SyntaxKind.Tilde, "~");
-
-            // Act
-            var result = DefaultRazorCompletionFactsService.IsDirectiveCompletableToken(csharpToken);
-
-            // Assert
-            Assert.False(result);
-        }
-
-        private static void AssertRazorCompletionItem(string completionDisplayText, DirectiveDescriptor directive, RazorCompletionItem item)
-        {
-            Assert.Equal(item.DisplayText, completionDisplayText);
-            Assert.Equal(item.InsertText, directive.Directive);
-            Assert.Equal(directive.Description, item.Description);
-        }
-
-        private static void AssertRazorCompletionItem(DirectiveDescriptor directive, RazorCompletionItem item) =>
-            AssertRazorCompletionItem(directive.Directive, directive, item);
-
-        private static RazorSyntaxTree CreateSyntaxTree(string text, params DirectiveDescriptor[] directives)
-        {
-            return CreateSyntaxTree(text, FileKinds.Legacy, directives);
-        }
-
-        private static RazorSyntaxTree CreateSyntaxTree(string text, string fileKind, params DirectiveDescriptor[] directives)
-        {
-            var sourceDocument = TestRazorSourceDocument.Create(text);
-            var options = RazorParserOptions.Create(builder =>
-            {
-                foreach (var directive in directives)
-                {
-                    builder.Directives.Add(directive);
-                }
-            }, fileKind);
-            var syntaxTree = RazorSyntaxTree.Parse(sourceDocument, options);
-            return syntaxTree;
+            Assert.Equal(new[] { completionItem1, completionItem2 }, completionItems);
         }
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -1,0 +1,258 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Moq;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    public class DirectiveCompletionItemProviderTest
+    {
+        private static readonly IReadOnlyList<DirectiveDescriptor> DefaultDirectives = new[]
+        {
+            CSharpCodeParser.AddTagHelperDirectiveDescriptor,
+            CSharpCodeParser.RemoveTagHelperDirectiveDescriptor,
+            CSharpCodeParser.TagHelperPrefixDirectiveDescriptor,
+        };
+
+        [Fact]
+        public void GetDirectiveCompletionItems_ReturnsDefaultDirectivesAsCompletionItems()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("@addTag");
+
+            // Act
+            var completionItems = DirectiveCompletionItemProvider.GetDirectiveCompletionItems(syntaxTree);
+
+            // Assert
+            Assert.Collection(
+                completionItems,
+                item => AssertRazorCompletionItem(DefaultDirectives[0], item),
+                item => AssertRazorCompletionItem(DefaultDirectives[1], item),
+                item => AssertRazorCompletionItem(DefaultDirectives[2], item));
+        }
+
+        [Fact]
+        public void GetDirectiveCompletionItems_ReturnsCustomDirectivesAsCompletionItems()
+        {
+            // Arrange
+            var customDirective = DirectiveDescriptor.CreateSingleLineDirective("custom", builder =>
+            {
+                builder.Description = "My Custom Directive.";
+            });
+            var syntaxTree = CreateSyntaxTree("@addTag", customDirective);
+
+            // Act
+            var completionItems = DirectiveCompletionItemProvider.GetDirectiveCompletionItems(syntaxTree);
+
+            // Assert
+            Assert.Collection(
+                completionItems,
+                item => AssertRazorCompletionItem(customDirective, item),
+                item => AssertRazorCompletionItem(DefaultDirectives[0], item),
+                item => AssertRazorCompletionItem(DefaultDirectives[1], item),
+                item => AssertRazorCompletionItem(DefaultDirectives[2], item));
+        }
+
+        [Fact]
+        public void GetDirectiveCompletionItems_UsesDisplayNamesWhenNotNull()
+        {
+            // Arrange
+            var customDirective = DirectiveDescriptor.CreateSingleLineDirective("custom", builder =>
+            {
+                builder.DisplayName = "different";
+                builder.Description = "My Custom Directive.";
+            });
+            var syntaxTree = CreateSyntaxTree("@addTag", customDirective);
+
+            // Act
+            var completionItems = DirectiveCompletionItemProvider.GetDirectiveCompletionItems(syntaxTree);
+
+            // Assert
+            Assert.Collection(
+                completionItems,
+                item => AssertRazorCompletionItem("different", customDirective, item),
+                item => AssertRazorCompletionItem(DefaultDirectives[0], item),
+                item => AssertRazorCompletionItem(DefaultDirectives[1], item),
+                item => AssertRazorCompletionItem(DefaultDirectives[2], item));
+        }
+
+        [Fact]
+        public void GetDirectiveCompletionItems_ComponentDocument_DoesNotReturnsDefaultDirectivesAsCompletionItems()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("@addTag", FileKinds.Component);
+
+            // Act
+            var completionItems = DirectiveCompletionItemProvider.GetDirectiveCompletionItems(syntaxTree);
+
+            // Assert
+            Assert.Empty(completionItems);
+        }
+
+        [Fact]
+        public void AtDirectiveCompletionPoint_ReturnsFalseIfSyntaxTreeNull()
+        {
+            // Act
+            var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree: null, location: new SourceSpan(0, 0));
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AtDirectiveCompletionPoint_ReturnsFalseIfNoOwner()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("@");
+            var location = new SourceSpan(2, 0);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AtDirectiveCompletionPoint_ReturnsFalseWhenOwnerIsNotExpression()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("@{");
+            var location = new SourceSpan(2, 0);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AtDirectiveCompletionPoint_ReturnsFalseWhenOwnerIsComplexExpression()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("@DateTime.Now");
+            var location = new SourceSpan(2, 0);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AtDirectiveCompletionPoint_ReturnsFalseWhenOwnerIsExplicitExpression()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("@(something)");
+            var location = new SourceSpan(4, 0);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AtDirectiveCompletionPoint_ReturnsTrueForSimpleImplicitExpressions()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("@mod");
+            var location = new SourceSpan(2, 0);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsDirectiveCompletableToken_ReturnsTrueForCSharpIdentifiers()
+        {
+            // Arrange
+            var csharpToken = SyntaxFactory.Token(SyntaxKind.Identifier, "model");
+
+            // Act
+            var result = DirectiveCompletionItemProvider.IsDirectiveCompletableToken(csharpToken);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsDirectiveCompletableToken_ReturnsTrueForCSharpMarkerTokens()
+        {
+            // Arrange
+            var csharpToken = SyntaxFactory.Token(SyntaxKind.Marker, string.Empty);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.IsDirectiveCompletableToken(csharpToken);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsDirectiveCompletableToken_ReturnsFalseForNonCSharpTokens()
+        {
+            // Arrange
+            var token = SyntaxFactory.Token(SyntaxKind.Text, string.Empty);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.IsDirectiveCompletableToken(token);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsDirectiveCompletableToken_ReturnsFalseForInvalidCSharpTokens()
+        {
+            // Arrange
+            var csharpToken = SyntaxFactory.Token(SyntaxKind.Tilde, "~");
+
+            // Act
+            var result = DirectiveCompletionItemProvider.IsDirectiveCompletableToken(csharpToken);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        private static void AssertRazorCompletionItem(string completionDisplayText, DirectiveDescriptor directive, RazorCompletionItem item)
+        {
+            Assert.Equal(item.DisplayText, completionDisplayText);
+            Assert.Equal(item.InsertText, directive.Directive);
+            Assert.Equal(directive.Description, item.Description);
+        }
+
+        private static void AssertRazorCompletionItem(DirectiveDescriptor directive, RazorCompletionItem item) =>
+            AssertRazorCompletionItem(directive.Directive, directive, item);
+
+        private static RazorSyntaxTree CreateSyntaxTree(string text, params DirectiveDescriptor[] directives)
+        {
+            return CreateSyntaxTree(text, FileKinds.Legacy, directives);
+        }
+
+        private static RazorSyntaxTree CreateSyntaxTree(string text, string fileKind, params DirectiveDescriptor[] directives)
+        {
+            var sourceDocument = TestRazorSourceDocument.Create(text);
+            var options = RazorParserOptions.Create(builder =>
+            {
+                foreach (var directive in directives)
+                {
+                    builder.Directives.Add(directive);
+                }
+            }, fileKind);
+            var syntaxTree = RazorSyntaxTree.Parse(sourceDocument, options);
+            return syntaxTree;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Moq;
@@ -152,6 +153,62 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             // Arrange
             var syntaxTree = CreateSyntaxTree("@(something)");
             var location = new SourceSpan(4, 0);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AtDirectiveCompletionPoint_ReturnsFalseWhenInsideStatement()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("@{ @ }");
+            var location = new SourceSpan(4, 0);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AtDirectiveCompletionPoint_ReturnsFalseWhenInsideMarkup()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("<p>@ </p>");
+            var location = new SourceSpan(4, 0);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AtDirectiveCompletionPoint_ReturnsFalseWhenInsideAttributeArea()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("<p @ >");
+            var location = new SourceSpan(4, 0);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AtDirectiveCompletionPoint_ReturnsFalseWhenInsideDirective()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("@functions { @  }", FunctionsDirective.Directive);
+            var location = new SourceSpan(14, 0);
 
             // Act
             var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorDirectiveCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorDirectiveCompletionProviderTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             CompletionBroker = Mock.Of<IAsyncCompletionBroker>(broker => broker.IsCompletionSupported(It.IsAny<IContentType>()) == true);
             var razorBuffer = Mock.Of<ITextBuffer>(buffer => buffer.ContentType == Mock.Of<IContentType>());
             TextBufferProvider = Mock.Of<RazorTextBufferProvider>(provider => provider.TryGetFromDocument(It.IsAny<TextDocument>(), out razorBuffer) == true);
-            CompletionFactsService = new DefaultRazorCompletionFactsService();
+            CompletionFactsService = new DefaultRazorCompletionFactsService(new[] { new DirectiveCompletionItemProvider() });
             CompletionProviderDependencies = new Lazy<CompletionProviderDependencies>(() => new DefaultCompletionProviderDependencies(CompletionFactsService, CompletionBroker));
         }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorDirectiveCompletionSourceTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -27,7 +28,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             CSharpCodeParser.TagHelperPrefixDirectiveDescriptor,
         };
 
-        private RazorCompletionFactsService CompletionFactsService { get; } = new DefaultRazorCompletionFactsService();
+        private RazorCompletionFactsService CompletionFactsService { get; } = new DefaultRazorCompletionFactsService(new[] { new DirectiveCompletionItemProvider() });
 
         [ForegroundFact]
         public async Task GetCompletionContextAsync_DoesNotProvideCompletionsPriorToParseResults()
@@ -156,6 +157,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var syntaxTree = CreateSyntaxTree(text, directives);
             var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create(text, RazorSourceDocumentProperties.Default));
             codeDocument.SetSyntaxTree(syntaxTree);
+            codeDocument.SetTagHelperContext(TagHelperDocumentContext.Create(prefix: null, Enumerable.Empty<TagHelperDescriptor>()));
             var parser = new Mock<VisualStudioRazorParser>();
             parser.Setup(p => p.GetLatestCodeDocumentAsync(It.IsAny<ITextSnapshot>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(codeDocument));


### PR DESCRIPTION
- Completions will be coming from multiple different sources in the future and in order to build a system that works in both VSCode, VSWindows and VSMac we need the ability to toggle certain types of completions on and off easily.
- Created a `DirectiveCompletionItemProvider` this was basically a direct copy from the facts service.
- Also moved tests from the facts service over to the new directive completion item provider.
- Made `RazorCompletionItem`s `IEquatable` to ease in testing now and in the future.

This is bullet point 2 of https://github.com/aspnet/AspNetCore/issues/6364#issuecomment-495432347

aspnet/AspNetCore#6364
