### PR TITLE
Make Razor directive completion provider more strict.

### DIFF
--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Moq;
@@ -152,6 +153,62 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             // Arrange
             var syntaxTree = CreateSyntaxTree("@(something)");
             var location = new SourceSpan(4, 0);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AtDirectiveCompletionPoint_ReturnsFalseWhenInsideStatement()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("@{ @ }");
+            var location = new SourceSpan(4, 0);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AtDirectiveCompletionPoint_ReturnsFalseWhenInsideMarkup()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("<p>@ </p>");
+            var location = new SourceSpan(4, 0);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AtDirectiveCompletionPoint_ReturnsFalseWhenInsideAttributeArea()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("<p @ >");
+            var location = new SourceSpan(4, 0);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AtDirectiveCompletionPoint_ReturnsFalseWhenInsideDirective()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("@functions { @  }", FunctionsDirective.Directive);
+            var location = new SourceSpan(14, 0);
 
             // Act
             var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);


### PR DESCRIPTION
- The directive completion provider no longer provides completions unless an implicit expression is at the top level (not nested).
- Added tests to validate the new functionality.

This is bullet point 3 of https://github.com/aspnet/AspNetCore/issues/6364#issuecomment-495432347

@ajaybhargavb / @rynowak if you guys can think of any other constructs make sense to ignore let me know.

aspnet/AspNetCore#6364
