### PR TITLE
Add support for directive attribute completion names.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AttributeCompletionDescription.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AttributeCompletionDescription.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    internal class AttributeCompletionDescription
+    {
+        public AttributeCompletionDescription(IReadOnlyList<AttributeDescriptionInfo> descriptionInfos)
+        {
+            if (descriptionInfos == null)
+            {
+                throw new ArgumentNullException(nameof(descriptionInfos));
+            }
+
+            DescriptionInfos = descriptionInfos;
+        }
+
+        public IReadOnlyList<AttributeDescriptionInfo> DescriptionInfos { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AttributeDescriptionInfo.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AttributeDescriptionInfo.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    internal sealed class AttributeDescriptionInfo : IEquatable<AttributeDescriptionInfo>
+    {
+        public AttributeDescriptionInfo(
+            string returnTypeName,
+            string typeName,
+            string propertyName,
+            string documentation)
+        {
+            if (returnTypeName is null)
+            {
+                throw new ArgumentNullException(nameof(returnTypeName));
+            }
+
+            if (typeName is null)
+            {
+                throw new ArgumentNullException(nameof(typeName));
+            }
+
+            if (propertyName is null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            ReturnTypeName = returnTypeName;
+            TypeName = typeName;
+            PropertyName = propertyName;
+            Documentation = documentation ?? string.Empty;
+        }
+
+        public string ReturnTypeName { get; }
+
+        public string TypeName { get; }
+
+        public string PropertyName { get; }
+
+        public string Documentation { get; }
+
+        public bool Equals(AttributeDescriptionInfo other)
+        {
+            if (!string.Equals(ReturnTypeName, other.ReturnTypeName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (!string.Equals(TypeName, other.TypeName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (!string.Equals(PropertyName, other.PropertyName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (!string.Equals(Documentation, other.Documentation, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = HashCodeCombiner.Start();
+            combiner.Add(ReturnTypeName);
+            combiner.Add(TypeName);
+            combiner.Add(PropertyName);
+            combiner.Add(Documentation);
+
+            return combiner.CombinedHash;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -1,0 +1,171 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.VisualStudio.Editor.Razor;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    [Shared]
+    [Export(typeof(RazorCompletionItemProvider))]
+    internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeCompletionItemProviderBase
+    {
+        private readonly TagHelperFactsService _tagHelperFactsService;
+
+        [ImportingConstructor]
+        public DirectiveAttributeCompletionItemProvider(TagHelperFactsService tagHelperFactsService)
+        {
+            if (tagHelperFactsService is null)
+            {
+                throw new ArgumentNullException(nameof(tagHelperFactsService));
+            }
+
+            _tagHelperFactsService = tagHelperFactsService;
+        }
+
+        public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorSyntaxTree syntaxTree, TagHelperDocumentContext tagHelperDocumentContext, SourceSpan location)
+        {
+            if (syntaxTree is null)
+            {
+                throw new ArgumentNullException(nameof(syntaxTree));
+            }
+
+            if (tagHelperDocumentContext is null)
+            {
+                throw new ArgumentNullException(nameof(tagHelperDocumentContext));
+            }
+
+            if (!FileKinds.IsComponent(syntaxTree.Options.FileKind))
+            {
+                // Directive attributes are only supported in components
+                return Array.Empty<RazorCompletionItem>();
+            }
+
+            var change = new SourceChange(location, string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(change);
+
+            if (owner == null)
+            {
+                return Array.Empty<RazorCompletionItem>();
+            }
+
+            if (!TryGetAttributeInfo(owner, out var attributeName, out var attributeNameLocation, out _, out _))
+            {
+                // Either we're not in an attribute or the attribute is so malformed that we can't provide proper completions.
+                return Array.Empty<RazorCompletionItem>();
+            }
+
+            if (!attributeNameLocation.IntersectsWith(location.AbsoluteIndex))
+            {
+                // We're trying to retrieve completions on a portion of the name that is not supported (such as a parameter).
+                return Array.Empty<RazorCompletionItem>();
+            }
+
+            if (!TryGetElementInfo(owner.Parent.Parent, out var containingTagName, out var attributes))
+            {
+                // This should never be the case, it means that we're operating on an attribute that doesn't have a tag.
+                return Array.Empty<RazorCompletionItem>();
+            }
+
+            // At this point we've determined that completions have been requested for the name portion of the selected attribute.
+
+            var completionItems = GetAttributeCompletions(attributeName, containingTagName, attributes, tagHelperDocumentContext);
+
+            return completionItems;
+        }
+
+        // Internal for testing
+        internal IReadOnlyList<RazorCompletionItem> GetAttributeCompletions(
+            string selectedAttributeName,
+            string containingTagName,
+            IEnumerable<string> attributes,
+            TagHelperDocumentContext tagHelperDocumentContext)
+        {
+            var descriptorsForTag = _tagHelperFactsService.GetTagHelpersGivenTag(tagHelperDocumentContext, containingTagName, parentTag: null);
+            if (descriptorsForTag.Count == 0)
+            {
+                // If the current tag has no possible descriptors then we can't have any directive attributes.
+                return Array.Empty<RazorCompletionItem>();
+            }
+
+            // Attributes are case sensitive when matching
+            var attributeCompletions = new HashSet<string>(StringComparer.Ordinal);
+            for (var i = 0; i < descriptorsForTag.Count; i++)
+            {
+                var descriptor = descriptorsForTag[i];
+
+                foreach (var attributeDescriptor in descriptor.BoundAttributes)
+                {
+                    if (!attributeDescriptor.IsDirectiveAttribute())
+                    {
+                        // We don't care about non-directive attributes
+                        continue;
+                    }
+
+                    if (!TryAddCompletion(attributeDescriptor.Name) && attributeDescriptor.BoundAttributeParameters.Count > 0)
+                    {
+                        // This attribute has parameters and the base attribute name (@bind) is already satisfied. We need to check if there are any valid
+                        // parameters left to be provided, if so, we need to still represent the base attribute name in the completion list.
+
+                        for (var j = 0; j < attributeDescriptor.BoundAttributeParameters.Count; j++)
+                        {
+                            var parameterDescriptor = attributeDescriptor.BoundAttributeParameters[j];
+                            if (!attributes.Any(name => TagHelperMatchingConventions.SatisfiesBoundAttributeWithParameter(name, attributeDescriptor, parameterDescriptor)))
+                            {
+                                // This bound attribute parameter has not had a completion entry added for it, re-represent the base attribute name in the completion list
+                                attributeCompletions.Add(attributeDescriptor.Name);
+                                break;
+                            }
+                        }
+                    }
+
+                    if (!string.IsNullOrEmpty(attributeDescriptor.IndexerNamePrefix))
+                    {
+                        TryAddCompletion(attributeDescriptor.IndexerNamePrefix + "...");
+                    }
+                }
+            }
+
+            var completionItems = new List<RazorCompletionItem>();
+            foreach (var completion in attributeCompletions)
+            {
+                var insertText = completion;
+                if (insertText.EndsWith("..."))
+                {
+                    // Indexer attribute, we don't want to insert with the triple dot.
+                    insertText = insertText.Substring(0, insertText.Length - 3);
+                }
+
+                var razorCompletionItem = new RazorCompletionItem(
+                    completion,
+                    insertText,
+                    description: string.Empty,
+                    RazorCompletionItemKind.DirectiveAttribute);
+
+                completionItems.Add(razorCompletionItem);
+            }
+
+            return completionItems;
+
+            bool TryAddCompletion(string attributeName)
+            {
+                if (attributes.Any(name => string.Equals(name, attributeName, StringComparison.Ordinal)) &&
+                    !string.Equals(selectedAttributeName, attributeName, StringComparison.Ordinal))
+                {
+                    // Attribute is already present on this element and it is not the selected attribute.
+                    // It shouldn't exist in the completion list.
+                    return false;
+                }
+
+                attributeCompletions.Add(attributeName);
+
+                return true;
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProviderBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProviderBase.cs
@@ -1,0 +1,194 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using RazorSyntaxList = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxList<Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode>;
+using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    internal abstract class DirectiveAttributeCompletionItemProviderBase : RazorCompletionItemProvider
+    {
+        // Internal for testing
+        internal static bool TryGetAttributeInfo(
+            RazorSyntaxNode attributeLeafOwner,
+            out string name,
+            out TextSpan nameLocation,
+            out string parameterName,
+            out TextSpan parameterLocation)
+        {
+            var attribute = attributeLeafOwner.Parent;
+
+            switch (attribute)
+            {
+                case MarkupMinimizedAttributeBlockSyntax minimizedMarkupAttribute:
+                    TryExtractIncompleteDirectiveAttribute(
+                        minimizedMarkupAttribute.Name.GetContent(),
+                        minimizedMarkupAttribute.Name.Span,
+                        out name,
+                        out nameLocation,
+                        out parameterName,
+                        out parameterLocation);
+
+                    return true;
+                case MarkupAttributeBlockSyntax markupAttribute:
+                    TryExtractIncompleteDirectiveAttribute(
+                        markupAttribute.Name.GetContent(),
+                        markupAttribute.Name.Span,
+                        out name,
+                        out nameLocation,
+                        out parameterName,
+                        out parameterLocation);
+                    return true;
+                case MarkupMinimizedTagHelperAttributeSyntax minimizedTagHelperAttribute:
+                    TryExtractIncompleteDirectiveAttribute(
+                        minimizedTagHelperAttribute.Name.GetContent(),
+                        minimizedTagHelperAttribute.Name.Span,
+                        out name,
+                        out nameLocation,
+                        out parameterName,
+                        out parameterLocation);
+                    return true;
+                case MarkupTagHelperAttributeSyntax tagHelperAttribute:
+                    TryExtractIncompleteDirectiveAttribute(
+                        tagHelperAttribute.Name.GetContent(),
+                        tagHelperAttribute.Name.Span,
+                        out name,
+                        out nameLocation,
+                        out parameterName,
+                        out parameterLocation);
+                    return true;
+                case MarkupTagHelperDirectiveAttributeSyntax directiveAttribute:
+                    {
+                        var attributeName = directiveAttribute.Name;
+                        var directiveAttributeTransition = directiveAttribute.Transition;
+                        var nameStart = directiveAttributeTransition?.SpanStart ?? attributeName.SpanStart;
+                        var nameEnd = attributeName?.Span.End ?? directiveAttributeTransition.Span.End;
+                        name = string.Concat(directiveAttributeTransition?.GetContent(), attributeName?.GetContent());
+                        nameLocation = new TextSpan(nameStart, nameEnd - nameStart);
+                        parameterName = directiveAttribute.ParameterName?.GetContent();
+                        parameterLocation = directiveAttribute.ParameterName?.Span ?? default;
+                        return true;
+                    }
+                case MarkupMinimizedTagHelperDirectiveAttributeSyntax minimizedDirectiveAttribute:
+                    {
+                        var attributeName = minimizedDirectiveAttribute.Name;
+                        var directiveAttributeTransition = minimizedDirectiveAttribute.Transition;
+                        var nameStart = directiveAttributeTransition?.SpanStart ?? attributeName.SpanStart;
+                        var nameEnd = attributeName?.Span.End ?? directiveAttributeTransition.Span.End;
+                        name = string.Concat(directiveAttributeTransition?.GetContent(), attributeName?.GetContent());
+                        nameLocation = new TextSpan(nameStart, nameEnd - nameStart);
+                        parameterName = minimizedDirectiveAttribute.ParameterName?.GetContent();
+                        parameterLocation = minimizedDirectiveAttribute.ParameterName?.Span ?? default;
+                        return true;
+                    }
+            }
+
+            name = null;
+            nameLocation = default;
+            parameterName = null;
+            parameterLocation = default;
+            return false;
+        }
+
+        // Internal for testing
+        internal static bool TryGetElementInfo(RazorSyntaxNode element, out string containingTagName, out IEnumerable<string> attributeNames)
+        {
+            if (element is MarkupStartTagSyntax startTag)
+            {
+                containingTagName = startTag.Name.GetContent();
+                attributeNames = ExtractAttributeNames(startTag.Attributes);
+                return true;
+            }
+
+            if (element is MarkupTagHelperStartTagSyntax startTagHelper)
+            {
+                containingTagName = startTagHelper.Name.GetContent();
+                attributeNames = ExtractAttributeNames(startTagHelper.Attributes);
+                return true;
+            }
+
+            containingTagName = null;
+            attributeNames = default;
+            return false;
+        }
+
+        private static IEnumerable<string> ExtractAttributeNames(RazorSyntaxList attributes)
+        {
+            var attributeNames = new List<string>();
+
+            for (var i = 0; i < attributes.Count; i++)
+            {
+                var attribute = attributes[i];
+                if (attribute is MarkupTagHelperAttributeSyntax tagHelperAttribute)
+                {
+                    var name = tagHelperAttribute.Name.GetContent();
+                    attributeNames.Add(name);
+                }
+                else if (attribute is MarkupMinimizedTagHelperAttributeSyntax minimizedTagHelperAttribute)
+                {
+                    var name = minimizedTagHelperAttribute.Name.GetContent();
+                    attributeNames.Add(name);
+                }
+                else if (attribute is MarkupAttributeBlockSyntax markupAttribute)
+                {
+                    var name = markupAttribute.Name.GetContent();
+                    attributeNames.Add(name);
+                }
+                else if (attribute is MarkupMinimizedAttributeBlockSyntax minimizedMarkupAttribute)
+                {
+                    var name = minimizedMarkupAttribute.Name.GetContent();
+                    attributeNames.Add(name);
+                }
+                else if (attribute is MarkupTagHelperDirectiveAttributeSyntax directiveAttribute)
+                {
+                    var name = directiveAttribute.FullName;
+                    attributeNames.Add(name);
+                }
+                else if (attribute is MarkupMinimizedTagHelperDirectiveAttributeSyntax minimizedDirectiveAttribute)
+                {
+                    var name = minimizedDirectiveAttribute.FullName;
+                    attributeNames.Add(name);
+                }
+            }
+
+            return attributeNames;
+        }
+
+        private static void TryExtractIncompleteDirectiveAttribute(
+            string attributeName,
+            TextSpan attributeNameLocation,
+            out string name,
+            out TextSpan nameLocation,
+            out string parameterName,
+            out TextSpan parameterLocation)
+        {
+            name = attributeName;
+            nameLocation = attributeNameLocation;
+            parameterName = default;
+            parameterLocation = default;
+
+            // It's possible that the attribute looks like a directive attribute but is incomplete. 
+            // We should try and extract out the transition and parameter.
+
+            if (!attributeName.StartsWith("@"))
+            {
+                // Doesn't look like a directive attribute. Not an incomplete directive attribute.
+                return;
+            }
+
+            var colonIndex = attributeName.IndexOf(':');
+            if (colonIndex == -1)
+            {
+                // There's no parameter, the existing attribute name and location is sufficient.
+                return;
+            }
+
+            parameterName = attributeName.Substring(colonIndex + 1);
+            parameterLocation = new TextSpan(attributeNameLocation.Start + colonIndex + 1, parameterName.Length);
+            name = attributeName.Substring(0, colonIndex);
+            nameLocation = new TextSpan(attributeNameLocation.Start, name.Length);
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeParameterCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeParameterCompletionItemProvider.cs
@@ -1,0 +1,147 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.VisualStudio.Editor.Razor;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    [Shared]
+    [Export(typeof(RazorCompletionItemProvider))]
+    internal class DirectiveAttributeParameterCompletionItemProvider : DirectiveAttributeCompletionItemProviderBase
+    {
+        private readonly TagHelperFactsService _tagHelperFactsService;
+
+        [ImportingConstructor]
+        public DirectiveAttributeParameterCompletionItemProvider(TagHelperFactsService tagHelperFactsService)
+        {
+            if (tagHelperFactsService is null)
+            {
+                throw new ArgumentNullException(nameof(tagHelperFactsService));
+            }
+
+            _tagHelperFactsService = tagHelperFactsService;
+        }
+
+        public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorSyntaxTree syntaxTree, TagHelperDocumentContext tagHelperDocumentContext, SourceSpan location)
+        {
+            if (syntaxTree is null)
+            {
+                throw new ArgumentNullException(nameof(syntaxTree));
+            }
+
+            if (tagHelperDocumentContext is null)
+            {
+                throw new ArgumentNullException(nameof(tagHelperDocumentContext));
+            }
+
+            if (!FileKinds.IsComponent(syntaxTree.Options.FileKind))
+            {
+                // Directive attribute parameters are only supported in components
+                return Array.Empty<RazorCompletionItem>();
+            }
+
+            var change = new SourceChange(location, string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(change);
+
+            if (owner == null)
+            {
+                return Array.Empty<RazorCompletionItem>();
+            }
+
+            if (!TryGetAttributeInfo(owner, out var attributeName, out _, out var parameterName, out var parameterNameLocation))
+            {
+                // Either we're not in an attribute or the attribute is so malformed that we can't provide proper completions.
+                return Array.Empty<RazorCompletionItem>();
+            }
+
+            if (!parameterNameLocation.IntersectsWith(location.AbsoluteIndex))
+            {
+                // We're trying to retrieve completions on a portion of the name that is not supported (such as the name, i.e., |@bind|:format).
+                return Array.Empty<RazorCompletionItem>();
+            }
+
+            if (!TryGetElementInfo(owner.Parent.Parent, out var containingTagName, out var attributes))
+            {
+                // This should never be the case, it means that we're operating on an attribute that doesn't have a tag.
+                return Array.Empty<RazorCompletionItem>();
+            }
+
+            var completions = GetAttributeParameterCompletions(attributeName, parameterName, containingTagName, attributes, tagHelperDocumentContext);
+            return completions;
+        }
+
+        // Internal for testing
+        internal IReadOnlyList<RazorCompletionItem> GetAttributeParameterCompletions(
+            string attributeName,
+            string parameterName,
+            string containingTagName,
+            IEnumerable<string> attributes,
+            TagHelperDocumentContext tagHelperDocumentContext)
+        {
+            var descriptorsForTag = _tagHelperFactsService.GetTagHelpersGivenTag(tagHelperDocumentContext, containingTagName, parentTag: null);
+            if (descriptorsForTag.Count == 0)
+            {
+                // If the current tag has no possible descriptors then we can't have any additional attributes.
+                return Array.Empty<RazorCompletionItem>();
+            }
+
+            // Attribute parameters are case sensitive when matching
+            var attributeCompletions = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var descriptor in descriptorsForTag)
+            {
+                for (var i = 0; i < descriptor.BoundAttributes.Count; i++)
+                {
+                    var attributeDescriptor = descriptor.BoundAttributes[i];
+                    var boundAttributeParameters = attributeDescriptor.BoundAttributeParameters;
+                    if (boundAttributeParameters.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    if (TagHelperMatchingConventions.CanSatisfyBoundAttribute(attributeName, attributeDescriptor))
+                    {
+                        for (var j = boundAttributeParameters.Count - 1; j >= 0; j--)
+                        {
+                            var parameterDescriptor = boundAttributeParameters[j];
+
+                            if (attributes.Any(name => TagHelperMatchingConventions.SatisfiesBoundAttributeWithParameter(name, attributeDescriptor, parameterDescriptor)))
+                            {
+                                // There's already an existing attribute that satisfies this parameter, don't show it in the completion list.
+                                continue;
+                            }
+
+                            attributeCompletions.Add(parameterDescriptor.Name);
+                        }
+                    }
+                }
+            }
+
+            var completionItems = new List<RazorCompletionItem>();
+            foreach (var completion in attributeCompletions)
+            {
+                if (string.Equals(completion, parameterName, StringComparison.Ordinal))
+                {
+                    // This completion is identical to the selected parameter, don't provide for completions for what's already
+                    // present in the document.
+                    continue;
+                }
+
+                var razorCompletionItem = new RazorCompletionItem(
+                    completion,
+                    completion,
+                    description: string.Empty,
+                    RazorCompletionItemKind.DirectiveAttributeParameter);
+
+                completionItems.Add(razorCompletionItem);
+            }
+
+            return completionItems;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeParameterCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeParameterCompletionItemProvider.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
 
                     if (TagHelperMatchingConventions.CanSatisfyBoundAttribute(attributeName, attributeDescriptor))
                     {
-                        for (var j = boundAttributeParameters.Count - 1; j >= 0; j--)
+                        for (var j = 0; j < boundAttributeParameters.Count; j++)
                         {
                             var parameterDescriptor = boundAttributeParameters[j];
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionDescription.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionDescription.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    internal class DirectiveCompletionDescription
+    {
+        public DirectiveCompletionDescription(string description)
+        {
+            if (description == null)
+            {
+                throw new ArgumentNullException(nameof(description));
+            }
+
+            Description = description;
+        }
+
+        public string Description { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -108,8 +108,9 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                 var completionItem = new RazorCompletionItem(
                     completionDisplayText,
                     directive.Directive,
-                    directive.Description,
                     RazorCompletionItemKind.Directive);
+                var completionDescription = new DirectiveCompletionDescription(directive.Description);
+                completionItem.SetDirectiveCompletionDescription(completionDescription);
                 completionItems.Add(completionItem);
             }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemExtensions.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    internal static class RazorCompletionItemExtensions
+    {
+        private readonly static string AttributeCompletionDescriptionKey = "Razor.AttributeDescription";
+        private readonly static string DirectiveCompletionDescriptionKey = "Razor.DirectiveDescription";
+
+        public static void SetAttributeCompletionDescription(this RazorCompletionItem completionItem, AttributeCompletionDescription attributeCompletionDescription)
+        {
+            if (completionItem is null)
+            {
+                throw new ArgumentNullException(nameof(completionItem));
+            }
+
+            completionItem.Items[AttributeCompletionDescriptionKey] = attributeCompletionDescription;
+        }
+
+        public static AttributeCompletionDescription GetAttributeCompletionDescription(this RazorCompletionItem completionItem)
+        {
+            if (completionItem is null)
+            {
+                throw new ArgumentNullException(nameof(completionItem));
+            }
+
+            var attributeCompletionDescription = completionItem.Items[AttributeCompletionDescriptionKey] as AttributeCompletionDescription;
+            return attributeCompletionDescription;
+        }
+
+        public static void SetDirectiveCompletionDescription(this RazorCompletionItem completionItem, DirectiveCompletionDescription attributeCompletionDescription)
+        {
+            if (completionItem is null)
+            {
+                throw new ArgumentNullException(nameof(completionItem));
+            }
+
+            completionItem.Items[DirectiveCompletionDescriptionKey] = attributeCompletionDescription;
+        }
+
+        public static DirectiveCompletionDescription GetDirectiveCompletionDescription(this RazorCompletionItem completionItem)
+        {
+            if (completionItem is null)
+            {
+                throw new ArgumentNullException(nameof(completionItem));
+            }
+
+            var attributeCompletionDescription = completionItem.Items[DirectiveCompletionDescriptionKey] as DirectiveCompletionDescription;
+            return attributeCompletionDescription;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemKind.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemKind.cs
@@ -5,6 +5,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
 {
     internal enum RazorCompletionItemKind
     {
-        Directive
+        Directive,
+        DirectiveAttribute
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemKind.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemKind.cs
@@ -6,6 +6,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
     internal enum RazorCompletionItemKind
     {
         Directive,
-        DirectiveAttribute
+        DirectiveAttribute,
+        DirectiveAttributeParameter
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/DefaultVisualStudioDescriptionFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/DefaultVisualStudioDescriptionFactory.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.VisualStudio.Core.Imaging;
+using Microsoft.VisualStudio.Text.Adornments;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
+{
+    [Shared]
+    [Export(typeof(VisualStudioDescriptionFactory))]
+    internal class DefaultVisualStudioDescriptionFactory : VisualStudioDescriptionFactory
+    {
+        // Internal for testing
+        internal static readonly ContainerElement SeparatorElement = new ContainerElement(
+            ContainerElementStyle.Wrapped,
+            new ClassifiedTextElement(
+                new ClassifiedTextRun(PredefinedClassificationNames.Comment, "------------")));
+
+        private static readonly IReadOnlyDictionary<string, string> KeywordTypeNameLookups = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [typeof(byte).FullName] = "byte",
+            [typeof(sbyte).FullName] = "sbyte",
+            [typeof(int).FullName] = "int",
+            [typeof(uint).FullName] = "uint",
+            [typeof(short).FullName] = "short",
+            [typeof(ushort).FullName] = "ushort",
+            [typeof(long).FullName] = "long",
+            [typeof(ulong).FullName] = "ulong",
+            [typeof(float).FullName] = "float",
+            [typeof(double).FullName] = "double",
+            [typeof(char).FullName] = "char",
+            [typeof(bool).FullName] = "bool",
+            [typeof(object).FullName] = "object",
+            [typeof(string).FullName] = "string",
+            [typeof(decimal).FullName] = "decimal",
+        };
+
+        // Hardcoding the Guid here to avoid a reference to Microsoft.VisualStudio.ImageCatalog.dll
+        // that is not present in Visual Studio for Mac
+        private static readonly Guid ImageCatalogGuid = new Guid("{ae27a6b0-e345-4288-96df-5eaf394ee369}");
+        private static readonly ImageElement PropertyGlyph = new ImageElement(
+            new ImageId(ImageCatalogGuid, 2429), // KnownImageIds.Type = 2429
+            "Razor Attribute Glyph");
+        private static readonly ClassifiedTextRun SpaceLiteral = new ClassifiedTextRun(PredefinedClassificationNames.Literal, " ");
+        private static readonly ClassifiedTextRun DotLiteral = new ClassifiedTextRun(PredefinedClassificationNames.Literal, ".");
+
+        public override ContainerElement CreateClassifiedDescription(AttributeCompletionDescription completionDescription)
+        {
+            if (completionDescription is null)
+            {
+                throw new ArgumentNullException(nameof(completionDescription));
+            }
+
+            var descriptionElements = new List<object>();
+            foreach (var descriptionInfo in completionDescription.DescriptionInfos)
+            {
+                if (descriptionElements.Count > 0)
+                {
+                    descriptionElements.Add(SeparatorElement);
+                }
+
+                var returnTypeClassification = PredefinedClassificationNames.Type;
+                if (KeywordTypeNameLookups.TryGetValue(descriptionInfo.ReturnTypeName, out var returnTypeName))
+                {
+                    returnTypeClassification = PredefinedClassificationNames.Keyword;
+                }
+                else
+                {
+                    returnTypeName = descriptionInfo.ReturnTypeName;
+                }
+
+                var tagHelperTypeName = descriptionInfo.TypeName;
+                var tagHelperTypeNamePrefix = string.Empty;
+                var tagHelperTypeNameProper = tagHelperTypeName;
+
+                var lastDot = tagHelperTypeName.LastIndexOf('.');
+                if (lastDot > 0)
+                {
+                    var afterLastDot = lastDot + 1;
+
+                    // We're pulling apart the type name so the prefix looks like:
+                    //
+                    // Microsoft.AspnetCore.Components.
+                    tagHelperTypeNamePrefix = tagHelperTypeName.Substring(0, afterLastDot);
+
+                    // And the type name looks like BindBinds
+                    tagHelperTypeNameProper = tagHelperTypeName.Substring(afterLastDot);
+                }
+
+                descriptionElements.Add(
+                    new ContainerElement(
+                        ContainerElementStyle.Wrapped,
+                        PropertyGlyph,
+                        new ClassifiedTextElement(
+                            new ClassifiedTextRun(returnTypeClassification, returnTypeName),
+                            SpaceLiteral,
+                            new ClassifiedTextRun(PredefinedClassificationNames.Literal, tagHelperTypeNamePrefix),
+                            new ClassifiedTextRun(PredefinedClassificationNames.Type, tagHelperTypeNameProper),
+                            DotLiteral,
+                            new ClassifiedTextRun(PredefinedClassificationNames.Identifier, descriptionInfo.PropertyName))));
+
+                if (descriptionInfo.Documentation != null)
+                {
+                    descriptionElements.Add(
+                        new ContainerElement(
+                            ContainerElementStyle.Wrapped,
+                            new ClassifiedTextElement(
+                                new ClassifiedTextRun(PredefinedClassificationNames.NaturalLanguage, descriptionInfo.Documentation))));
+                }
+            }
+
+            var descriptionContainer = new ContainerElement(ContainerElementStyle.Stacked, descriptionElements);
+            return descriptionContainer;
+        }
+
+        private static class PredefinedClassificationNames
+        {
+            public const string Keyword = "keyword";
+
+            public const string Literal = "literal";
+
+            public const string Type = "Type";
+
+            public const string Identifier = "identifier";
+
+            public const string Comment = "comment";
+
+            public const string NaturalLanguage = "natural language";
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/PropertyCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/PropertyCollectionExtensions.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
+{
+    internal static class PropertyCollectionExtensions
+    {
+        public static object CompletionItemKindsKey = new object();
+
+        public static void SetCompletionItemKinds(this PropertyCollection properties, ICollection<RazorCompletionItemKind> completionItemKinds)
+        {
+            if (properties is null)
+            {
+                throw new ArgumentNullException(nameof(properties));
+            }
+
+            if (completionItemKinds is null)
+            {
+                throw new ArgumentNullException(nameof(completionItemKinds));
+            }
+
+            properties[CompletionItemKindsKey] = completionItemKinds;
+        }
+
+        public static bool TryGetCompletionItemKinds(this PropertyCollection properties, out ICollection<RazorCompletionItemKind> completionItemKinds)
+        {
+            if (properties is null)
+            {
+                throw new ArgumentNullException(nameof(properties));
+            }
+
+            return properties.TryGetProperty(CompletionItemKindsKey, out completionItemKinds);
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCommitManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCommitManager.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
+{
+    internal class RazorDirectiveAttributeCommitManager : IAsyncCompletionCommitManager
+    {
+        public IEnumerable<char> PotentialCommitCharacters => new[] { '=' };
+
+        public bool ShouldCommitCompletion(IAsyncCompletionSession session, SnapshotPoint location, char typedChar, CancellationToken token)
+        {
+            if (session is null)
+            {
+                throw new ArgumentNullException(nameof(session));
+            }
+
+            if (!session.Properties.TryGetCompletionItemKinds(out _))
+            {
+                // There were no completions provided from our directive attribute completion provider(s).
+                return false;
+            }
+
+            // Directive attribute completion. This class is only ever called for our specific commit characters, allow the commit.
+
+            return true;
+        }
+
+        public CommitResult TryCommit(IAsyncCompletionSession session, ITextBuffer buffer, CompletionItem item, char typedChar, CancellationToken token)
+        {
+            // Do default behavior for the commit. This enables things like typing `=` and letting the Html completion engine finish off the attribute.
+            return CommitResult.Unhandled;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCommitManagerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCommitManagerProvider.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
+{
+    [System.Composition.Shared]
+    [Export(typeof(IAsyncCompletionCommitManagerProvider))]
+    [Name("Razor directive attribute completion commit provider.")]
+    [ContentType(RazorLanguage.CoreContentType)]
+    internal class RazorDirectiveAttributeCommitManagerProvider : IAsyncCompletionCommitManagerProvider
+    {
+        public IAsyncCompletionCommitManager GetOrCreate(ITextView textView)
+        {
+            if (textView == null)
+            {
+                throw new ArgumentNullException(nameof(textView));
+            }
+
+            var razorBuffer = textView.BufferGraph.GetRazorBuffers().FirstOrDefault();
+            if (!razorBuffer.Properties.TryGetProperty(typeof(RazorDirectiveAttributeCommitManager), out IAsyncCompletionCommitManager completionSource) ||
+                completionSource == null)
+            {
+                completionSource = CreateCommitManager();
+                razorBuffer.Properties.AddProperty(typeof(RazorDirectiveAttributeCommitManager), completionSource);
+            }
+
+            return completionSource;
+        }
+
+        // Internal for testing
+        internal IAsyncCompletionCommitManager CreateCommitManager()
+        {
+            var completionSource = new RazorDirectiveAttributeCommitManager();
+            return completionSource;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSource.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSource.cs
@@ -109,9 +109,10 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
                 var completionItemKinds = new HashSet<RazorCompletionItemKind>();
                 foreach (var razorCompletionItem in razorCompletionItems)
                 {
-                    if (razorCompletionItem.Kind != RazorCompletionItemKind.DirectiveAttribute)
+                    if (razorCompletionItem.Kind != RazorCompletionItemKind.DirectiveAttribute &&
+                        razorCompletionItem.Kind != RazorCompletionItemKind.DirectiveAttributeParameter)
                     {
-                        // Don't support any other types of completion kinds other than directive attributes.
+                        // Don't support any other types of completion kinds other than directive attributes and their parameters.
                         continue;
                     }
 
@@ -233,7 +234,10 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
                 }
                 else
                 {
-                    return CompletionStartData.DoesNotParticipateInCompletion;
+                    // The trigger location falls on the right hand side of the directive attribute parameter delimiter (:)
+                    //
+                    // <InputSelect @bind-foo:|something|
+                    leftEnd = parameterDelimiter + 1;
                 }
             }
             else

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSource.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSource.cs
@@ -1,0 +1,257 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.VisualStudio.Core.Imaging;
+using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Adornments;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
+{
+    internal class RazorDirectiveAttributeCompletionSource : IAsyncCompletionSource
+    {
+        // Hardcoding the Guid here to avoid a reference to Microsoft.VisualStudio.ImageCatalog.dll
+        // that is not present in Visual Studio for Mac
+        private static readonly Guid ImageCatalogGuid = new Guid("{ae27a6b0-e345-4288-96df-5eaf394ee369}");
+        private static readonly ImageElement DirectiveAttributeImageGlyph = new ImageElement(
+            new ImageId(ImageCatalogGuid, 3564), // KnownImageIds.Type = 3564
+            "Razor Directive Attribute.");
+        private static readonly ImmutableArray<CompletionFilter> DirectiveAttributeCompletionFilters = new[] {
+            new CompletionFilter("Razor Directive Attrsibute", "r", DirectiveAttributeImageGlyph)
+        }.ToImmutableArray();
+
+        private readonly VisualStudioRazorParser _parser;
+        private readonly RazorCompletionFactsService _completionFactsService;
+        private readonly ICompletionBroker _completionBroker;
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+
+        public RazorDirectiveAttributeCompletionSource(
+            ForegroundDispatcher foregroundDispatcher,
+            VisualStudioRazorParser parser,
+            RazorCompletionFactsService completionFactsService,
+            ICompletionBroker completionBroker)
+        {
+            if (foregroundDispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            if (parser == null)
+            {
+                throw new ArgumentNullException(nameof(parser));
+            }
+
+            if (completionFactsService == null)
+            {
+                throw new ArgumentNullException(nameof(completionFactsService));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher;
+            _parser = parser;
+            _completionFactsService = completionFactsService;
+            _completionBroker = completionBroker;
+        }
+
+        public async Task<CompletionContext> GetCompletionContextAsync(IAsyncCompletionSession session, CompletionTrigger trigger, SnapshotPoint triggerLocation, SnapshotSpan applicableToSpan, CancellationToken token)
+        {
+            _foregroundDispatcher.AssertBackgroundThread();
+
+            try
+            {
+                var codeDocument = await _parser.GetLatestCodeDocumentAsync(triggerLocation.Snapshot, token);
+                if (codeDocument == null)
+                {
+                    // Code document not available yet.
+                    return CompletionContext.Empty;
+                }
+
+                var syntaxTree = codeDocument.GetSyntaxTree();
+                var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
+                var location = new SourceSpan(triggerLocation.Position, 0);
+                var razorCompletionItems = _completionFactsService.GetCompletionItems(syntaxTree, tagHelperDocumentContext, location);
+
+                if (razorCompletionItems.Count == 0)
+                {
+                    return CompletionContext.Empty;
+                }
+
+                // Check if we're providing completion items while a legacy completion session is active. If so
+                // we'll need to dismiss the legacy completion session to ensure we don't get two completion lists.
+                var activeSessions = _completionBroker.GetSessions(session.TextView);
+                foreach (var activeSession in activeSessions)
+                {
+                    if (activeSession.Properties.ContainsProperty(nameof(IAsyncCompletionSession)))
+                    {
+                        continue;
+                    }
+
+                    // Legacy completion is also active, we need to dismiss it.
+
+                    _ = Task.Factory.StartNew(
+                        () => activeSession.Dismiss(),
+                        CancellationToken.None,
+                        TaskCreationOptions.None,
+                        _foregroundDispatcher.ForegroundScheduler);
+                }
+
+                var completionItems = new List<CompletionItem>();
+                var completionItemKinds = new HashSet<RazorCompletionItemKind>();
+                foreach (var razorCompletionItem in razorCompletionItems)
+                {
+                    if (razorCompletionItem.Kind != RazorCompletionItemKind.DirectiveAttribute)
+                    {
+                        // Don't support any other types of completion kinds other than directive attributes.
+                        continue;
+                    }
+
+                    var completionItem = new CompletionItem(
+                        displayText: razorCompletionItem.DisplayText,
+                        filterText: razorCompletionItem.DisplayText,
+                        insertText: razorCompletionItem.InsertText,
+                        source: this,
+                        icon: DirectiveAttributeImageGlyph,
+                        filters: DirectiveAttributeCompletionFilters,
+                        suffix: string.Empty,
+                        sortText: razorCompletionItem.DisplayText,
+                        attributeIcons: ImmutableArray<ImageElement>.Empty);
+                    completionItems.Add(completionItem);
+                    completionItemKinds.Add(razorCompletionItem.Kind);
+                }
+
+                session.Properties.SetCompletionItemKinds(completionItemKinds);
+                var orderedCompletionItems = completionItems.OrderBy(item => item.DisplayText);
+                var context = new CompletionContext(orderedCompletionItems.ToImmutableArray());
+                return context;
+            }
+            catch (OperationCanceledException)
+            {
+                return CompletionContext.Empty;
+            }
+        }
+
+        public Task<object> GetDescriptionAsync(IAsyncCompletionSession session, CompletionItem item, CancellationToken token)
+        {
+            return Task.FromResult<object>(string.Empty);
+        }
+
+        public CompletionStartData InitializeCompletion(CompletionTrigger trigger, SnapshotPoint triggerLocation, CancellationToken token)
+        {
+            // We can't retrieve the correct SyntaxTree/CodeDocument at this time because this extension point is synchronous so we need 
+            // to make our "do we participate in completion and what do we aspply to" decision without one. We'll look to see if what
+            // we're operating on potentially looks like a directive attribute. We care about things that look like a expressions to
+            // provide directive attribute completions. Basically anything starting with a transition (@).
+
+            var snapshot = triggerLocation.Snapshot;
+            if (snapshot.Length == 0)
+            {
+                // Empty document, can not provide completions.
+                return CompletionStartData.DoesNotParticipateInCompletion;
+            }
+
+            if (triggerLocation.Position == 0)
+            {
+                // Completion triggered at beginning of document, can't possibly be an attribute.
+                return CompletionStartData.DoesNotParticipateInCompletion;
+            }
+
+            var leftEnd = triggerLocation.Position - 1;
+            for (; leftEnd >= 0; leftEnd--)
+            {
+                var currentCharacter = snapshot[leftEnd];
+
+                if (char.IsWhiteSpace(currentCharacter))
+                {
+                    // Valid left end attribute delimiter
+                    leftEnd++;
+                    break;
+                }
+                else if (IsInvalidAttributeDelimiter(currentCharacter))
+                {
+                    return CompletionStartData.DoesNotParticipateInCompletion;
+                }
+            }
+
+            if (leftEnd >= snapshot.Length)
+            {
+                // Left part of the trigger is at the very end of the document without a possible transition
+                return CompletionStartData.DoesNotParticipateInCompletion;
+            }
+
+            var leftMostCharacter = snapshot[leftEnd];
+            if (leftMostCharacter != '@')
+            {
+                // The left side of our simple expression should always be a Razor transition. We have this restriction to
+                // ensure that we don't provide directive attribute completions that override WTE's legacy completion.
+                // Since WTE's legacy completion also provides HTML completions and is not yet on modern completion we'd
+                // end up nuking all HTML completions without this restriction.
+                return CompletionStartData.DoesNotParticipateInCompletion;
+            }
+
+            var rightEnd = triggerLocation.Position;
+            for (; rightEnd < snapshot.Length; rightEnd++)
+            {
+                var currentCharacter = snapshot[rightEnd];
+
+                if (char.IsWhiteSpace(currentCharacter) || currentCharacter == '=' || IsInvalidAttributeDelimiter(currentCharacter))
+                {
+                    // Right hand side of the current attribute
+                    break;
+                }
+            }
+
+            var parameterDelimiter = -1;
+            for (var i = leftEnd; i < rightEnd; i++)
+            {
+                if (snapshot[i] == ':')
+                {
+                    parameterDelimiter = i;
+                }
+            }
+
+            if (parameterDelimiter != -1)
+            {
+                // There's a parameter delimiter in the expression that we've triggered on. We need to decide which side will
+                // be the applicable to span.
+
+                if (triggerLocation.Position <= parameterDelimiter)
+                {
+                    // The trigger location falls on the left hand side of the directive attribute parameter delimiter (:)
+                    //
+                    // <InputSelect |@bind-foo|:something
+                    rightEnd = parameterDelimiter;
+                }
+                else
+                {
+                    return CompletionStartData.DoesNotParticipateInCompletion;
+                }
+            }
+            else
+            {
+                // Do nothing, our directive attribute does not have parameters and our leftEnd -> rightEnd bounds already encompass the attribute
+                //
+                // <InputSelect |@bind-foo|
+            }
+
+            var applicableSpanLength = rightEnd - leftEnd;
+            var applicableToSpan = new SnapshotSpan(triggerLocation.Snapshot, leftEnd, applicableSpanLength);
+
+            return new CompletionStartData(CompletionParticipation.ProvidesItems, applicableToSpan);
+        }
+
+        private static bool IsInvalidAttributeDelimiter(char currentCharacter)
+        {
+            return currentCharacter == '<' || currentCharacter == '>' || currentCharacter == '\'' || currentCharacter == '"' || currentCharacter == '/';
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSource.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSource.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -177,9 +175,9 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
         public CompletionStartData InitializeCompletion(CompletionTrigger trigger, SnapshotPoint triggerLocation, CancellationToken token)
         {
             // We can't retrieve the correct SyntaxTree/CodeDocument at this time because this extension point is synchronous so we need 
-            // to make our "do we participate in completion and what do we aspply to" decision without one. We'll look to see if what
-            // we're operating on potentially looks like a directive attribute. We care about things that look like a expressions to
-            // provide directive attribute completions. Basically anything starting with a transition (@).
+            // to make our "do we participate in completion and what do we apply to" decision without one. We'll look to see if what
+            // we're operating on potentially looks like a directive attribute. We care about syntax that looks like an expression when
+            // providing directive attribute completions. Basically anything starting with a transition (@).
 
             var snapshot = triggerLocation.Snapshot;
             if (snapshot.Length == 0)

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSourceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSourceProvider.cs
@@ -23,13 +23,15 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly RazorCompletionFactsService _completionFactsService;
         private readonly ICompletionBroker _completionBroker;
+        private readonly VisualStudioDescriptionFactory _descriptionFactory;
 
         [ImportingConstructor]
         public RazorDirectiveAttributeCompletionSourceProvider(
             ForegroundDispatcher foregroundDispatcher,
             RazorCompletionFactsService completionFactsService,
             IAsyncCompletionBroker asyncCoompletionBroker,
-            ICompletionBroker completionBroker)
+            ICompletionBroker completionBroker,
+            VisualStudioDescriptionFactory descriptionFactory)
         {
             if (foregroundDispatcher == null)
             {
@@ -46,9 +48,15 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
                 throw new ArgumentNullException(nameof(asyncCoompletionBroker));
             }
 
+            if (descriptionFactory == null)
+            {
+                throw new ArgumentNullException(nameof(descriptionFactory));
+            }
+
             _foregroundDispatcher = foregroundDispatcher;
             _completionFactsService = completionFactsService;
             _completionBroker = completionBroker;
+            _descriptionFactory = descriptionFactory;
         }
 
         public IAsyncCompletionSource GetOrCreate(ITextView textView)
@@ -78,7 +86,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
                 return null;
             }
 
-            var completionSource = new RazorDirectiveAttributeCompletionSource(_foregroundDispatcher, parser, _completionFactsService, _completionBroker);
+            var completionSource = new RazorDirectiveAttributeCompletionSource(_foregroundDispatcher, parser, _completionFactsService, _completionBroker, _descriptionFactory);
             return completionSource;
         }
     }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSourceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSourceProvider.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
+{
+    [System.Composition.Shared]
+    [Export(typeof(IAsyncCompletionSourceProvider))]
+    [Name("Razor directive attribute completion provider.")]
+    [ContentType(RazorLanguage.CoreContentType)]
+    internal class RazorDirectiveAttributeCompletionSourceProvider : IAsyncCompletionSourceProvider
+    {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+        private readonly RazorCompletionFactsService _completionFactsService;
+        private readonly ICompletionBroker _completionBroker;
+
+        [ImportingConstructor]
+        public RazorDirectiveAttributeCompletionSourceProvider(
+            ForegroundDispatcher foregroundDispatcher,
+            RazorCompletionFactsService completionFactsService,
+            IAsyncCompletionBroker asyncCoompletionBroker,
+            ICompletionBroker completionBroker)
+        {
+            if (foregroundDispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            if (completionFactsService == null)
+            {
+                throw new ArgumentNullException(nameof(completionFactsService));
+            }
+
+            if (asyncCoompletionBroker is null)
+            {
+                throw new ArgumentNullException(nameof(asyncCoompletionBroker));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher;
+            _completionFactsService = completionFactsService;
+            _completionBroker = completionBroker;
+        }
+
+        public IAsyncCompletionSource GetOrCreate(ITextView textView)
+        {
+            if (textView == null)
+            {
+                throw new ArgumentNullException(nameof(textView));
+            }
+
+            var razorBuffer = textView.BufferGraph.GetRazorBuffers().FirstOrDefault();
+            if (!razorBuffer.Properties.TryGetProperty(typeof(RazorDirectiveAttributeCompletionSource), out IAsyncCompletionSource completionSource) ||
+                completionSource == null)
+            {
+                completionSource = CreateCompletionSource(razorBuffer);
+                razorBuffer.Properties.AddProperty(typeof(RazorDirectiveAttributeCompletionSource), completionSource);
+            }
+
+            return completionSource;
+        }
+
+        // Internal for testing
+        internal IAsyncCompletionSource CreateCompletionSource(ITextBuffer razorBuffer)
+        {
+            if (!razorBuffer.Properties.TryGetProperty(typeof(VisualStudioRazorParser), out VisualStudioRazorParser parser))
+            {
+                // Parser hasn't been associated with the text buffer yet.
+                return null;
+            }
+
+            var completionSource = new RazorDirectiveAttributeCompletionSource(_foregroundDispatcher, parser, _completionFactsService, _completionBroker);
+            return completionSource;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionProvider.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Tags;
 using Microsoft.CodeAnalysis.Text;
@@ -153,9 +152,10 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
                 }
 
                 var propertyDictionary = new Dictionary<string, string>(StringComparer.Ordinal);
-                if (!string.IsNullOrEmpty(razorCompletionItem.Description))
+                var completionDescription = razorCompletionItem.GetDirectiveCompletionDescription();
+                if (!string.IsNullOrEmpty(completionDescription.Description))
                 {
-                    propertyDictionary[DescriptionKey] = razorCompletionItem.Description;
+                    propertyDictionary[DescriptionKey] = completionDescription.Description;
                 }
 
                 var completionItem = CompletionItem.Create(

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionProvider.cs
@@ -21,7 +21,7 @@ using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Projection;
 
-namespace Microsoft.VisualStudio.Editor.Razor
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
 {
     [System.Composition.Shared]
     [Export(typeof(CompletionProvider))]

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSource.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSource.cs
@@ -102,7 +102,8 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
                         suffix: string.Empty,
                         sortText: razorCompletionItem.DisplayText,
                         attributeIcons: ImmutableArray<ImageElement>.Empty);
-                    completionItem.Properties.AddProperty(DescriptionKey, razorCompletionItem.Description);
+                    var completionDescription = razorCompletionItem.GetDirectiveCompletionDescription();
+                    completionItem.Properties.AddProperty(DescriptionKey, completionDescription);
                     completionItems.Add(completionItem);
                 }
                 var context = new CompletionContext(completionItems.ToImmutableArray());
@@ -116,12 +117,12 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
 
         public Task<object> GetDescriptionAsync(IAsyncCompletionSession session, CompletionItem item, CancellationToken token)
         {
-            if (!item.Properties.TryGetProperty<string>(DescriptionKey, out var directiveDescription))
+            if (!item.Properties.TryGetProperty(DescriptionKey, out DirectiveCompletionDescription directiveDescription))
             {
-                directiveDescription = string.Empty;
+                return Task.FromResult<object>(string.Empty);
             }
 
-            return Task.FromResult<object>(directiveDescription);
+            return Task.FromResult<object>(directiveDescription.Description);
         }
 
         public CompletionStartData InitializeCompletion(CompletionTrigger trigger, SnapshotPoint triggerLocation, CancellationToken token)

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSource.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSource.cs
@@ -10,13 +10,12 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.VisualStudio.Core.Imaging;
-using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Adornments;
 
-namespace Microsoft.VisualStudio.Editor.Razor
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
 {
     internal class RazorDirectiveCompletionSource : IAsyncCompletionSource
     {

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSourceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSourceProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 
-namespace Microsoft.VisualStudio.Editor.Razor
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
 {
     [System.Composition.Shared]
     [Export(typeof(IAsyncCompletionSourceProvider))]

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/VisualStudioDescriptionFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/VisualStudioDescriptionFactory.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.VisualStudio.Text.Adornments;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
+{
+    internal abstract class VisualStudioDescriptionFactory
+    {
+        public abstract ContainerElement CreateClassifiedDescription(AttributeCompletionDescription completionDescription);
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
@@ -16,9 +16,9 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             // Arrange
             var syntaxTree = RazorSyntaxTree.Parse(TestRazorSourceDocument.Create());
             var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: null, Enumerable.Empty<TagHelperDescriptor>());
-            var completionItem1 = new RazorCompletionItem("displayText1", "insertText1", "description1", RazorCompletionItemKind.Directive);
+            var completionItem1 = new RazorCompletionItem("displayText1", "insertText1", RazorCompletionItemKind.Directive);
             var provider1 = Mock.Of<RazorCompletionItemProvider>(p => p.GetCompletionItems(syntaxTree, tagHelperDocumentContext, default) == new[] { completionItem1 });
-            var completionItem2 = new RazorCompletionItem("displayText2", "insertText2", "description2", RazorCompletionItemKind.Directive);
+            var completionItem2 = new RazorCompletionItem("displayText2", "insertText2", RazorCompletionItemKind.Directive);
             var provider2 = Mock.Of<RazorCompletionItemProvider>(p => p.GetCompletionItems(syntaxTree, tagHelperDocumentContext, default) == new[] { completionItem2 });
             var completionFactsService = new DefaultRazorCompletionFactsService(new[] { provider1, provider2 });
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderBaseTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderBaseTest.cs
@@ -1,0 +1,235 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Xunit;
+using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    public class DirectiveAttributeCompletionItemProviderBaseTest : RazorIntegrationTestBase
+    {
+        internal override string FileKind => FileKinds.Component;
+
+        internal override bool UseTwoPhaseCompilation => true;
+
+        [Fact]
+        public void TryGetAttributeInfo_NonAttribute_ReturnsFalse()
+        {
+            // Arrange
+            var node = GetNodeAt("@DateTime.Now", 4);
+
+            // Act
+            var result = DirectiveAttributeCompletionItemProviderBase.TryGetAttributeInfo(node, out _, out _, out _, out _);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void TryGetAttributeInfo_EmptyAttribute_ReturnsFalse()
+        {
+            // Arrange
+            var node = GetNodeAt("<p    >", 3);
+
+            // Act
+            var result = DirectiveAttributeCompletionItemProviderBase.TryGetAttributeInfo(node, out _, out _, out _, out _);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void TryGetAttributeInfo_PartialAttribute_ReturnsTrue()
+        {
+            // Arrange
+            var node = GetNodeAt("<p bin>", 4);
+
+            // Act
+            var result = DirectiveAttributeCompletionItemProviderBase.TryGetAttributeInfo(node, out var name, out var nameLocation, out var parameterName, out var parameterNameLocation);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal("bin", name);
+            Assert.Equal(new TextSpan(3, 3), nameLocation);
+            Assert.Null(parameterName);
+        }
+
+        [Fact]
+        public void TryGetAttributeInfo_PartialTransitionedAttribute_ReturnsTrue()
+        {
+            // Arrange
+            var node = GetNodeAt("<p @>", 4);
+
+            // Act
+            var result = DirectiveAttributeCompletionItemProviderBase.TryGetAttributeInfo(node, out var name, out var nameLocation, out var parameterName, out var parameterNameLocation);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal("@", name);
+            Assert.Equal(new TextSpan(3, 1), nameLocation);
+            Assert.Null(parameterName);
+        }
+
+        [Fact]
+        public void TryGetAttributeInfo_FullAttribute_ReturnsTrue()
+        {
+            // Arrange
+            var node = GetNodeAt("<p foo=\"anything\">", 4);
+
+            // Act
+            var result = DirectiveAttributeCompletionItemProviderBase.TryGetAttributeInfo(node, out var name, out var nameLocation, out var parameterName, out var parameterNameLocation);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal("foo", name);
+            Assert.Equal(new TextSpan(3, 3), nameLocation);
+            Assert.Null(parameterName);
+        }
+
+        [Fact]
+        public void TryGetAttributeInfo_PartialDirectiveAttribute_ReturnsTrue()
+        {
+            var node = GetNodeAt("<input type=\"text\" @bind />", 22);
+
+            // Act
+            var result = DirectiveAttributeCompletionItemProviderBase.TryGetAttributeInfo(node, out var name, out var nameLocation, out var parameterName, out var parameterNameLocation);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal("@bind", name);
+            Assert.Equal(new TextSpan(19, 5), nameLocation);
+            Assert.Null(parameterName);
+        }
+
+        [Fact]
+        public void TryGetAttributeInfo_DirectiveAttribute_ReturnsTrue()
+        {
+            var node = GetNodeAt(@"<input type=""text"" @bind=""@CurrentDate"" />
+@code {
+    public DateTime CurrentDate { get; set; } = DateTime.Now;
+}", 22);
+
+            // Act
+            var result = DirectiveAttributeCompletionItemProviderBase.TryGetAttributeInfo(node, out var name, out var nameLocation, out var parameterName, out var parameterNameLocation);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal("@bind", name);
+            Assert.Equal(new TextSpan(19, 5), nameLocation);
+            Assert.Null(parameterName);
+        }
+
+        [Fact]
+        public void TryGetAttributeInfo_DirectiveAttributeWithParameter_ReturnsTrue()
+        {
+            var node = GetNodeAt(@"<input type=""text"" @bind:format=""MM/dd/yyyy"" @bind=""@CurrentDate"" />
+@code {
+    public DateTime CurrentDate { get; set; } = DateTime.Now;
+}", 22);
+
+            // Act
+            var result = DirectiveAttributeCompletionItemProviderBase.TryGetAttributeInfo(node, out var name, out var nameLocation, out var parameterName, out var parameterNameLocation);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal("@bind", name);
+            Assert.Equal(new TextSpan(19, 5), nameLocation);
+            Assert.Equal("format", parameterName);
+            Assert.Equal(new TextSpan(25, 6), parameterNameLocation);
+        }
+
+        [Fact]
+        public void TryGetElementInfo_MarkupTagParent()
+        {
+            // Arrange
+            var node = GetNodeAt("<p class='hello @DateTime.Now'>", 2);
+
+            // Act
+            var result = DirectiveAttributeCompletionItemProviderBase.TryGetElementInfo(node.Parent, out var tagName, out var attributes);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal("p", tagName);
+            var attributeName = Assert.Single(attributes);
+            Assert.Equal("class", attributeName);
+        }
+
+        [Fact]
+        public void TryGetElementInfo_TagHelperParent()
+        {
+            // Arrange
+            var node = GetNodeAt(@"<input type=""text"" @bind=""@CurrentDate"" />
+@code {
+    public DateTime CurrentDate { get; set; } = DateTime.Now;
+}", 2);
+
+            // Act
+            var result = DirectiveAttributeCompletionItemProviderBase.TryGetElementInfo(node.Parent, out var tagName, out var attributes);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal("input", tagName);
+            Assert.Equal(new[] { "type", "@bind" }, attributes);
+        }
+
+        [Fact]
+        public void TryGetElementInfo_NoAttributes_ReturnsEmptyAttributeCollection()
+        {
+            // Arrange
+            var node = GetNodeAt("<p>", 2);
+
+            // Act
+            var result = DirectiveAttributeCompletionItemProviderBase.TryGetElementInfo(node.Parent, out _, out var attributes);
+
+            // Assert
+            Assert.True(result);
+            Assert.Empty(attributes);
+        }
+
+        [Fact]
+        public void TryGetElementInfo_SingleAttribute_ReturnsAttributeName()
+        {
+            // Arrange
+            var node = GetNodeAt("<p class='hello @DateTime.Now'>", 2);
+
+            // Act
+            var result = DirectiveAttributeCompletionItemProviderBase.TryGetElementInfo(node.Parent, out _, out var attributes);
+
+            // Assert
+            Assert.True(result);
+            var attributeName = Assert.Single(attributes);
+            Assert.Equal("class", attributeName);
+        }
+
+        [Fact]
+        public void TryGetElementInfo_MixedAttributes_ReturnsStringifiedAttributesResult()
+        {
+            // Arrange
+            var node = GetNodeAt(@"<input type=""text"" @bind:format=""MM/dd/yyyy"" something @bind=""@CurrentDate"" />
+@code {
+    public DateTime CurrentDate { get; set; } = DateTime.Now;
+}", 2);
+
+            // Act
+            var result = DirectiveAttributeCompletionItemProviderBase.TryGetElementInfo(node.Parent, out _, out var attributes);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(new[] { "type", "@bind:format", "something", "@bind" }, attributes);
+        }
+
+        private RazorSyntaxNode GetNodeAt(string content, int index)
+        {
+            var result = CompileToCSharp(content, throwOnFailure: false);
+            var syntaxTree = result.CodeDocument.GetSyntaxTree();
+            var change = new SourceChange(new SourceSpan(index, 0), string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(change);
+
+            return owner;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
@@ -1,0 +1,221 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
+using Microsoft.VisualStudio.Editor.Razor;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    public class DirectiveAttributeCompletionItemProviderTest : RazorIntegrationTestBase
+    {
+        internal override string FileKind => FileKinds.Component;
+
+        internal override bool UseTwoPhaseCompilation => true;
+
+        public DirectiveAttributeCompletionItemProviderTest()
+        {
+            Provider = new DirectiveAttributeCompletionItemProvider(new DefaultTagHelperFactsService());
+            var codeDocument = GetCodeDocument(string.Empty);
+            DefaultTagHelperDocumentContext = codeDocument.GetTagHelperContext();
+            EmptyAttributes = Enumerable.Empty<string>();
+        }
+
+        private DirectiveAttributeCompletionItemProvider Provider { get; }
+
+        private TagHelperDocumentContext DefaultTagHelperDocumentContext { get; }
+
+        private IEnumerable<string> EmptyAttributes { get; }
+
+        private RazorCodeDocument GetCodeDocument(string content)
+        {
+            var result = CompileToCSharp(content, throwOnFailure: false);
+            return result.CodeDocument;
+        }
+
+        [Fact]
+        public void GetCompletionItems_LocationHasNoOwner_ReturnsEmptyCollection()
+        {
+            // Arrange
+            var codeDocument = GetCodeDocument("<input @  />");
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
+            var span = new SourceSpan(30, 0);
+
+            // Act
+            var completions = Provider.GetCompletionItems(syntaxTree, tagHelperDocumentContext, span);
+
+            // Assert
+            Assert.Empty(completions);
+        }
+
+        [Fact]
+        public void GetCompletionItems_OnNonAttributeArea_ReturnsEmptyCollection()
+        {
+            // Arrange
+            var codeDocument = GetCodeDocument("<input @  />");
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
+            var span = new SourceSpan(3, 0);
+
+            // Act
+            var completions = Provider.GetCompletionItems(syntaxTree, tagHelperDocumentContext, span);
+
+            // Assert
+            Assert.Empty(completions);
+        }
+
+        [Fact]
+        public void GetCompletionItems_OnDirectiveAttributeParameter_ReturnsEmptyCollection()
+        {
+            // Arrange
+            var codeDocument = GetCodeDocument("<input @bind:fo  />");
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
+            var span = new SourceSpan(14, 0);
+
+            // Act
+            var completions = Provider.GetCompletionItems(syntaxTree, tagHelperDocumentContext, span);
+
+            // Assert
+            Assert.Empty(completions);
+        }
+
+        [Fact]
+        public void GetCompletionItems_OnDirectiveAttributeName_ReturnsCompletions()
+        {
+            // Arrange
+            var codeDocument = GetCodeDocument("<input @  />");
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
+            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
+            var span = new SourceSpan(8, 0);
+
+            // Act
+            var completions = Provider.GetCompletionItems(syntaxTree, tagHelperDocumentContext, span);
+
+            // Assert
+            Assert.Contains(expectedCompletion, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_NoDescriptorsForTag_ReturnsEmptyCollection()
+        {
+            // Arrange
+            var documentContext = TagHelperDocumentContext.Create(string.Empty, Enumerable.Empty<TagHelperDescriptor>());
+
+            // Act
+            var completions = Provider.GetAttributeCompletions("@bin", "foobarbaz", EmptyAttributes, documentContext);
+
+            // Assert
+            Assert.Empty(completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_NoDirectiveAttributesForTag_ReturnsEmptyCollection()
+        {
+            // Arrange
+            var descriptor = TagHelperDescriptorBuilder.Create("CatchAll", "TestAssembly");
+            descriptor.BoundAttributeDescriptor(boundAttribute => boundAttribute.Name = "Test");
+            descriptor.TagMatchingRule(rule => rule.RequireTagName("*"));
+            var documentContext = TagHelperDocumentContext.Create(string.Empty, new[] { descriptor.Build() });
+
+            // Act
+            var completions = Provider.GetAttributeCompletions("@bin", "input", EmptyAttributes, documentContext);
+
+            // Assert
+            Assert.Empty(completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_SelectedDirectiveAttribute_IsIncludedInCompletions()
+        {
+            // Arrange
+            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
+            var attributeNames = new string[] { "@bind" };
+
+            // Act
+            var completions = Provider.GetAttributeCompletions("@bind", "input", attributeNames, DefaultTagHelperDocumentContext);
+
+            // Assert
+            Assert.Contains(expectedCompletion, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_NonIndexer_ReturnsCompletion()
+        {
+            // Arrange
+            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
+
+            // Act
+            var completions = Provider.GetAttributeCompletions("@", "input", EmptyAttributes, DefaultTagHelperDocumentContext);
+
+            // Assert
+            Assert.Contains(expectedCompletion, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_Indexer_ReturnsCompletion()
+        {
+            // Arrange
+            var expectedCompletion = new RazorCompletionItem("@bind-...", "@bind-", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
+
+            // Act
+            var completions = Provider.GetAttributeCompletions("@", "input", EmptyAttributes, DefaultTagHelperDocumentContext);
+
+            // Assert
+            Assert.Contains(expectedCompletion, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_BaseDirectiveAttributeDoesNotExist_DoesNotIncludeParamterizedAttribute()
+        {
+            // Arrange
+            var expectedCompletion = new RazorCompletionItem("@bind:", "@bind:", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
+            var attributeNames = new[] { "@" };
+
+            // Act
+            var completions = Provider.GetAttributeCompletions("@", "input", attributeNames, DefaultTagHelperDocumentContext);
+
+            // Assert
+            Assert.DoesNotContain(expectedCompletion, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_BaseDirectiveAttributeAlreadyExists_IncludesBaseAttribute()
+        {
+            // Arrange
+            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
+            var attributeNames = new[] { "@bind", "@" };
+
+            // Act
+            var completions = Provider.GetAttributeCompletions("@", "input", attributeNames, DefaultTagHelperDocumentContext);
+
+            // Assert
+            Assert.Contains(expectedCompletion, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_BaseDirectiveAttributeAndParameterVariationsExist_ExcludesCompletion()
+        {
+            // Arrange
+            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
+            var attributeNames = new[]
+            {
+                "@bind",
+                "@bind:format",
+                "@bind:event",
+                "@",
+            };
+
+            // Act
+            var completions = Provider.GetAttributeCompletions("@", "input", attributeNames, DefaultTagHelperDocumentContext);
+
+            // Assert
+            Assert.DoesNotContain(expectedCompletion, completions);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
@@ -91,14 +91,13 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var codeDocument = GetCodeDocument("<input @  />");
             var syntaxTree = codeDocument.GetSyntaxTree();
             var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
             var span = new SourceSpan(8, 0);
 
             // Act
             var completions = Provider.GetCompletionItems(syntaxTree, tagHelperDocumentContext, span);
 
             // Assert
-            Assert.Contains(expectedCompletion, completions);
+            AssertContains(completions, "@bind");
         }
 
         [Fact]
@@ -134,75 +133,59 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetAttributeCompletions_SelectedDirectiveAttribute_IsIncludedInCompletions()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
             var attributeNames = new string[] { "@bind" };
 
             // Act
             var completions = Provider.GetAttributeCompletions("@bind", "input", attributeNames, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.Contains(expectedCompletion, completions);
+            AssertContains(completions, "@bind");
         }
 
         [Fact]
         public void GetAttributeCompletions_NonIndexer_ReturnsCompletion()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
+
 
             // Act
             var completions = Provider.GetAttributeCompletions("@", "input", EmptyAttributes, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.Contains(expectedCompletion, completions);
+            AssertContains(completions, "@bind");
         }
 
         [Fact]
         public void GetAttributeCompletions_Indexer_ReturnsCompletion()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("@bind-...", "@bind-", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
+
 
             // Act
             var completions = Provider.GetAttributeCompletions("@", "input", EmptyAttributes, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.Contains(expectedCompletion, completions);
-        }
-
-        [Fact]
-        public void GetAttributeCompletions_BaseDirectiveAttributeDoesNotExist_DoesNotIncludeParamterizedAttribute()
-        {
-            // Arrange
-            var expectedCompletion = new RazorCompletionItem("@bind:", "@bind:", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
-            var attributeNames = new[] { "@" };
-
-            // Act
-            var completions = Provider.GetAttributeCompletions("@", "input", attributeNames, DefaultTagHelperDocumentContext);
-
-            // Assert
-            Assert.DoesNotContain(expectedCompletion, completions);
+            AssertContains(completions, "@bind-", "@bind-...");
         }
 
         [Fact]
         public void GetAttributeCompletions_BaseDirectiveAttributeAlreadyExists_IncludesBaseAttribute()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
             var attributeNames = new[] { "@bind", "@" };
 
             // Act
             var completions = Provider.GetAttributeCompletions("@", "input", attributeNames, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.Contains(expectedCompletion, completions);
+            AssertContains(completions, "@bind");
         }
 
         [Fact]
         public void GetAttributeCompletions_BaseDirectiveAttributeAndParameterVariationsExist_ExcludesCompletion()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
+            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", RazorCompletionItemKind.DirectiveAttribute);
             var attributeNames = new[]
             {
                 "@bind",
@@ -215,7 +198,31 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var completions = Provider.GetAttributeCompletions("@", "input", attributeNames, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.DoesNotContain(expectedCompletion, completions);
+            AssertDoesNotContain(completions, "@bind");
+        }
+
+        private static void AssertContains(IReadOnlyList<RazorCompletionItem> completions, string insertText, string displayText = null)
+        {
+            displayText = displayText ?? insertText;
+
+            Assert.Contains(completions, completion =>
+            {
+                return insertText == completion.InsertText &&
+                    displayText == completion.DisplayText &&
+                    RazorCompletionItemKind.DirectiveAttribute == completion.Kind;
+            });
+        }
+
+        private static void AssertDoesNotContain(IReadOnlyList<RazorCompletionItem> completions, string insertText, string displayText = null)
+        {
+            displayText = displayText ?? insertText;
+
+            Assert.DoesNotContain(completions, completion =>
+            {
+                return insertText == completion.InsertText &&
+                   displayText == completion.DisplayText &&
+                   RazorCompletionItemKind.DirectiveAttribute == completion.Kind;
+            });
         }
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
@@ -1,0 +1,184 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
+using Microsoft.VisualStudio.Editor.Razor;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    public class DirectiveAttributeParameterCompletionItemProviderTest : RazorIntegrationTestBase
+    {
+        internal override string FileKind => FileKinds.Component;
+
+        internal override bool UseTwoPhaseCompilation => true;
+
+        public DirectiveAttributeParameterCompletionItemProviderTest()
+        {
+            Provider = new DirectiveAttributeParameterCompletionItemProvider(new DefaultTagHelperFactsService());
+            var codeDocument = GetCodeDocument(string.Empty);
+            DefaultTagHelperDocumentContext = codeDocument.GetTagHelperContext();
+            EmptyAttributes = Enumerable.Empty<string>();
+        }
+
+        private DirectiveAttributeParameterCompletionItemProvider Provider { get; }
+
+        private TagHelperDocumentContext DefaultTagHelperDocumentContext { get; }
+
+        private IEnumerable<string> EmptyAttributes { get; }
+
+        private RazorCodeDocument GetCodeDocument(string content)
+        {
+            var result = CompileToCSharp(content, throwOnFailure: false);
+            return result.CodeDocument;
+        }
+
+        [Fact]
+        public void GetCompletionItems_LocationHasNoOwner_ReturnsEmptyCollection()
+        {
+            // Arrange
+            var codeDocument = GetCodeDocument("<input @  />");
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
+            var span = new SourceSpan(30, 0);
+
+            // Act
+            var completions = Provider.GetCompletionItems(syntaxTree, tagHelperDocumentContext, span);
+
+            // Assert
+            Assert.Empty(completions);
+        }
+
+        [Fact]
+        public void GetCompletionItems_OnNonAttributeArea_ReturnsEmptyCollection()
+        {
+            // Arrange
+            var codeDocument = GetCodeDocument("<input @  />");
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
+            var span = new SourceSpan(3, 0);
+
+            // Act
+            var completions = Provider.GetCompletionItems(syntaxTree, tagHelperDocumentContext, span);
+
+            // Assert
+            Assert.Empty(completions);
+        }
+
+        [Fact]
+        public void GetCompletionItems_OnDirectiveAttributeName_ReturnsEmptyCollection()
+        {
+            // Arrange
+            var codeDocument = GetCodeDocument("<input @bind:fo  />");
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
+            var span = new SourceSpan(8, 0);
+
+            // Act
+            var completions = Provider.GetCompletionItems(syntaxTree, tagHelperDocumentContext, span);
+
+            // Assert
+            Assert.Empty(completions);
+        }
+
+        [Fact]
+        public void GetCompletionItems_OnDirectiveAttributeParameter_ReturnsCompletions()
+        {
+            // Arrange
+            var codeDocument = GetCodeDocument("<input @bind:fo  />");
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
+            var expectedCompletions = new[] {
+                new RazorCompletionItem("event", "event", string.Empty, RazorCompletionItemKind.DirectiveAttributeParameter),
+                new RazorCompletionItem("format", "format", string.Empty, RazorCompletionItemKind.DirectiveAttributeParameter),
+            };
+            var span = new SourceSpan(14, 0);
+
+            // Act
+            var completions = Provider.GetCompletionItems(syntaxTree, tagHelperDocumentContext, span);
+
+            // Assert
+            var orderedCompletions = completions.OrderBy(c => c.DisplayText);
+            Assert.Equal(expectedCompletions, orderedCompletions);
+        }
+
+        [Fact]
+        public void GetAttributeParameterCompletions_NoDescriptorsForTag_ReturnsEmptyCollection()
+        {
+            // Arrange
+            var documentContext = TagHelperDocumentContext.Create(string.Empty, Enumerable.Empty<TagHelperDescriptor>());
+
+            // Act
+            var completions = Provider.GetAttributeParameterCompletions("@bin", string.Empty, "foobarbaz", EmptyAttributes, documentContext);
+
+            // Assert
+            Assert.Empty(completions);
+        }
+
+        [Fact]
+        public void GetAttributeParameterCompletions_NoDirectiveAttributesForTag_ReturnsEmptyCollection()
+        {
+            // Arrange
+            var descriptor = TagHelperDescriptorBuilder.Create("CatchAll", "TestAssembly");
+            descriptor.BoundAttributeDescriptor(boundAttribute => boundAttribute.Name = "Test");
+            descriptor.TagMatchingRule(rule => rule.RequireTagName("*"));
+            var documentContext = TagHelperDocumentContext.Create(string.Empty, new[] { descriptor.Build() });
+
+            // Act
+            var completions = Provider.GetAttributeParameterCompletions("@bin", string.Empty, "input", EmptyAttributes, documentContext);
+
+            // Assert
+            Assert.Empty(completions);
+        }
+
+        [Fact]
+        public void GetAttributeParameterCompletions_SelectedDirectiveAttributeParameter_IsExcludedInCompletions()
+        {
+            // Arrange
+            var expectedCompletion = new RazorCompletionItem("format", "format", string.Empty, RazorCompletionItemKind.DirectiveAttributeParameter);
+            var attributeNames = new string[] { "@bind" };
+
+            // Act
+            var completions = Provider.GetAttributeParameterCompletions("@bind", "format", "input", attributeNames, DefaultTagHelperDocumentContext);
+
+            // Assert
+            Assert.DoesNotContain(expectedCompletion, completions);
+        }
+
+        [Fact]
+        public void GetAttributeParameterCompletions_ReturnsCompletion()
+        {
+            // Arrange
+            var expectedCompletion = new RazorCompletionItem("format", "format", string.Empty, RazorCompletionItemKind.DirectiveAttributeParameter);
+
+            // Act
+            var completions = Provider.GetAttributeParameterCompletions("@bind", string.Empty, "input", EmptyAttributes, DefaultTagHelperDocumentContext);
+
+            // Assert
+            Assert.Contains(expectedCompletion, completions);
+        }
+
+        [Fact]
+        public void GetAttributeParameterCompletions_BaseDirectiveAttributeAndParameterVariationsExist_ExcludesCompletion()
+        {
+            // Arrange
+            var expectedCompletion = new RazorCompletionItem("format", "format", string.Empty, RazorCompletionItemKind.DirectiveAttributeParameter);
+            var attributeNames = new[]
+            {
+                "@bind",
+                "@bind:format",
+                "@bind:event",
+                "@",
+            };
+
+            // Act
+            var completions = Provider.GetAttributeParameterCompletions("@bind", string.Empty, "input", attributeNames, DefaultTagHelperDocumentContext);
+
+            // Assert
+            Assert.DoesNotContain(expectedCompletion, completions);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
@@ -91,18 +91,15 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var codeDocument = GetCodeDocument("<input @bind:fo  />");
             var syntaxTree = codeDocument.GetSyntaxTree();
             var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var expectedCompletions = new[] {
-                new RazorCompletionItem("event", "event", string.Empty, RazorCompletionItemKind.DirectiveAttributeParameter),
-                new RazorCompletionItem("format", "format", string.Empty, RazorCompletionItemKind.DirectiveAttributeParameter),
-            };
             var span = new SourceSpan(14, 0);
 
             // Act
             var completions = Provider.GetCompletionItems(syntaxTree, tagHelperDocumentContext, span);
 
             // Assert
-            var orderedCompletions = completions.OrderBy(c => c.DisplayText);
-            Assert.Equal(expectedCompletions, orderedCompletions);
+            Assert.Equal(2, completions.Count);
+            AssertContains(completions, "event");
+            AssertContains(completions, "format");
         }
 
         [Fact]
@@ -138,34 +135,32 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetAttributeParameterCompletions_SelectedDirectiveAttributeParameter_IsExcludedInCompletions()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("format", "format", string.Empty, RazorCompletionItemKind.DirectiveAttributeParameter);
             var attributeNames = new string[] { "@bind" };
 
             // Act
             var completions = Provider.GetAttributeParameterCompletions("@bind", "format", "input", attributeNames, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.DoesNotContain(expectedCompletion, completions);
+            AssertDoesNotContain(completions, "format");
         }
 
         [Fact]
         public void GetAttributeParameterCompletions_ReturnsCompletion()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("format", "format", string.Empty, RazorCompletionItemKind.DirectiveAttributeParameter);
+
 
             // Act
             var completions = Provider.GetAttributeParameterCompletions("@bind", string.Empty, "input", EmptyAttributes, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.Contains(expectedCompletion, completions);
+            AssertContains(completions, "format");
         }
 
         [Fact]
         public void GetAttributeParameterCompletions_BaseDirectiveAttributeAndParameterVariationsExist_ExcludesCompletion()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("format", "format", string.Empty, RazorCompletionItemKind.DirectiveAttributeParameter);
             var attributeNames = new[]
             {
                 "@bind",
@@ -178,7 +173,28 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var completions = Provider.GetAttributeParameterCompletions("@bind", string.Empty, "input", attributeNames, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.DoesNotContain(expectedCompletion, completions);
+            AssertDoesNotContain(completions, "format");
+        }
+
+        private static void AssertContains(IReadOnlyList<RazorCompletionItem> completions, string insertText)
+        {
+            Assert.Contains(completions, completion =>
+            {
+                return insertText == completion.InsertText &&
+                    insertText == completion.DisplayText &&
+                    RazorCompletionItemKind.DirectiveAttributeParameter == completion.Kind;
+            });
+        }
+
+        private static void AssertDoesNotContain(IReadOnlyList<RazorCompletionItem> completions, string insertText)
+        {
+
+            Assert.DoesNotContain(completions, completion =>
+            {
+                return insertText == completion.InsertText &&
+                   insertText == completion.DisplayText &&
+                   RazorCompletionItemKind.DirectiveAttributeParameter == completion.Kind;
+            });
         }
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -287,7 +287,8 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             Assert.Equal(item.DisplayText, completionDisplayText);
             Assert.Equal(item.InsertText, directive.Directive);
-            Assert.Equal(directive.Description, item.Description);
+            var completionDescription = item.GetDirectiveCompletionDescription();
+            Assert.Equal(directive.Description, completionDescription.Description);
         }
 
         private static void AssertRazorCompletionItem(DirectiveDescriptor directive, RazorCompletionItem item) =>

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/DefaultVisualStudioDescriptionFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/DefaultVisualStudioDescriptionFactoryTest.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.VisualStudio.Text.Adornments;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
+{
+    public class DefaultVisualStudioDescriptionFactoryTest
+    {
+        [Fact]
+        public void CreateClassifiedDescription_SingleDescription_NoSeparator()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("TheReturnType", "TheTypeName", "ThePropertyName", "The documentation"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            Assert.DoesNotContain(DefaultVisualStudioDescriptionFactory.SeparatorElement, result.Elements);
+        }
+
+        [Fact]
+        public void CreateClassifiedDescription_MultipleDescription_Separator()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("TheReturnType", "TheTypeName", "ThePropertyName", "The documentation"),
+                new AttributeDescriptionInfo("TheReturnType2", "TheTypeName2", "ThePropertyName2", "The documentation2"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            Assert.Contains(DefaultVisualStudioDescriptionFactory.SeparatorElement, result.Elements);
+        }
+
+        [Fact]
+        public void CreateClassifiedDescription_RepresentsReturnType()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("TheReturnType", "TheTypeName", "ThePropertyName", "The documentation"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            var flattened = FlattenToStrings(result);
+            Assert.Contains(description.DescriptionInfos[0].ReturnTypeName, flattened);
+        }
+
+        [Fact]
+        public void CreateClassifiedDescription_RepresentsTypeName()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("TheReturnType", "TheTypeName", "ThePropertyName", "The documentation"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            var flattened = FlattenToStrings(result);
+            Assert.Contains(description.DescriptionInfos[0].TypeName, flattened);
+        }
+
+        [Fact]
+        public void CreateClassifiedDescription_RepresentsPropertyName()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("TheReturnType", "TheTypeName", "ThePropertyName", "The documentation"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            var flattened = FlattenToStrings(result);
+            Assert.Contains(description.DescriptionInfos[0].PropertyName, flattened);
+        }
+
+        [Fact]
+        public void CreateClassifiedDescription_RepresentsDocumentation()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("TheReturnType", "TheTypeName", "ThePropertyName", "The documentation"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            var flattened = FlattenToStrings(result);
+            Assert.Contains(description.DescriptionInfos[0].Documentation, flattened);
+        }
+
+        [Fact]
+        public void CreateClassifiedDescription_CanSimplifyKeywordReturnTypes()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("System.String", "TheTypeName", "ThePropertyName", "The documentation"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            var flattened = FlattenToStrings(result);
+            Assert.DoesNotContain(description.DescriptionInfos[0].ReturnTypeName, flattened);
+            Assert.Contains("string", flattened);
+        }
+
+        [Fact]
+        public void CreateClassifiedDescription_CanRepresentMultipleDescriptions()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("System.String", "TheTypeName", "ThePropertyName", "The documentation"),
+                new AttributeDescriptionInfo("System.Int32", "TheSecondTypeName", "TheSecondPropertyName", "The second documentation"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            var flattened = FlattenToStrings(result);
+            Assert.Contains(description.DescriptionInfos[0].TypeName, flattened);
+            Assert.Contains(description.DescriptionInfos[1].TypeName, flattened);
+            Assert.Contains(description.DescriptionInfos[0].Documentation, flattened);
+            Assert.Contains(description.DescriptionInfos[1].Documentation, flattened);
+        }
+
+        public IReadOnlyList<string> FlattenToStrings(ContainerElement element)
+        {
+            var flattenedList = new List<string>();
+            foreach (var child in element.Elements)
+            {
+                switch (child)
+                {
+                    case ContainerElement childContainer:
+                        var flattened = FlattenToStrings(childContainer);
+                        flattenedList.AddRange(flattened);
+                        break;
+                    case ClassifiedTextElement textElement:
+                        foreach (var run in textElement.Runs)
+                        {
+                            flattenedList.Add(run.Text);
+                        }
+                        break;
+                }
+            }
+
+            return flattenedList;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveAttributeCommitManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveAttributeCommitManagerTest.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
+using Microsoft.VisualStudio.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
+{
+    public class RazorDirectiveAttributeCommitManagerTest
+    {
+        [Fact]
+        public void ShouldCommitCompletion_NoCompletionItemKinds_ReturnsFalse()
+        {
+            // Arrange
+            var manager = new RazorDirectiveAttributeCommitManager();
+            var properties = new PropertyCollection();
+            var session = Mock.Of<IAsyncCompletionSession>(s => s.Properties == properties);
+
+            // Act
+            var result = manager.ShouldCommitCompletion(session, location: default, typedChar: '=', token: default);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ShouldCommitCompletion_CompletionItemKinds_ReturnsTrue()
+        {
+            // Arrange
+            var manager = new RazorDirectiveAttributeCommitManager();
+            var properties = new PropertyCollection();
+            properties.SetCompletionItemKinds(new HashSet<RazorCompletionItemKind>() { RazorCompletionItemKind.DirectiveAttribute });
+            var session = Mock.Of<IAsyncCompletionSession>(s => s.Properties == properties);
+
+            // Act
+            var result = manager.ShouldCommitCompletion(session, location: default, typedChar: '=', token: default);
+
+            // Assert
+            Assert.True(result);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveAttributeCommitManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveAttributeCommitManagerTest.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Utilities;
@@ -45,6 +41,22 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
 
             // Assert
             Assert.True(result);
+        }
+
+        [Fact]
+        public void ShouldCommitCompletion_DirectiveParameterCompletion_ColonCommit_ReturnsFalse()
+        {
+            // Arrange
+            var manager = new RazorDirectiveAttributeCommitManager();
+            var properties = new PropertyCollection();
+            properties.SetCompletionItemKinds(new HashSet<RazorCompletionItemKind>() { RazorCompletionItemKind.DirectiveAttributeParameter });
+            var session = Mock.Of<IAsyncCompletionSession>(s => s.Properties == properties);
+
+            // Act
+            var result = manager.ShouldCommitCompletion(session, location: default, typedChar: ':', token: default);
+
+            // Assert
+            Assert.False(result);
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveAttributeCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveAttributeCompletionSourceTest.cs
@@ -80,22 +80,6 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
         }
 
         [Fact]
-        public void InitializeCompletion_TriggeredAtPossibleDirectiveAttributeParameter_ReturnsDoesNotParticipate()
-        {
-            // Arrange
-            var source = CreateCompletionSource();
-            var snapshot = new StringTextSnapshot("<input @bind:format='@foo' />");
-            var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
-            var triggerLocation = new SnapshotPoint(snapshot, 14);
-
-            // Act
-            var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);
-
-            // Assert
-            Assert.Equal(CompletionStartData.DoesNotParticipateInCompletion, result);
-        }
-
-        [Fact]
         public void InitializeCompletion_TriggeredAtPossibleDirectiveWithAttributeParameter_ReturnsParticipate()
         {
             // Arrange
@@ -104,6 +88,23 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
             var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
             var triggerLocation = new SnapshotPoint(snapshot, 9);
             var expectedApplicableToSpan = new SnapshotSpan(snapshot, new Span(7, 5));
+
+            // Act
+            var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(expectedApplicableToSpan, result.ApplicableToSpan);
+        }
+
+        [Fact]
+        public void InitializeCompletion_TriggeredAtPossibleDirectiveAttributeParameter_ReturnsParticipate()
+        {
+            // Arrange
+            var source = CreateCompletionSource();
+            var snapshot = new StringTextSnapshot("<input @bind:format='@foo' />");
+            var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
+            var triggerLocation = new SnapshotPoint(snapshot, 13);
+            var expectedApplicableToSpan = new SnapshotSpan(snapshot, new Span(13, 6));
 
             // Act
             var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveAttributeCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveAttributeCompletionSourceTest.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
+{
+    public class RazorDirectiveAttributeCompletionSourceTest : ForegroundDispatcherTestBase
+    {
+        [Fact]
+        public void InitializeCompletion_EmptySnapshot_ReturnsDoesNotParticipate()
+        {
+            // Arrange
+            var source = CreateCompletionSource();
+            var emptySnapshot = new StringTextSnapshot(string.Empty);
+            var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, emptySnapshot);
+            var triggerLocation = new SnapshotPoint(emptySnapshot, 0);
+
+            // Act
+            var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(CompletionStartData.DoesNotParticipateInCompletion, result);
+        }
+
+        [Fact]
+        public void InitializeCompletion_TriggeredAtStartOfDocument_ReturnsDoesNotParticipate()
+        {
+            // Arrange
+            var source = CreateCompletionSource();
+            var snapshot = new StringTextSnapshot("<p class='foo'></p>");
+            var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
+            var triggerLocation = new SnapshotPoint(snapshot, 0);
+
+            // Act
+            var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(CompletionStartData.DoesNotParticipateInCompletion, result);
+        }
+
+        [Fact]
+        public void InitializeCompletion_TriggeredAtInvalidLocation_ReturnsDoesNotParticipate()
+        {
+            // Arrange
+            var source = CreateCompletionSource();
+            var snapshot = new StringTextSnapshot("<p class='foo'></p>");
+            var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
+
+            // Act & Assert
+            for (var i = 0; i < snapshot.Length; i++)
+            {
+                var triggerLocation = new SnapshotPoint(snapshot, i);
+                var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);
+                Assert.Equal(CompletionStartData.DoesNotParticipateInCompletion, result);
+            }
+        }
+
+        [Fact]
+        public void InitializeCompletion_TriggeredAtPossibleDirectiveAttribute_ReturnsParticipate()
+        {
+            // Arrange
+            var source = CreateCompletionSource();
+            var snapshot = new StringTextSnapshot("<input @bind='@foo' />");
+            var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
+            var triggerLocation = new SnapshotPoint(snapshot, 9);
+            var expectedApplicableToSpan = new SnapshotSpan(snapshot, new Span(7, 5));
+
+            // Act
+            var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(expectedApplicableToSpan, result.ApplicableToSpan);
+        }
+
+        [Fact]
+        public void InitializeCompletion_TriggeredAtPossibleDirectiveAttributeParameter_ReturnsDoesNotParticipate()
+        {
+            // Arrange
+            var source = CreateCompletionSource();
+            var snapshot = new StringTextSnapshot("<input @bind:format='@foo' />");
+            var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
+            var triggerLocation = new SnapshotPoint(snapshot, 14);
+
+            // Act
+            var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(CompletionStartData.DoesNotParticipateInCompletion, result);
+        }
+
+        [Fact]
+        public void InitializeCompletion_TriggeredAtPossibleDirectiveWithAttributeParameter_ReturnsParticipate()
+        {
+            // Arrange
+            var source = CreateCompletionSource();
+            var snapshot = new StringTextSnapshot("<input @bind:format='@foo' />");
+            var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
+            var triggerLocation = new SnapshotPoint(snapshot, 9);
+            var expectedApplicableToSpan = new SnapshotSpan(snapshot, new Span(7, 5));
+
+            // Act
+            var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(expectedApplicableToSpan, result.ApplicableToSpan);
+        }
+
+        private RazorDirectiveAttributeCompletionSource CreateCompletionSource()
+        {
+            var source = new RazorDirectiveAttributeCompletionSource(
+                Dispatcher,
+                Mock.Of<VisualStudioRazorParser>(),
+                Mock.Of<RazorCompletionFactsService>(),
+                Mock.Of<ICompletionBroker>());
+            return source;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionProviderTest.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
@@ -21,7 +20,7 @@ using Moq;
 using Xunit;
 using ITextBuffer = Microsoft.VisualStudio.Text.ITextBuffer;
 
-namespace Microsoft.VisualStudio.Editor.Razor
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
 {
     public class RazorDirectiveCompletionProviderTest
     {

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceProviderTest.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.Utilities;
 using Moq;
 using Xunit;
 
-namespace Microsoft.VisualStudio.Editor.Razor
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
 {
     public class RazorDirectiveCompletionSourceProviderTest : ForegroundDispatcherTestBase
     {

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
         {
             // Arrange
             var completionItem = new CompletionItem("TestDirective", Mock.Of<IAsyncCompletionSource>());
-            var expectedDescription = "The expected description";
+            var expectedDescription = new DirectiveCompletionDescription("The expected description");
             completionItem.Properties.AddProperty(RazorDirectiveCompletionSource.DescriptionKey, expectedDescription);
             var completionSource = new RazorDirectiveCompletionSource(Dispatcher, Mock.Of<VisualStudioRazorParser>(), CompletionFactsService);
 
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
 
             // Assert
             var description = Assert.IsType<string>(descriptionObject);
-            Assert.Equal(expectedDescription, descriptionObject);
+            Assert.Equal(expectedDescription.Description, descriptionObject);
         }
 
         [Fact]
@@ -132,8 +132,8 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
             Assert.Equal(item.FilterText, completionDisplayText);
             Assert.Equal(item.InsertText, directive.Directive);
             Assert.Same(item.Source, source);
-            Assert.True(item.Properties.TryGetProperty<string>(RazorDirectiveCompletionSource.DescriptionKey, out var actualDescription));
-            Assert.Equal(directive.Description, actualDescription);
+            Assert.True(item.Properties.TryGetProperty<DirectiveCompletionDescription>(RazorDirectiveCompletionSource.DescriptionKey, out var actualDescription));
+            Assert.Equal(directive.Description, actualDescription.Description);
 
             AssertRazorCompletionItemDefaults(item);
         }

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
@@ -17,7 +16,7 @@ using Moq;
 using Xunit;
 using Span = Microsoft.VisualStudio.Text.Span;
 
-namespace Microsoft.VisualStudio.Editor.Razor
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
 {
     public class RazorDirectiveCompletionSourceTest : ForegroundDispatcherTestBase
     {


### PR DESCRIPTION
- Added a completion source to hook into VisualStudio's modern completion. To properly hook into VisualStudio I needed to restrict our completion events to only fire in potential attribute scenarios. When detecting potential directive attributes we needed to determine which parts of the completion would be replaced on a committed completion without having a SyntaxTree. To do this I do a fuzzy textual character search to find things that look like a directive attribute name or a parameter (`:parameterName`) following a directive attribute name.
- Part of hooking into VS' completion engine involved handling the situation when legacy completion is active while modern completion is being invoked, to not have two completion lists pop up we dismiss the legacy completion sessions when we think we can provide completions.
- Utilized the same image monikers as TagHelper element/attribute completions to make things seem seamless when alternating between legacy and modern completion.
- Expanded the completion facts service to understand directive attribute names (not parameters). Had to handle malformed attributes, partially valid directive attributes, untyped attributes etc.
- Added new tests to verify VS completion and completion facts service functionality.

![image](https://i.imgur.com/JOSqDyq.gif)

This is bullet point five https://github.com/aspnet/AspNetCore/issues/6364#issuecomment-495432347

aspnet/AspNetCore#6364