### PR TITLE
Add support for directive attribute descriptions

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AttributeCompletionDescription.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AttributeCompletionDescription.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    internal class AttributeCompletionDescription
+    {
+        public AttributeCompletionDescription(IReadOnlyList<AttributeDescriptionInfo> descriptionInfos)
+        {
+            if (descriptionInfos == null)
+            {
+                throw new ArgumentNullException(nameof(descriptionInfos));
+            }
+
+            DescriptionInfos = descriptionInfos;
+        }
+
+        public IReadOnlyList<AttributeDescriptionInfo> DescriptionInfos { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AttributeDescriptionInfo.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AttributeDescriptionInfo.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    internal sealed class AttributeDescriptionInfo : IEquatable<AttributeDescriptionInfo>
+    {
+        public AttributeDescriptionInfo(
+            string returnTypeName,
+            string typeName,
+            string propertyName,
+            string documentation)
+        {
+            if (returnTypeName is null)
+            {
+                throw new ArgumentNullException(nameof(returnTypeName));
+            }
+
+            if (typeName is null)
+            {
+                throw new ArgumentNullException(nameof(typeName));
+            }
+
+            if (propertyName is null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            ReturnTypeName = returnTypeName;
+            TypeName = typeName;
+            PropertyName = propertyName;
+            Documentation = documentation ?? string.Empty;
+        }
+
+        public string ReturnTypeName { get; }
+
+        public string TypeName { get; }
+
+        public string PropertyName { get; }
+
+        public string Documentation { get; }
+
+        public bool Equals(AttributeDescriptionInfo other)
+        {
+            if (!string.Equals(ReturnTypeName, other.ReturnTypeName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (!string.Equals(TypeName, other.TypeName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (!string.Equals(PropertyName, other.PropertyName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (!string.Equals(Documentation, other.Documentation, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = HashCodeCombiner.Start();
+            combiner.Add(ReturnTypeName);
+            combiner.Add(TypeName);
+            combiner.Add(PropertyName);
+            combiner.Add(Documentation);
+
+            return combiner.CombinedHash;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionDescription.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionDescription.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    internal class DirectiveCompletionDescription
+    {
+        public DirectiveCompletionDescription(string description)
+        {
+            if (description == null)
+            {
+                throw new ArgumentNullException(nameof(description));
+            }
+
+            Description = description;
+        }
+
+        public string Description { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -108,8 +108,9 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                 var completionItem = new RazorCompletionItem(
                     completionDisplayText,
                     directive.Directive,
-                    directive.Description,
                     RazorCompletionItemKind.Directive);
+                var completionDescription = new DirectiveCompletionDescription(directive.Description);
+                completionItem.SetDirectiveCompletionDescription(completionDescription);
                 completionItems.Add(completionItem);
             }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemExtensions.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    internal static class RazorCompletionItemExtensions
+    {
+        private readonly static string AttributeCompletionDescriptionKey = "Razor.AttributeDescription";
+        private readonly static string DirectiveCompletionDescriptionKey = "Razor.DirectiveDescription";
+
+        public static void SetAttributeCompletionDescription(this RazorCompletionItem completionItem, AttributeCompletionDescription attributeCompletionDescription)
+        {
+            if (completionItem is null)
+            {
+                throw new ArgumentNullException(nameof(completionItem));
+            }
+
+            completionItem.Items[AttributeCompletionDescriptionKey] = attributeCompletionDescription;
+        }
+
+        public static AttributeCompletionDescription GetAttributeCompletionDescription(this RazorCompletionItem completionItem)
+        {
+            if (completionItem is null)
+            {
+                throw new ArgumentNullException(nameof(completionItem));
+            }
+
+            var attributeCompletionDescription = completionItem.Items[AttributeCompletionDescriptionKey] as AttributeCompletionDescription;
+            return attributeCompletionDescription;
+        }
+
+        public static void SetDirectiveCompletionDescription(this RazorCompletionItem completionItem, DirectiveCompletionDescription attributeCompletionDescription)
+        {
+            if (completionItem is null)
+            {
+                throw new ArgumentNullException(nameof(completionItem));
+            }
+
+            completionItem.Items[DirectiveCompletionDescriptionKey] = attributeCompletionDescription;
+        }
+
+        public static DirectiveCompletionDescription GetDirectiveCompletionDescription(this RazorCompletionItem completionItem)
+        {
+            if (completionItem is null)
+            {
+                throw new ArgumentNullException(nameof(completionItem));
+            }
+
+            var attributeCompletionDescription = completionItem.Items[DirectiveCompletionDescriptionKey] as DirectiveCompletionDescription;
+            return attributeCompletionDescription;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/DefaultVisualStudioDescriptionFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/DefaultVisualStudioDescriptionFactory.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.VisualStudio.Core.Imaging;
+using Microsoft.VisualStudio.Text.Adornments;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
+{
+    [Shared]
+    [Export(typeof(VisualStudioDescriptionFactory))]
+    internal class DefaultVisualStudioDescriptionFactory : VisualStudioDescriptionFactory
+    {
+        // Internal for testing
+        internal static readonly ContainerElement SeparatorElement = new ContainerElement(
+            ContainerElementStyle.Wrapped,
+            new ClassifiedTextElement(
+                new ClassifiedTextRun(PredefinedClassificationNames.Comment, "------------")));
+
+        private static readonly IReadOnlyDictionary<string, string> KeywordTypeNameLookups = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [typeof(byte).FullName] = "byte",
+            [typeof(sbyte).FullName] = "sbyte",
+            [typeof(int).FullName] = "int",
+            [typeof(uint).FullName] = "uint",
+            [typeof(short).FullName] = "short",
+            [typeof(ushort).FullName] = "ushort",
+            [typeof(long).FullName] = "long",
+            [typeof(ulong).FullName] = "ulong",
+            [typeof(float).FullName] = "float",
+            [typeof(double).FullName] = "double",
+            [typeof(char).FullName] = "char",
+            [typeof(bool).FullName] = "bool",
+            [typeof(object).FullName] = "object",
+            [typeof(string).FullName] = "string",
+            [typeof(decimal).FullName] = "decimal",
+        };
+
+        // Hardcoding the Guid here to avoid a reference to Microsoft.VisualStudio.ImageCatalog.dll
+        // that is not present in Visual Studio for Mac
+        private static readonly Guid ImageCatalogGuid = new Guid("{ae27a6b0-e345-4288-96df-5eaf394ee369}");
+        private static readonly ImageElement PropertyGlyph = new ImageElement(
+            new ImageId(ImageCatalogGuid, 2429), // KnownImageIds.Type = 2429
+            "Razor Attribute Glyph");
+        private static readonly ClassifiedTextRun SpaceLiteral = new ClassifiedTextRun(PredefinedClassificationNames.Literal, " ");
+        private static readonly ClassifiedTextRun DotLiteral = new ClassifiedTextRun(PredefinedClassificationNames.Literal, ".");
+
+        public override ContainerElement CreateClassifiedDescription(AttributeCompletionDescription completionDescription)
+        {
+            if (completionDescription is null)
+            {
+                throw new ArgumentNullException(nameof(completionDescription));
+            }
+
+            var descriptionElements = new List<object>();
+            foreach (var descriptionInfo in completionDescription.DescriptionInfos)
+            {
+                if (descriptionElements.Count > 0)
+                {
+                    descriptionElements.Add(SeparatorElement);
+                }
+
+                var returnTypeClassification = PredefinedClassificationNames.Type;
+                if (KeywordTypeNameLookups.TryGetValue(descriptionInfo.ReturnTypeName, out var returnTypeName))
+                {
+                    returnTypeClassification = PredefinedClassificationNames.Keyword;
+                }
+                else
+                {
+                    returnTypeName = descriptionInfo.ReturnTypeName;
+                }
+
+                var tagHelperTypeName = descriptionInfo.TypeName;
+                var tagHelperTypeNamePrefix = string.Empty;
+                var tagHelperTypeNameProper = tagHelperTypeName;
+
+                var lastDot = tagHelperTypeName.LastIndexOf('.');
+                if (lastDot > 0)
+                {
+                    var afterLastDot = lastDot + 1;
+
+                    // We're pulling apart the type name so the prefix looks like:
+                    //
+                    // Microsoft.AspnetCore.Components.
+                    tagHelperTypeNamePrefix = tagHelperTypeName.Substring(0, afterLastDot);
+
+                    // And the type name looks like BindBinds
+                    tagHelperTypeNameProper = tagHelperTypeName.Substring(afterLastDot);
+                }
+
+                descriptionElements.Add(
+                    new ContainerElement(
+                        ContainerElementStyle.Wrapped,
+                        PropertyGlyph,
+                        new ClassifiedTextElement(
+                            new ClassifiedTextRun(returnTypeClassification, returnTypeName),
+                            SpaceLiteral,
+                            new ClassifiedTextRun(PredefinedClassificationNames.Literal, tagHelperTypeNamePrefix),
+                            new ClassifiedTextRun(PredefinedClassificationNames.Type, tagHelperTypeNameProper),
+                            DotLiteral,
+                            new ClassifiedTextRun(PredefinedClassificationNames.Identifier, descriptionInfo.PropertyName))));
+
+                if (descriptionInfo.Documentation != null)
+                {
+                    descriptionElements.Add(
+                        new ContainerElement(
+                            ContainerElementStyle.Wrapped,
+                            new ClassifiedTextElement(
+                                new ClassifiedTextRun(PredefinedClassificationNames.NaturalLanguage, descriptionInfo.Documentation))));
+                }
+            }
+
+            var descriptionContainer = new ContainerElement(ContainerElementStyle.Stacked, descriptionElements);
+            return descriptionContainer;
+        }
+
+        private static class PredefinedClassificationNames
+        {
+            public const string Keyword = "keyword";
+
+            public const string Literal = "literal";
+
+            public const string Type = "Type";
+
+            public const string Identifier = "identifier";
+
+            public const string Comment = "comment";
+
+            public const string NaturalLanguage = "natural language";
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSourceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSourceProvider.cs
@@ -23,13 +23,15 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly RazorCompletionFactsService _completionFactsService;
         private readonly ICompletionBroker _completionBroker;
+        private readonly VisualStudioDescriptionFactory _descriptionFactory;
 
         [ImportingConstructor]
         public RazorDirectiveAttributeCompletionSourceProvider(
             ForegroundDispatcher foregroundDispatcher,
             RazorCompletionFactsService completionFactsService,
             IAsyncCompletionBroker asyncCoompletionBroker,
-            ICompletionBroker completionBroker)
+            ICompletionBroker completionBroker,
+            VisualStudioDescriptionFactory descriptionFactory)
         {
             if (foregroundDispatcher == null)
             {
@@ -46,9 +48,15 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
                 throw new ArgumentNullException(nameof(asyncCoompletionBroker));
             }
 
+            if (descriptionFactory == null)
+            {
+                throw new ArgumentNullException(nameof(descriptionFactory));
+            }
+
             _foregroundDispatcher = foregroundDispatcher;
             _completionFactsService = completionFactsService;
             _completionBroker = completionBroker;
+            _descriptionFactory = descriptionFactory;
         }
 
         public IAsyncCompletionSource GetOrCreate(ITextView textView)
@@ -78,7 +86,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
                 return null;
             }
 
-            var completionSource = new RazorDirectiveAttributeCompletionSource(_foregroundDispatcher, parser, _completionFactsService, _completionBroker);
+            var completionSource = new RazorDirectiveAttributeCompletionSource(_foregroundDispatcher, parser, _completionFactsService, _completionBroker, _descriptionFactory);
             return completionSource;
         }
     }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionProvider.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Tags;
 using Microsoft.CodeAnalysis.Text;
@@ -153,9 +152,10 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
                 }
 
                 var propertyDictionary = new Dictionary<string, string>(StringComparer.Ordinal);
-                if (!string.IsNullOrEmpty(razorCompletionItem.Description))
+                var completionDescription = razorCompletionItem.GetDirectiveCompletionDescription();
+                if (!string.IsNullOrEmpty(completionDescription.Description))
                 {
-                    propertyDictionary[DescriptionKey] = razorCompletionItem.Description;
+                    propertyDictionary[DescriptionKey] = completionDescription.Description;
                 }
 
                 var completionItem = CompletionItem.Create(

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSource.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSource.cs
@@ -102,7 +102,8 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
                         suffix: string.Empty,
                         sortText: razorCompletionItem.DisplayText,
                         attributeIcons: ImmutableArray<ImageElement>.Empty);
-                    completionItem.Properties.AddProperty(DescriptionKey, razorCompletionItem.Description);
+                    var completionDescription = razorCompletionItem.GetDirectiveCompletionDescription();
+                    completionItem.Properties.AddProperty(DescriptionKey, completionDescription);
                     completionItems.Add(completionItem);
                 }
                 var context = new CompletionContext(completionItems.ToImmutableArray());
@@ -116,12 +117,12 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
 
         public Task<object> GetDescriptionAsync(IAsyncCompletionSession session, CompletionItem item, CancellationToken token)
         {
-            if (!item.Properties.TryGetProperty<string>(DescriptionKey, out var directiveDescription))
+            if (!item.Properties.TryGetProperty(DescriptionKey, out DirectiveCompletionDescription directiveDescription))
             {
-                directiveDescription = string.Empty;
+                return Task.FromResult<object>(string.Empty);
             }
 
-            return Task.FromResult<object>(directiveDescription);
+            return Task.FromResult<object>(directiveDescription.Description);
         }
 
         public CompletionStartData InitializeCompletion(CompletionTrigger trigger, SnapshotPoint triggerLocation, CancellationToken token)

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/VisualStudioDescriptionFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/VisualStudioDescriptionFactory.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.VisualStudio.Text.Adornments;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
+{
+    internal abstract class VisualStudioDescriptionFactory
+    {
+        public abstract ContainerElement CreateClassifiedDescription(AttributeCompletionDescription completionDescription);
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
@@ -16,9 +16,9 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             // Arrange
             var syntaxTree = RazorSyntaxTree.Parse(TestRazorSourceDocument.Create());
             var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: null, Enumerable.Empty<TagHelperDescriptor>());
-            var completionItem1 = new RazorCompletionItem("displayText1", "insertText1", "description1", RazorCompletionItemKind.Directive);
+            var completionItem1 = new RazorCompletionItem("displayText1", "insertText1", RazorCompletionItemKind.Directive);
             var provider1 = Mock.Of<RazorCompletionItemProvider>(p => p.GetCompletionItems(syntaxTree, tagHelperDocumentContext, default) == new[] { completionItem1 });
-            var completionItem2 = new RazorCompletionItem("displayText2", "insertText2", "description2", RazorCompletionItemKind.Directive);
+            var completionItem2 = new RazorCompletionItem("displayText2", "insertText2", RazorCompletionItemKind.Directive);
             var provider2 = Mock.Of<RazorCompletionItemProvider>(p => p.GetCompletionItems(syntaxTree, tagHelperDocumentContext, default) == new[] { completionItem2 });
             var completionFactsService = new DefaultRazorCompletionFactsService(new[] { provider1, provider2 });
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
@@ -91,14 +91,13 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var codeDocument = GetCodeDocument("<input @  />");
             var syntaxTree = codeDocument.GetSyntaxTree();
             var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
             var span = new SourceSpan(8, 0);
 
             // Act
             var completions = Provider.GetCompletionItems(syntaxTree, tagHelperDocumentContext, span);
 
             // Assert
-            Assert.Contains(expectedCompletion, completions);
+            AssertContains(completions, "@bind");
         }
 
         [Fact]
@@ -134,75 +133,59 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetAttributeCompletions_SelectedDirectiveAttribute_IsIncludedInCompletions()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
             var attributeNames = new string[] { "@bind" };
 
             // Act
             var completions = Provider.GetAttributeCompletions("@bind", "input", attributeNames, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.Contains(expectedCompletion, completions);
+            AssertContains(completions, "@bind");
         }
 
         [Fact]
         public void GetAttributeCompletions_NonIndexer_ReturnsCompletion()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
+
 
             // Act
             var completions = Provider.GetAttributeCompletions("@", "input", EmptyAttributes, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.Contains(expectedCompletion, completions);
+            AssertContains(completions, "@bind");
         }
 
         [Fact]
         public void GetAttributeCompletions_Indexer_ReturnsCompletion()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("@bind-...", "@bind-", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
+
 
             // Act
             var completions = Provider.GetAttributeCompletions("@", "input", EmptyAttributes, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.Contains(expectedCompletion, completions);
-        }
-
-        [Fact]
-        public void GetAttributeCompletions_BaseDirectiveAttributeDoesNotExist_DoesNotIncludeParamterizedAttribute()
-        {
-            // Arrange
-            var expectedCompletion = new RazorCompletionItem("@bind:", "@bind:", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
-            var attributeNames = new[] { "@" };
-
-            // Act
-            var completions = Provider.GetAttributeCompletions("@", "input", attributeNames, DefaultTagHelperDocumentContext);
-
-            // Assert
-            Assert.DoesNotContain(expectedCompletion, completions);
+            AssertContains(completions, "@bind-", "@bind-...");
         }
 
         [Fact]
         public void GetAttributeCompletions_BaseDirectiveAttributeAlreadyExists_IncludesBaseAttribute()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
             var attributeNames = new[] { "@bind", "@" };
 
             // Act
             var completions = Provider.GetAttributeCompletions("@", "input", attributeNames, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.Contains(expectedCompletion, completions);
+            AssertContains(completions, "@bind");
         }
 
         [Fact]
         public void GetAttributeCompletions_BaseDirectiveAttributeAndParameterVariationsExist_ExcludesCompletion()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", string.Empty, RazorCompletionItemKind.DirectiveAttribute);
+            var expectedCompletion = new RazorCompletionItem("@bind", "@bind", RazorCompletionItemKind.DirectiveAttribute);
             var attributeNames = new[]
             {
                 "@bind",
@@ -215,7 +198,31 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var completions = Provider.GetAttributeCompletions("@", "input", attributeNames, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.DoesNotContain(expectedCompletion, completions);
+            AssertDoesNotContain(completions, "@bind");
+        }
+
+        private static void AssertContains(IReadOnlyList<RazorCompletionItem> completions, string insertText, string displayText = null)
+        {
+            displayText = displayText ?? insertText;
+
+            Assert.Contains(completions, completion =>
+            {
+                return insertText == completion.InsertText &&
+                    displayText == completion.DisplayText &&
+                    RazorCompletionItemKind.DirectiveAttribute == completion.Kind;
+            });
+        }
+
+        private static void AssertDoesNotContain(IReadOnlyList<RazorCompletionItem> completions, string insertText, string displayText = null)
+        {
+            displayText = displayText ?? insertText;
+
+            Assert.DoesNotContain(completions, completion =>
+            {
+                return insertText == completion.InsertText &&
+                   displayText == completion.DisplayText &&
+                   RazorCompletionItemKind.DirectiveAttribute == completion.Kind;
+            });
         }
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
@@ -91,18 +91,15 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var codeDocument = GetCodeDocument("<input @bind:fo  />");
             var syntaxTree = codeDocument.GetSyntaxTree();
             var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var expectedCompletions = new[] {
-                new RazorCompletionItem("event", "event", string.Empty, RazorCompletionItemKind.DirectiveAttributeParameter),
-                new RazorCompletionItem("format", "format", string.Empty, RazorCompletionItemKind.DirectiveAttributeParameter),
-            };
             var span = new SourceSpan(14, 0);
 
             // Act
             var completions = Provider.GetCompletionItems(syntaxTree, tagHelperDocumentContext, span);
 
             // Assert
-            var orderedCompletions = completions.OrderBy(c => c.DisplayText);
-            Assert.Equal(expectedCompletions, orderedCompletions);
+            Assert.Equal(2, completions.Count);
+            AssertContains(completions, "event");
+            AssertContains(completions, "format");
         }
 
         [Fact]
@@ -138,34 +135,32 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetAttributeParameterCompletions_SelectedDirectiveAttributeParameter_IsExcludedInCompletions()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("format", "format", string.Empty, RazorCompletionItemKind.DirectiveAttributeParameter);
             var attributeNames = new string[] { "@bind" };
 
             // Act
             var completions = Provider.GetAttributeParameterCompletions("@bind", "format", "input", attributeNames, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.DoesNotContain(expectedCompletion, completions);
+            AssertDoesNotContain(completions, "format");
         }
 
         [Fact]
         public void GetAttributeParameterCompletions_ReturnsCompletion()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("format", "format", string.Empty, RazorCompletionItemKind.DirectiveAttributeParameter);
+
 
             // Act
             var completions = Provider.GetAttributeParameterCompletions("@bind", string.Empty, "input", EmptyAttributes, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.Contains(expectedCompletion, completions);
+            AssertContains(completions, "format");
         }
 
         [Fact]
         public void GetAttributeParameterCompletions_BaseDirectiveAttributeAndParameterVariationsExist_ExcludesCompletion()
         {
             // Arrange
-            var expectedCompletion = new RazorCompletionItem("format", "format", string.Empty, RazorCompletionItemKind.DirectiveAttributeParameter);
             var attributeNames = new[]
             {
                 "@bind",
@@ -178,7 +173,28 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var completions = Provider.GetAttributeParameterCompletions("@bind", string.Empty, "input", attributeNames, DefaultTagHelperDocumentContext);
 
             // Assert
-            Assert.DoesNotContain(expectedCompletion, completions);
+            AssertDoesNotContain(completions, "format");
+        }
+
+        private static void AssertContains(IReadOnlyList<RazorCompletionItem> completions, string insertText)
+        {
+            Assert.Contains(completions, completion =>
+            {
+                return insertText == completion.InsertText &&
+                    insertText == completion.DisplayText &&
+                    RazorCompletionItemKind.DirectiveAttributeParameter == completion.Kind;
+            });
+        }
+
+        private static void AssertDoesNotContain(IReadOnlyList<RazorCompletionItem> completions, string insertText)
+        {
+
+            Assert.DoesNotContain(completions, completion =>
+            {
+                return insertText == completion.InsertText &&
+                   insertText == completion.DisplayText &&
+                   RazorCompletionItemKind.DirectiveAttributeParameter == completion.Kind;
+            });
         }
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -287,7 +287,8 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             Assert.Equal(item.DisplayText, completionDisplayText);
             Assert.Equal(item.InsertText, directive.Directive);
-            Assert.Equal(directive.Description, item.Description);
+            var completionDescription = item.GetDirectiveCompletionDescription();
+            Assert.Equal(directive.Description, completionDescription.Description);
         }
 
         private static void AssertRazorCompletionItem(DirectiveDescriptor directive, RazorCompletionItem item) =>

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/DefaultVisualStudioDescriptionFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/DefaultVisualStudioDescriptionFactoryTest.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.VisualStudio.Text.Adornments;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Completion
+{
+    public class DefaultVisualStudioDescriptionFactoryTest
+    {
+        [Fact]
+        public void CreateClassifiedDescription_SingleDescription_NoSeparator()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("TheReturnType", "TheTypeName", "ThePropertyName", "The documentation"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            Assert.DoesNotContain(DefaultVisualStudioDescriptionFactory.SeparatorElement, result.Elements);
+        }
+
+        [Fact]
+        public void CreateClassifiedDescription_MultipleDescription_Separator()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("TheReturnType", "TheTypeName", "ThePropertyName", "The documentation"),
+                new AttributeDescriptionInfo("TheReturnType2", "TheTypeName2", "ThePropertyName2", "The documentation2"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            Assert.Contains(DefaultVisualStudioDescriptionFactory.SeparatorElement, result.Elements);
+        }
+
+        [Fact]
+        public void CreateClassifiedDescription_RepresentsReturnType()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("TheReturnType", "TheTypeName", "ThePropertyName", "The documentation"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            var flattened = FlattenToStrings(result);
+            Assert.Contains(description.DescriptionInfos[0].ReturnTypeName, flattened);
+        }
+
+        [Fact]
+        public void CreateClassifiedDescription_RepresentsTypeName()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("TheReturnType", "TheTypeName", "ThePropertyName", "The documentation"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            var flattened = FlattenToStrings(result);
+            Assert.Contains(description.DescriptionInfos[0].TypeName, flattened);
+        }
+
+        [Fact]
+        public void CreateClassifiedDescription_RepresentsPropertyName()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("TheReturnType", "TheTypeName", "ThePropertyName", "The documentation"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            var flattened = FlattenToStrings(result);
+            Assert.Contains(description.DescriptionInfos[0].PropertyName, flattened);
+        }
+
+        [Fact]
+        public void CreateClassifiedDescription_RepresentsDocumentation()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("TheReturnType", "TheTypeName", "ThePropertyName", "The documentation"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            var flattened = FlattenToStrings(result);
+            Assert.Contains(description.DescriptionInfos[0].Documentation, flattened);
+        }
+
+        [Fact]
+        public void CreateClassifiedDescription_CanSimplifyKeywordReturnTypes()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("System.String", "TheTypeName", "ThePropertyName", "The documentation"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            var flattened = FlattenToStrings(result);
+            Assert.DoesNotContain(description.DescriptionInfos[0].ReturnTypeName, flattened);
+            Assert.Contains("string", flattened);
+        }
+
+        [Fact]
+        public void CreateClassifiedDescription_CanRepresentMultipleDescriptions()
+        {
+            // Arrange
+            var factory = new DefaultVisualStudioDescriptionFactory();
+            var description = new AttributeCompletionDescription(new[]
+            {
+                new AttributeDescriptionInfo("System.String", "TheTypeName", "ThePropertyName", "The documentation"),
+                new AttributeDescriptionInfo("System.Int32", "TheSecondTypeName", "TheSecondPropertyName", "The second documentation"),
+            });
+
+            // Act
+            var result = factory.CreateClassifiedDescription(description);
+
+            // Assert
+            var flattened = FlattenToStrings(result);
+            Assert.Contains(description.DescriptionInfos[0].TypeName, flattened);
+            Assert.Contains(description.DescriptionInfos[1].TypeName, flattened);
+            Assert.Contains(description.DescriptionInfos[0].Documentation, flattened);
+            Assert.Contains(description.DescriptionInfos[1].Documentation, flattened);
+        }
+
+        public IReadOnlyList<string> FlattenToStrings(ContainerElement element)
+        {
+            var flattenedList = new List<string>();
+            foreach (var child in element.Elements)
+            {
+                switch (child)
+                {
+                    case ContainerElement childContainer:
+                        var flattened = FlattenToStrings(childContainer);
+                        flattenedList.AddRange(flattened);
+                        break;
+                    case ClassifiedTextElement textElement:
+                        foreach (var run in textElement.Runs)
+                        {
+                            flattenedList.Add(run.Text);
+                        }
+                        break;
+                }
+            }
+
+            return flattenedList;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
         {
             // Arrange
             var completionItem = new CompletionItem("TestDirective", Mock.Of<IAsyncCompletionSource>());
-            var expectedDescription = "The expected description";
+            var expectedDescription = new DirectiveCompletionDescription("The expected description");
             completionItem.Properties.AddProperty(RazorDirectiveCompletionSource.DescriptionKey, expectedDescription);
             var completionSource = new RazorDirectiveCompletionSource(Dispatcher, Mock.Of<VisualStudioRazorParser>(), CompletionFactsService);
 
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
 
             // Assert
             var description = Assert.IsType<string>(descriptionObject);
-            Assert.Equal(expectedDescription, descriptionObject);
+            Assert.Equal(expectedDescription.Description, descriptionObject);
         }
 
         [Fact]
@@ -132,8 +132,8 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
             Assert.Equal(item.FilterText, completionDisplayText);
             Assert.Equal(item.InsertText, directive.Directive);
             Assert.Same(item.Source, source);
-            Assert.True(item.Properties.TryGetProperty<string>(RazorDirectiveCompletionSource.DescriptionKey, out var actualDescription));
-            Assert.Equal(directive.Description, actualDescription);
+            Assert.True(item.Properties.TryGetProperty<DirectiveCompletionDescription>(RazorDirectiveCompletionSource.DescriptionKey, out var actualDescription));
+            Assert.Equal(directive.Description, actualDescription.Description);
 
             AssertRazorCompletionItemDefaults(item);
         }


### PR DESCRIPTION
- Updated the `RazorCompletionItem` type to no longer contain a `Documentation`/`Description` property because in completion scenarios descriptions are never readily available and don't make a lot of sense being on the completion item itself. This is also how Roslyn does completions.
- We now utilize an item bag on `RazorCompletionItem`s to hold description data. Currently there's just two type of completion descriptions (directive and attribute). Based off of the completion item kind (directive or attribute) we can extract the appropriate description. The goal of this new description type was to represent all data for a completion in an unstructured way so each platform can display it using its own capabilities.
- Added a description factory to convert description items into classified containers. Tried to replicate WTE's description look as much as possible.
- Left out documentation parsing. Will do this at a later date; however directive attributes rarely have documentation specific pieces that require parsing so we handle the 90% case.
- Updated existing tests to reflect the new documentation mechanisms for RazorCompletionItems.
- Added new tests to validate the completion source and the description factory.

![image](https://i.imgur.com/BFgEL5W.gif)

Note: This accomplishes bullet point six of https://github.com/aspnet/AspNetCore/issues/6364#issuecomment-495432347

aspnet/AspNetCore#6364
