### PR TITLE
Make LiveShareProjectPathProvider optional

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultProjectPathProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultProjectPathProvider.cs
@@ -20,11 +20,6 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 throw new ArgumentNullException(nameof(projectService));
             }
 
-            if (liveShareProjectPathProvider == null)
-            {
-                throw new ArgumentNullException(nameof(liveShareProjectPathProvider));
-            }
-
             _projectService = projectService;
             _liveShareProjectPathProvider = liveShareProjectPathProvider;
         }
@@ -36,7 +31,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 throw new ArgumentNullException(nameof(textBuffer));
             }
 
-            if (_liveShareProjectPathProvider.TryGetProjectPath(textBuffer, out filePath))
+            if (_liveShareProjectPathProvider != null &&
+                _liveShareProjectPathProvider.TryGetProjectPath(textBuffer, out filePath))
             {
                 return true;
             }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultProjectPathProviderFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultProjectPathProviderFactory.cs
@@ -18,16 +18,11 @@ namespace Microsoft.VisualStudio.Editor.Razor
         [ImportingConstructor]
         public DefaultProjectPathProviderFactory(
             TextBufferProjectService projectService,
-            LiveShareProjectPathProvider liveShareProjectPathProvider)
+            [Import(AllowDefault = true)] LiveShareProjectPathProvider liveShareProjectPathProvider)
         {
             if (projectService == null)
             {
                 throw new ArgumentNullException(nameof(projectService));
-            }
-
-            if (liveShareProjectPathProvider == null)
-            {
-                throw new ArgumentNullException(nameof(liveShareProjectPathProvider));
             }
 
             _projectService = projectService;

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultProjectPathProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultProjectPathProviderTest.cs
@@ -11,6 +11,27 @@ namespace Microsoft.VisualStudio.Editor.Razor
     public class DefaultProjectPathProviderTest
     {
         [Fact]
+        public void TryGetProjectPath_NullLiveShareProjectPathProvider_UsesProjectService()
+        {
+            // Arrange
+            var expectedProjectPath = "/my/project/path.csproj";
+            var projectService = new Mock<TextBufferProjectService>();
+            projectService.Setup(service => service.GetHostProject(It.IsAny<ITextBuffer>()))
+                .Returns(new object());
+            projectService.Setup(service => service.GetProjectPath(It.IsAny<object>()))
+                .Returns(expectedProjectPath);
+            var projectPathProvider = new DefaultProjectPathProvider(projectService.Object, liveShareProjectPathProvider: null);
+            var textBuffer = Mock.Of<ITextBuffer>();
+
+            // Act
+            var result = projectPathProvider.TryGetProjectPath(textBuffer, out var filePath);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedProjectPath, filePath);
+        }
+
+        [Fact]
         public void TryGetProjectPath_PrioritizesLiveShareProjectPathProvider()
         {
             // Arrange


### PR DESCRIPTION
- VS4Mac does not have LiveShare yet so this platform agnostic piece needs to allow optional for `LiveShareProjectPathProvider`.
- Added a test to ensure `null` project path providers are allowed

aspnet/AspNetCore#9645
