### PR TITLE
Fix argument out of range exception.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSource.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSource.cs
@@ -180,7 +180,9 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
             // providing directive attribute completions. Basically anything starting with a transition (@).
 
             var snapshot = triggerLocation.Snapshot;
-            if (snapshot.Length == 0)
+
+            // 4 because of the minimal situation possible "<a @|"
+            if (snapshot.Length < 4)
             {
                 // Empty document, can not provide completions.
                 return CompletionStartData.DoesNotParticipateInCompletion;
@@ -193,7 +195,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
             }
 
             var leftEnd = triggerLocation.Position - 1;
-            for (; leftEnd >= 0; leftEnd--)
+            for (; leftEnd > 0; leftEnd--)
             {
                 var currentCharacter = snapshot[leftEnd];
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveAttributeCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveAttributeCompletionSourceTest.cs
@@ -57,6 +57,39 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
         }
 
         [Fact]
+        public void InitializeCompletion_PageDirective_ReturnsDoesNotParticipate()
+        {
+            // Arrange
+            var source = CreateCompletionSource();
+            var snapshot = new StringTextSnapshot("@page");
+            var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
+            var triggerLocation = new SnapshotPoint(snapshot, 1);
+            var expectedApplicableToSpan = new SnapshotSpan(snapshot, new Span(0, 5));
+
+            // Act
+            var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(expectedApplicableToSpan, result.ApplicableToSpan);
+        }
+
+        [Fact]
+        public void InitializeCompletion_SingleTransition_ReturnsDoesNotParticipate()
+        {
+            // Arrange
+            var source = CreateCompletionSource();
+            var snapshot = new StringTextSnapshot("@");
+            var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
+            var triggerLocation = new SnapshotPoint(snapshot, 1);
+
+            // Act
+            var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(CompletionStartData.DoesNotParticipateInCompletion, result);
+        }
+
+        [Fact]
         public void InitializeCompletion_EmptySnapshot_ReturnsDoesNotParticipate()
         {
             // Arrange


### PR DESCRIPTION
- In the situation where a single transition was typed at the beginning of the document we'd argument out of range exception because `leftEnd` would be -1.
- Added a general restriction to document length to only support scenarios where we could possibly participate.
- Added a test to cover the situation

aspnet/AspNetCore#10708