### PR TITLE
Fix C# dot commit and CSS completions.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -141,6 +141,14 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                     insertText = insertText.Substring(0, insertText.Length - 3);
                 }
 
+                if (insertText.StartsWith("@"))
+                {
+                    // Strip off the @ from the insertion text. This change is here to align the insertion text with the
+                    // completion hooks into VS and VSCode. Basically, completion triggers when `@` is typed so we don't
+                    // want to insert `@bind` because `@` already exists.
+                    insertText = insertText.Substring(1);
+                }
+
                 var razorCompletionItem = new RazorCompletionItem(
                     completion.Key,
                     insertText,

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var completions = Provider.GetCompletionItems(syntaxTree, tagHelperDocumentContext, span);
 
             // Assert
-            AssertContains(completions, "@bind");
+            AssertContains(completions, "bind", "@bind");
         }
 
         [Fact]
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var completions = Provider.GetAttributeCompletions("@bind", "input", attributeNames, DefaultTagHelperDocumentContext);
 
             // Assert
-            AssertContains(completions, "@bind");
+            AssertContains(completions, "bind", "@bind");
         }
 
         [Fact]
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var completions = Provider.GetAttributeCompletions("@", "input", EmptyAttributes, DefaultTagHelperDocumentContext);
 
             // Assert
-            AssertContains(completions, "@bind");
+            AssertContains(completions, "bind", "@bind");
         }
 
         [Fact]
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var completions = Provider.GetAttributeCompletions("@", "input", EmptyAttributes, DefaultTagHelperDocumentContext);
 
             // Assert
-            AssertContains(completions, "@bind-", "@bind-...");
+            AssertContains(completions, "bind-", "@bind-...");
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var completions = Provider.GetAttributeCompletions("@", "input", attributeNames, DefaultTagHelperDocumentContext);
 
             // Assert
-            AssertContains(completions, "@bind");
+            AssertContains(completions, "bind", "@bind");
         }
 
         [Fact]
@@ -198,10 +198,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var completions = Provider.GetAttributeCompletions("@", "input", attributeNames, DefaultTagHelperDocumentContext);
 
             // Assert
-            AssertDoesNotContain(completions, "@bind");
+            AssertDoesNotContain(completions, "bind", "@bind");
         }
 
-        private static void AssertContains(IReadOnlyList<RazorCompletionItem> completions, string insertText, string displayText = null)
+        private static void AssertContains(IReadOnlyList<RazorCompletionItem> completions, string insertText, string displayText)
         {
             displayText = displayText ?? insertText;
 
@@ -213,7 +213,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             });
         }
 
-        private static void AssertDoesNotContain(IReadOnlyList<RazorCompletionItem> completions, string insertText, string displayText = null)
+        private static void AssertDoesNotContain(IReadOnlyList<RazorCompletionItem> completions, string insertText, string displayText)
         {
             displayText = displayText ?? insertText;
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveAttributeCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveAttributeCompletionSourceTest.cs
@@ -57,20 +57,41 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
         }
 
         [Fact]
-        public void InitializeCompletion_PageDirective_ReturnsDoesNotParticipate()
+        public void InitializeCompletion_PageDirective_ReturnsParticipateWithCorrectSpan()
         {
             // Arrange
             var source = CreateCompletionSource();
             var snapshot = new StringTextSnapshot("@page");
             var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
             var triggerLocation = new SnapshotPoint(snapshot, 1);
-            var expectedApplicableToSpan = new SnapshotSpan(snapshot, new Span(0, 5));
+            var expectedApplicableToSpan = new SnapshotSpan(snapshot, new Span(1, 4));
 
             // Act
             var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);
 
             // Assert
             Assert.Equal(expectedApplicableToSpan, result.ApplicableToSpan);
+        }
+
+        [Theory]
+        [InlineData("@Value[0]")]
+        [InlineData("@DateTime.Now")]
+        [InlineData("@SomeMethod()")]
+        [InlineData("@(DateTime.Now)")]
+        [InlineData("@{SomeProperty;}")]
+        public void InitializeCompletion_InvalidCharactersInExpressions_ReturnsDoesNotParticipate(string expression)
+        {
+            // Arrange
+            var source = CreateCompletionSource();
+            var snapshot = new StringTextSnapshot(expression);
+            var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
+            var triggerLocation = new SnapshotPoint(snapshot, 1);
+
+            // Act
+            var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(CompletionStartData.DoesNotParticipateInCompletion, result);
         }
 
         [Fact]
@@ -81,6 +102,22 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
             var snapshot = new StringTextSnapshot("@");
             var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
             var triggerLocation = new SnapshotPoint(snapshot, 1);
+
+            // Act
+            var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(CompletionStartData.DoesNotParticipateInCompletion, result);
+        }
+
+        [Fact]
+        public void InitializeCompletion_CSSEscapedTransition_ReturnsDoesNotParticipate()
+        {
+            // Arrange
+            var source = CreateCompletionSource();
+            var snapshot = new StringTextSnapshot("<style>@@</style");
+            var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
+            var triggerLocation = new SnapshotPoint(snapshot, 9);
 
             // Act
             var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);
@@ -146,7 +183,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
             var snapshot = new StringTextSnapshot("<input @bind='@foo' />");
             var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
             var triggerLocation = new SnapshotPoint(snapshot, 9);
-            var expectedApplicableToSpan = new SnapshotSpan(snapshot, new Span(7, 5));
+            var expectedApplicableToSpan = new SnapshotSpan(snapshot, new Span(8, 4));
 
             // Act
             var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);
@@ -163,7 +200,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
             var snapshot = new StringTextSnapshot("<input @bind:format='@foo' />");
             var trigger = new CompletionTrigger(CompletionTriggerReason.Invoke, snapshot);
             var triggerLocation = new SnapshotPoint(snapshot, 9);
-            var expectedApplicableToSpan = new SnapshotSpan(snapshot, new Span(7, 5));
+            var expectedApplicableToSpan = new SnapshotSpan(snapshot, new Span(8, 4));
 
             // Act
             var result = source.InitializeCompletion(trigger, triggerLocation, CancellationToken.None);


### PR DESCRIPTION
- Made our directive attribute completion provider less greedy when determining `applicableToSpan`s. We now restrict our `applicableToSpan` to todays current flavor of directive attributes, basically only simple implicit expressions`.
- Changed our `applicableToSpan`s to no longer include the `@` symbol in order for our `applicableToSpan`s to be compatible with Roslyn's.
- Updated and added tests to account for the fixes.
- Found that VS windows modern completion APIs interact a bit strangely when multiple completion providers are at play. This ended up being a design issue in the modern VS completion end that's not easily resolvable in a short amount of time. I've notified them of the problem and they're thinking through future changes.

The design issue:
- The first provider to return an `applicableToSpan` dictates which span will be passed to all of the other providers in the completion session.
- Roslyn returns 0 completions when they receive an `applicableToSpan` that is not compatible with the ones they create.

If things worked more like an LSP model `applicableToSpan` would be on a per-completion item basis instead of a per-completion session. Anyhow, this is now something known and will hopefully be resolved in the future.

aspnet/AspNetCore#10735