### PR TITLE
Add Razor component TagHelper detection.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/TagHelperDescriptorExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/TagHelperDescriptorExtensions.cs
@@ -124,7 +124,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
                 throw new ArgumentNullException(nameof(tagHelper));
             }
 
-            return !tagHelper.Metadata.ContainsKey(ComponentMetadata.SpecialKindKey);
+            return
+                string.Equals(tagHelper.Kind, ComponentMetadata.Component.TagHelperKind) &&
+                !tagHelper.Metadata.ContainsKey(ComponentMetadata.SpecialKindKey);
         }
 
         public static bool IsEventHandlerTagHelper(this TagHelperDescriptor tagHelper)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/TagHelperDescriptorExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/TagHelperDescriptorExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Razor.Language.Components;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -37,6 +38,26 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             tagHelper.Metadata.TryGetValue(TagHelperMetadata.Runtime.Name, out var value);
             return string.Equals(TagHelperConventions.DefaultKind, value, StringComparison.Ordinal);
+        }
+
+        public static bool IsComponentOrChildContentTagHelper(this TagHelperDescriptor tagHelper)
+        {
+            if (tagHelper == null)
+            {
+                throw new ArgumentNullException(nameof(tagHelper));
+            }
+
+            if (tagHelper.IsComponentTagHelper())
+            {
+                return true;
+            }
+
+            if (tagHelper.IsChildContentTagHelper())
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/BindTagHelperDescriptorProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/BindTagHelperDescriptorProviderTest.cs
@@ -71,6 +71,7 @@ namespace Test
             Assert.Equal(ComponentMetadata.Bind.RuntimeName, bind.Metadata[TagHelperMetadata.Runtime.Name]);
             Assert.False(bind.IsDefaultKind());
             Assert.False(bind.KindUsesDefaultTagHelperRuntime());
+            Assert.False(bind.IsComponentOrChildContentTagHelper());
 
             Assert.Equal("MyProperty", bind.Metadata[ComponentMetadata.Bind.ValueAttribute]);
             Assert.Equal("MyPropertyChanged", bind.Metadata[ComponentMetadata.Bind.ChangeAttribute]);
@@ -187,6 +188,7 @@ namespace Test
             Assert.Equal(ComponentMetadata.Bind.RuntimeName, bind.Metadata[TagHelperMetadata.Runtime.Name]);
             Assert.False(bind.IsDefaultKind());
             Assert.False(bind.KindUsesDefaultTagHelperRuntime());
+            Assert.False(bind.IsComponentOrChildContentTagHelper());
 
             Assert.Equal("MyProperty", bind.Metadata[ComponentMetadata.Bind.ValueAttribute]);
             Assert.Equal("MyPropertyChanged", bind.Metadata[ComponentMetadata.Bind.ChangeAttribute]);
@@ -334,6 +336,7 @@ namespace Test
             Assert.Equal(ComponentMetadata.Bind.RuntimeName, bind.Metadata[TagHelperMetadata.Runtime.Name]);
             Assert.False(bind.IsDefaultKind());
             Assert.False(bind.KindUsesDefaultTagHelperRuntime());
+            Assert.False(bind.IsComponentOrChildContentTagHelper());
 
             Assert.Equal("myprop", bind.Metadata[ComponentMetadata.Bind.ValueAttribute]);
             Assert.Equal("myevent", bind.Metadata[ComponentMetadata.Bind.ChangeAttribute]);
@@ -698,6 +701,7 @@ namespace Test
             Assert.Equal(ComponentMetadata.Bind.RuntimeName, bind.Metadata[TagHelperMetadata.Runtime.Name]);
             Assert.False(bind.IsDefaultKind());
             Assert.False(bind.KindUsesDefaultTagHelperRuntime());
+            Assert.False(bind.IsComponentOrChildContentTagHelper());
 
             Assert.False(bind.Metadata.ContainsKey(ComponentMetadata.Bind.ValueAttribute));
             Assert.False(bind.Metadata.ContainsKey(ComponentMetadata.Bind.ChangeAttribute));

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/ComponentTagHelperDescriptorProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/ComponentTagHelperDescriptorProviderTest.cs
@@ -60,6 +60,7 @@ namespace Test
             Assert.Equal(ComponentMetadata.Component.TagHelperKind, component.Kind);
             Assert.False(component.IsDefaultKind());
             Assert.False(component.KindUsesDefaultTagHelperRuntime());
+            Assert.True(component.IsComponentOrChildContentTagHelper());
 
             // No documentation in this test
             Assert.Null(component.Documentation);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/EventHandlerTagHelperDescriptorProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/EventHandlerTagHelperDescriptorProviderTest.cs
@@ -56,6 +56,7 @@ namespace Test
             Assert.Equal(ComponentMetadata.EventHandler.RuntimeName, item.Metadata[TagHelperMetadata.Runtime.Name]);
             Assert.False(item.IsDefaultKind());
             Assert.False(item.KindUsesDefaultTagHelperRuntime());
+            Assert.False(item.IsComponentOrChildContentTagHelper());
 
             Assert.Equal(
                 "Sets the '@onclick' attribute to the provided string or delegate value. " +

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/KeyTagHelperDescriptorProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/KeyTagHelperDescriptorProviderTest.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis.Razor
             Assert.Equal(ComponentMetadata.Key.RuntimeName, item.Metadata[TagHelperMetadata.Runtime.Name]);
             Assert.False(item.IsDefaultKind());
             Assert.False(item.KindUsesDefaultTagHelperRuntime());
+            Assert.False(item.IsComponentOrChildContentTagHelper());
 
             Assert.Equal(
                 "Ensures that the component or element will be preserved across renders if (and only if) the supplied key value matches.",

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/RefTagHelperDescriptorProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/RefTagHelperDescriptorProviderTest.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis.Razor
             Assert.Equal(ComponentMetadata.Ref.RuntimeName, item.Metadata[TagHelperMetadata.Runtime.Name]);
             Assert.False(item.IsDefaultKind());
             Assert.False(item.KindUsesDefaultTagHelperRuntime());
+            Assert.False(item.IsComponentOrChildContentTagHelper());
 
             Assert.Equal(
                 "Populates the specified field or property with a reference to the element or component.",


### PR DESCRIPTION
- WTE needs a way to detect if a `TagHelperDescriptor` is a component based `TagHelper` in order to turn features like validation, completion etc. on/off. What this boils down to is providing a nice method to say that a `TagHelper` is not a directive attribute `TagHelper`.
- Updated tests to add verification points for the new `IsRazorComponentTagHelper` method.

/cc @ToddGrun this will enable what you want. We'll need to insert before you can properly use it though.