### PR TITLE
Allow `content`, `output` and `context` as keywords to VC params.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ViewComponentTagHelperTargetExtension.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ViewComponentTagHelperTargetExtension.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 
         public string ViewComponentHelperTypeName { get; set; } = "global::Microsoft.AspNetCore.Mvc.IViewComponentHelper";
 
-        public string ViewComponentHelperVariableName { get; set; } = "_helper";
+        public string ViewComponentHelperVariableName { get; set; } = "__helper";
 
         public string ViewComponentInvokeMethodName { get; set; } = "InvokeAsync";
 
@@ -36,11 +36,11 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 
         public string TagHelperContextTypeName { get; set; } = "Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext";
 
-        public string TagHelperContextVariableName { get; set; } = "context";
+        public string TagHelperContextVariableName { get; set; } = "__context";
 
         public string TagHelperOutputTypeName { get; set; } = "Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput";
 
-        public string TagHelperOutputVariableName { get; set; } = "output";
+        public string TagHelperOutputVariableName { get; set; } = "__output";
 
         public string TagHelperOutputTagNamePropertyName { get; set; } = "TagName";
 
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 
         public string TagHelperContentSetMethodName { get; set; } = "SetHtmlContent";
 
-        public string TagHelperContentVariableName { get; set; } = "content";
+        public string TagHelperContentVariableName { get; set; } = "__helperContent";
 
         public string IViewContextAwareTypeName { get; set; } = "global::Microsoft.AspNetCore.Mvc.ViewFeatures.IViewContextAware";
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
@@ -75,20 +75,20 @@ global::System.Object __typeHelper = "*, AppCode";
         [Microsoft.AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute("vc:test")]
         public class __Generated__TestViewComponentTagHelper : Microsoft.AspNetCore.Razor.TagHelpers.TagHelper
         {
-            private readonly global::Microsoft.AspNetCore.Mvc.IViewComponentHelper _helper = null;
+            private readonly global::Microsoft.AspNetCore.Mvc.IViewComponentHelper __helper = null;
             public __Generated__TestViewComponentTagHelper(global::Microsoft.AspNetCore.Mvc.IViewComponentHelper helper)
             {
-                _helper = helper;
+                __helper = helper;
             }
             [Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeNotBoundAttribute, global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewContextAttribute]
             public global::Microsoft.AspNetCore.Mvc.Rendering.ViewContext ViewContext { get; set; }
             public System.String firstName { get; set; }
-            public override async global::System.Threading.Tasks.Task ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output)
+            public override async global::System.Threading.Tasks.Task ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext __context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput __output)
             {
-                (_helper as global::Microsoft.AspNetCore.Mvc.ViewFeatures.IViewContextAware)?.Contextualize(ViewContext);
-                var content = await _helper.InvokeAsync("Test", new { firstName });
-                output.TagName = null;
-                output.Content.SetHtmlContent(content);
+                (__helper as global::Microsoft.AspNetCore.Mvc.ViewFeatures.IViewContextAware)?.Contextualize(ViewContext);
+                var __helperContent = await __helper.InvokeAsync("Test", new { firstName });
+                __output.TagName = null;
+                __output.Content.SetHtmlContent(__helperContent);
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_Runtime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_Runtime.codegen.cs
@@ -92,20 +92,20 @@ namespace AspNetCore
         [Microsoft.AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute("vc:test")]
         public class __Generated__TestViewComponentTagHelper : Microsoft.AspNetCore.Razor.TagHelpers.TagHelper
         {
-            private readonly global::Microsoft.AspNetCore.Mvc.IViewComponentHelper _helper = null;
+            private readonly global::Microsoft.AspNetCore.Mvc.IViewComponentHelper __helper = null;
             public __Generated__TestViewComponentTagHelper(global::Microsoft.AspNetCore.Mvc.IViewComponentHelper helper)
             {
-                _helper = helper;
+                __helper = helper;
             }
             [Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeNotBoundAttribute, global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewContextAttribute]
             public global::Microsoft.AspNetCore.Mvc.Rendering.ViewContext ViewContext { get; set; }
             public System.String firstName { get; set; }
-            public override async global::System.Threading.Tasks.Task ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output)
+            public override async global::System.Threading.Tasks.Task ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext __context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput __output)
             {
-                (_helper as global::Microsoft.AspNetCore.Mvc.ViewFeatures.IViewContextAware)?.Contextualize(ViewContext);
-                var content = await _helper.InvokeAsync("Test", new { firstName });
-                output.TagName = null;
-                output.Content.SetHtmlContent(content);
+                (__helper as global::Microsoft.AspNetCore.Mvc.ViewFeatures.IViewContextAware)?.Contextualize(ViewContext);
+                var __helperContent = await __helper.InvokeAsync("Test", new { firstName });
+                __output.TagName = null;
+                __output.Content.SetHtmlContent(__helperContent);
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ViewComponentTagHelperTargetExtensionTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ViewComponentTagHelperTargetExtensionTest.cs
@@ -41,20 +41,20 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                 @"[Microsoft.AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute(""tagcloud"")]
 public class __Generated__TagCloudViewComponentTagHelper : Microsoft.AspNetCore.Razor.TagHelpers.TagHelper
 {
-    private readonly global::Microsoft.AspNetCore.Mvc.IViewComponentHelper _helper = null;
+    private readonly global::Microsoft.AspNetCore.Mvc.IViewComponentHelper __helper = null;
     public __Generated__TagCloudViewComponentTagHelper(global::Microsoft.AspNetCore.Mvc.IViewComponentHelper helper)
     {
-        _helper = helper;
+        __helper = helper;
     }
     [Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeNotBoundAttribute, global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewContextAttribute]
     public global::Microsoft.AspNetCore.Mvc.Rendering.ViewContext ViewContext { get; set; }
     public System.Int32 Foo { get; set; }
-    public override async global::System.Threading.Tasks.Task ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output)
+    public override async global::System.Threading.Tasks.Task ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext __context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput __output)
     {
-        (_helper as global::Microsoft.AspNetCore.Mvc.ViewFeatures.IViewContextAware)?.Contextualize(ViewContext);
-        var content = await _helper.InvokeAsync(""TagCloud"", new { Foo });
-        output.TagName = null;
-        output.Content.SetHtmlContent(content);
+        (__helper as global::Microsoft.AspNetCore.Mvc.ViewFeatures.IViewContextAware)?.Contextualize(ViewContext);
+        var __helperContent = await __helper.InvokeAsync(""TagCloud"", new { Foo });
+        __output.TagName = null;
+        __output.Content.SetHtmlContent(__helperContent);
     }
 }
 ",
@@ -95,21 +95,21 @@ public class __Generated__TagCloudViewComponentTagHelper : Microsoft.AspNetCore.
                 @"[Microsoft.AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute(""tagcloud"")]
 public class __Generated__TagCloudViewComponentTagHelper : Microsoft.AspNetCore.Razor.TagHelpers.TagHelper
 {
-    private readonly global::Microsoft.AspNetCore.Mvc.IViewComponentHelper _helper = null;
+    private readonly global::Microsoft.AspNetCore.Mvc.IViewComponentHelper __helper = null;
     public __Generated__TagCloudViewComponentTagHelper(global::Microsoft.AspNetCore.Mvc.IViewComponentHelper helper)
     {
-        _helper = helper;
+        __helper = helper;
     }
     [Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeNotBoundAttribute, global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewContextAttribute]
     public global::Microsoft.AspNetCore.Mvc.Rendering.ViewContext ViewContext { get; set; }
     public System.Collections.Generic.Dictionary<System.String, System.Int32> Tags { get; set; }
      = new System.Collections.Generic.Dictionary<System.String, System.Int32>();
-    public override async global::System.Threading.Tasks.Task ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output)
+    public override async global::System.Threading.Tasks.Task ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext __context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput __output)
     {
-        (_helper as global::Microsoft.AspNetCore.Mvc.ViewFeatures.IViewContextAware)?.Contextualize(ViewContext);
-        var content = await _helper.InvokeAsync(""TagCloud"", new { Tags });
-        output.TagName = null;
-        output.Content.SetHtmlContent(content);
+        (__helper as global::Microsoft.AspNetCore.Mvc.ViewFeatures.IViewContextAware)?.Contextualize(ViewContext);
+        var __helperContent = await __helper.InvokeAsync(""TagCloud"", new { Tags });
+        __output.TagName = null;
+        __output.Content.SetHtmlContent(__helperContent);
     }
 }
 ",


### PR DESCRIPTION
- It looks that when we first did VCTH we never put in the effort to reduce our footprint on available parameters for `ViewComponentTagHelper`s. I went ahead and added several underscores to the generated fields/parameters to reduce collisions.
- Updated tests to reflect the new codegen.

_Note: On initial investigation of this issue I must have had a bad environment because I thought that VCTH's weren't working at all. Turns out they work but can't have specifically named parameters. That's what this PR fixes._

aspnet/AspNetCore#8645