### PR TITLE
For bind on element, also write the updated attribute name to the render tree builder

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentBindLoweringPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentBindLoweringPass.cs
@@ -369,6 +369,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
                     Prefix = changeAttributeName + "=\"",
                     Suffix = "\"",
+
+                    EventUpdatesAttributeName = valueNode.AttributeName,
                 };
 
                 changeNode.Children.Add(new CSharpExpressionAttributeValueIntermediateNode());

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentRuntimeNodeWriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentRuntimeNodeWriter.cs
@@ -228,6 +228,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
             WriteAttribute(context, node.AttributeName, _currentAttributeValues);
             _currentAttributeValues.Clear();
+
+            if (!string.IsNullOrEmpty(node.EventUpdatesAttributeName))
+            {
+                context.CodeWriter
+                    .WriteStartMethodInvocation($"{_scopeStack.BuilderVarName}.{ComponentsApi.RenderTreeBuilder.SetUpdatesAttributeName}")
+                    .WriteStringLiteral(node.EventUpdatesAttributeName)
+                    .WriteEndMethodInvocation();
+            }
         }
 
         public override void WriteHtmlAttributeValue(CodeRenderingContext context, HtmlAttributeValueIntermediateNode node)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentsApi.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentsApi.cs
@@ -89,6 +89,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             public static readonly string ChildContent = nameof(ChildContent);
 
             public static readonly string SetKey = nameof(SetKey);
+
+            public static readonly string SetUpdatesAttributeName = nameof(SetUpdatesAttributeName);
         }
 
         public static class RuntimeHelpers

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Intermediate/HtmlAttributeIntermediateNode.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Intermediate/HtmlAttributeIntermediateNode.cs
@@ -15,6 +15,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
         public string Suffix { get; set; }
 
+        public string EventUpdatesAttributeName { get; set; }
+
         public override void Accept(IntermediateNodeVisitor visitor)
         {
             if (visitor == null)
@@ -32,6 +34,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
             formatter.WriteProperty(nameof(AttributeName), AttributeName);
             formatter.WriteProperty(nameof(Prefix), Prefix);
             formatter.WriteProperty(nameof(Suffix), Suffix);
+            formatter.WriteProperty(nameof(EventUpdatesAttributeName), EventUpdatesAttributeName);
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components/RenderTree/RenderTreeBuilder.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components/RenderTree/RenderTreeBuilder.cs
@@ -107,5 +107,9 @@ namespace Microsoft.AspNetCore.Components.RenderTree
         public void SetKey(object key)
         {
         }
+
+        public void SetUpdatesAttributeName(string updatesAttributeName)
+        {
+        }
     }
 }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -25,6 +25,7 @@ namespace Test
 #nullable disable
             , "MM/dd"));
             builder.AddAttribute(3, "onchange", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => CurrentDate = __value, CurrentDate, "MM/dd"));
+            builder.SetUpdatesAttributeName("value");
             builder.CloseElement();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (113:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1240:32,7 [77] )
+Generated Location: (1295:33,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
@@ -25,6 +25,7 @@ namespace Test
 #nullable disable
             ));
             builder.AddAttribute(3, "onchange", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue));
+            builder.SetUpdatesAttributeName("value");
             builder.CloseElement();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (86:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1222:32,7 [50] )
+Generated Location: (1277:33,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.codegen.cs
@@ -24,6 +24,7 @@ namespace Test
 #nullable disable
             ));
             builder.AddAttribute(2, "myevent", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue));
+            builder.SetUpdatesAttributeName("myvalue");
             builder.CloseElement();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (43:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1153:31,7 [55] )
+Generated Location: (1210:32,7 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.codegen.cs
@@ -24,6 +24,7 @@ namespace Test
 #nullable disable
             ));
             builder.AddAttribute(2, "myevent", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue));
+            builder.SetUpdatesAttributeName("myvalue");
             builder.CloseElement();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (42:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1152:31,7 [55] )
+Generated Location: (1209:32,7 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.codegen.cs
@@ -24,6 +24,7 @@ namespace Test
 #nullable disable
             ));
             builder.AddAttribute(2, "myevent", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue));
+            builder.SetUpdatesAttributeName("myvalue");
             builder.CloseElement();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (37:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1147:31,7 [55] )
+Generated Location: (1204:32,7 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
@@ -25,6 +25,7 @@ namespace Test
 #nullable disable
             ));
             builder.AddAttribute(3, "onchange", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => Enabled = __value, Enabled));
+            builder.SetUpdatesAttributeName("checked");
             builder.CloseElement();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (51:1,7 [41] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public bool Enabled { get; set; }
 |
-Generated Location: (1214:32,7 [41] )
+Generated Location: (1271:33,7 [41] )
 |
     public bool Enabled { get; set; }
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
@@ -33,6 +33,7 @@ namespace Test
 #nullable disable
             ));
             builder.AddAttribute(3, "onchange", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => CurrentDate = __value, CurrentDate, Format));
+            builder.SetUpdatesAttributeName("value");
             builder.CloseElement();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
@@ -4,7 +4,7 @@ Source Location: (73:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public string Format { get; set; } = "MM/dd/yyyy";
 |
-Generated Location: (1423:40,7 [135] )
+Generated Location: (1478:41,7 [135] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -25,6 +25,7 @@ namespace Test
 #nullable disable
             , "MM/dd/yyyy"));
             builder.AddAttribute(3, "onchange", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => CurrentDate = __value, CurrentDate, "MM/dd/yyyy"));
+            builder.SetUpdatesAttributeName("value");
             builder.CloseElement();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (76:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1244:32,7 [77] )
+Generated Location: (1299:33,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.codegen.cs
@@ -25,6 +25,7 @@ namespace Test
 #nullable disable
             ));
             builder.AddAttribute(3, "onchange", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue));
+            builder.SetUpdatesAttributeName("value");
             builder.CloseElement();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (51:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1216:32,7 [50] )
+Generated Location: (1271:33,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.codegen.cs
@@ -24,6 +24,7 @@ namespace Test
 #nullable disable
             ));
             builder.AddAttribute(2, "onchange", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue));
+            builder.SetUpdatesAttributeName("value");
             builder.CloseElement();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (39:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1150:31,7 [50] )
+Generated Location: (1205:32,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.codegen.cs
@@ -36,6 +36,7 @@ namespace Test
 #nullable disable
             ));
             builder.AddAttribute(6, "oninput", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => text = __value, text));
+            builder.SetUpdatesAttributeName("value");
             builder.CloseElement();
             builder.AddMarkupContent(7, "\r\n");
             builder.CloseElement();

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (129:3,12 [35] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private string text = "hi";
 |
-Generated Location: (1785:45,12 [35] )
+Generated Location: (1840:46,12 [35] )
 |
     private string text = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.codegen.cs
@@ -28,6 +28,7 @@ namespace Test
 #nullable disable
             ));
             builder.AddAttribute(6, "onchange", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => text = __value, text));
+            builder.SetUpdatesAttributeName("value");
             builder.CloseElement();
             builder.AddMarkupContent(7, "\r\n");
             builder.CloseElement();

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (83:3,12 [35] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private string text = "hi";
 |
-Generated Location: (1449:37,12 [35] )
+Generated Location: (1504:38,12 [35] )
 |
     private string text = "hi";
 |


### PR DESCRIPTION
This is needed for https://github.com/aspnet/AspNetCore/issues/8204

We have to know whether any given event is part of a two-way binding or not, because it's important that we **only** force the DOM to be consistent with the render tree if it's part of a two-way binding. Otherwise we destroy the entire ability to do one-way binding (i.e., just an input event handler that doesn't have any corresponding output value).