### PR TITLE
Use LogErrorFromException when FindAssembliesWithReferencesTo throws

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/FindAssembliesWithReferencesTo.cs
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/FindAssembliesWithReferencesTo.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -45,9 +46,15 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             var targetAssemblyNames = TargetAssemblyNames.Select(s => s.ItemSpec).ToList();
 
             var provider = new ReferenceResolver(targetAssemblyNames, referenceItems);
-            var assemblyNames = provider.ResolveAssemblies();
-
-            ResolvedAssemblies = assemblyNames.ToArray();
+            try
+            {
+                var assemblyNames = provider.ResolveAssemblies();
+                ResolvedAssemblies = assemblyNames.ToArray();
+            }
+            catch (Exception ex)
+            {
+                Log.LogErrorFromException(ex);
+            }
 
             return !Log.HasLoggedErrors;
         }

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.MvcApplicationPartsDiscovery.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.MvcApplicationPartsDiscovery.targets
@@ -17,9 +17,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />
 
   <PropertyGroup>
-    <GenerateMvcApplicationPartsAttribute Condition="'$(GenerateMvcApplicationPartsAssemblyAttributes)' == '' AND '$(OutputType)' == 'Exe'">true</GenerateMvcApplicationPartsAttribute>
+    <GenerateMvcApplicationPartsAssemblyAttributes Condition="'$(GenerateMvcApplicationPartsAssemblyAttributes)' == '' AND '$(OutputType)' == 'Exe'">true</GenerateMvcApplicationPartsAssemblyAttributes>
 
-    <CoreCompileDependsOn Condition="'$(GenerateMvcApplicationPartsAttribute)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
+    <CoreCompileDependsOn Condition="'$(GenerateMvcApplicationPartsAssemblyAttributes)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
       _DiscoverMvcApplicationParts;
       $(CoreCompileDependsOn);
     </CoreCompileDependsOn>

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/ApplicationPartDiscoveryIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/ApplicationPartDiscoveryIntegrationTest.cs
@@ -38,6 +38,17 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         }
 
         [Fact]
+        [InitializeTestProject("AppWithP2PReference", additionalProjects: "ClassLibrary")]
+        public async Task Build_ProjectWithDependencyThatReferencesMvc_DoesNotGenerateAttributeIfFlagIsReset()
+        {
+            var result = await DotnetMSBuild("Build /p:GenerateMvcApplicationPartsAssemblyAttributes=false");
+
+            Assert.BuildPassed(result);
+
+            Assert.FileDoesNotExist(result, IntermediateOutputPath, "AppWithP2PReference.MvcApplicationPartsAssemblyInfo.cs");
+        }
+
+        [Fact]
         [InitializeTestProject("SimpleMvc")]
         public async Task Build_ProjectWithoutMvcReferencingDependencies_DoesNotGenerateAttribute()
         {


### PR DESCRIPTION
Currently FindAssembliesWithReferencesTo produces a stacktrace when P2P builds fail - for instance
if the referenced project has a compiler error. This changes it to use LogErrorFromException.

In addition, there was a typo in the property that disabled the feature.

Fixes https://github.com/aspnet/AspNetCore/issues/11226
