### PR TITLE
Update tests to specify public [Parameter]

### DIFF
--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/BindTagHelperDescriptorProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/BindTagHelperDescriptorProviderTest.cs
@@ -32,13 +32,13 @@ namespace Test
         }
 
         [Parameter]
-        string MyProperty { get; set; }
+        public string MyProperty { get; set; }
 
         [Parameter]
-        Action<string> MyPropertyChanged { get; set; }
+        public Action<string> MyPropertyChanged { get; set; }
 
         [Parameter]
-        Expression<Func<string>> MyPropertyExpression { get; set; }
+        public Expression<Func<string>> MyPropertyExpression { get; set; }
     }
 }
 "));
@@ -156,10 +156,10 @@ namespace Test
         }
 
         [Parameter]
-        string MyProperty { get; set; }
+        public string MyProperty { get; set; }
 
         [Parameter]
-        EventCallback<string> MyPropertyChanged { get; set; }
+        public EventCallback<string> MyPropertyChanged { get; set; }
     }
 }
 "));

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/ComponentTagHelperDescriptorProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/ComponentTagHelperDescriptorProviderTest.cs
@@ -31,7 +31,7 @@ namespace Test
         }
 
         [Parameter]
-        private string MyProperty { get; set; }
+        public string MyProperty { get; set; }
     }
 }
 
@@ -151,7 +151,7 @@ namespace Test
         }
 
         [Parameter]
-        private string MyProperty { get; set; }
+        public string MyProperty { get; set; }
     }
 }
 
@@ -215,7 +215,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        string MyProperty { get; set; }
+        public string MyProperty { get; set; }
     }
 }
 
@@ -257,7 +257,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        bool MyProperty { get; set; }
+        public bool MyProperty { get; set; }
     }
 }
 
@@ -310,7 +310,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        MyEnum MyProperty { get; set; }
+        public MyEnum MyProperty { get; set; }
     }
 }
 
@@ -357,7 +357,7 @@ namespace Test
     public class MyComponent<T> : ComponentBase
     {
         [Parameter]
-        T MyProperty { get; set; }
+        public T MyProperty { get; set; }
     }
 }
 
@@ -415,13 +415,13 @@ namespace Test
     public class MyComponent<T, U, V> : ComponentBase
     {
         [Parameter]
-        T MyProperty1 { get; set; }
+        public T MyProperty1 { get; set; }
 
         [Parameter]
-        U MyProperty2 { get; set; }
+        public U MyProperty2 { get; set; }
 
         [Parameter]
-        V MyProperty3 { get; set; }
+        public V MyProperty3 { get; set; }
     }
 }
 
@@ -496,7 +496,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        Action<UIMouseEventArgs> OnClick { get; set; }
+        public Action<UIMouseEventArgs> OnClick { get; set; }
     }
 }
 
@@ -546,7 +546,7 @@ namespace Test
     public class MyComponent<T> : ComponentBase
     {
         [Parameter]
-        Action<T> OnClick { get; set; }
+        public Action<T> OnClick { get; set; }
     }
 }
 
@@ -608,7 +608,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        EventCallback OnClick { get; set; }
+        public EventCallback OnClick { get; set; }
     }
 }
 
@@ -658,7 +658,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        EventCallback<UIMouseEventArgs> OnClick { get; set; }
+        public EventCallback<UIMouseEventArgs> OnClick { get; set; }
     }
 }
 
@@ -713,7 +713,7 @@ namespace Test
     public class MyComponent<T> : ComponentBase
     {
         [Parameter]
-        EventCallback<T> OnClick { get; set; }
+        public EventCallback<T> OnClick { get; set; }
     }
 }
 
@@ -776,7 +776,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        RenderFragment ChildContent2 { get; set; }
+        public RenderFragment ChildContent2 { get; set; }
     }
 }
 
@@ -833,7 +833,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        RenderFragment<string> ChildContent2 { get; set; }
+        public RenderFragment<string> ChildContent2 { get; set; }
     }
 }
 
@@ -905,10 +905,10 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        RenderFragment<string> ChildContent2 { get; set; }
+        public RenderFragment<string> ChildContent2 { get; set; }
 
         [Parameter]
-        string Context { get; set; }
+        public string Context { get; set; }
     }
 }
 
@@ -980,7 +980,7 @@ namespace Test
     public class MyComponent<T> : ComponentBase
     {
         [Parameter]
-        RenderFragment<T> ChildContent2 { get; set; }
+        public RenderFragment<T> ChildContent2 { get; set; }
     }
 }
 
@@ -1062,7 +1062,7 @@ namespace Test
     public class MyComponent<T> : ComponentBase
     {
         [Parameter]
-        RenderFragment<List<string>> ChildContent2 { get; set; }
+        public RenderFragment<List<string>> ChildContent2 { get; set; }
     }
 }
 
@@ -1144,7 +1144,7 @@ namespace Test
     public class MyComponent<T> : ComponentBase
     {
         [Parameter]
-        RenderFragment<List<T>> ChildContent2 { get; set; }
+        public RenderFragment<List<T>> ChildContent2 { get; set; }
     }
 }
 
@@ -1225,7 +1225,7 @@ namespace Test
     public class MyComponent<T> : ComponentBase
     {
         [Parameter]
-        RenderFragment<Context> ChildContent2 { get; set; }
+        public RenderFragment<Context> ChildContent2 { get; set; }
 
         public class Context
         {
@@ -1310,13 +1310,13 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        RenderFragment ChildContent { get; set; }
+        public RenderFragment ChildContent { get; set; }
 
         [Parameter]
-        RenderFragment<string> Header { get; set; }
+        public RenderFragment<string> Header { get; set; }
 
         [Parameter]
-        RenderFragment<string> Footer { get; set; }
+        public RenderFragment<string> Footer { get; set; }
     }
 }
 
@@ -1388,21 +1388,21 @@ namespace Test
     public abstract class MyBase : ComponentBase
     {
         [Parameter]
-        protected string Hidden { get; set; }
+        public string Hidden { get; set; }
     }
 
     public class MyComponent : MyBase
     {
         [Parameter]
-        string NoSetter { get; }
+        public string NoSetter { get; }
 
         [Parameter]
-        static string StaticProperty { get; set; }
+        public static string StaticProperty { get; set; }
 
         public string NoParameterAttribute { get; set; }
 
         // No attribute here, hides base-class property of the same name.
-        protected new int Hidden { get; set; }
+        public new int Hidden { get; set; }
 
         public string this[int i]
         {

--- a/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentChildContentIntegrationTest.cs
+++ b/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentChildContentIntegrationTest.cs
@@ -23,7 +23,7 @@ namespace Test
         }
 
         [Parameter]
-        RenderFragment ChildContent { get; set; }
+        public RenderFragment ChildContent { get; set; }
     }
 }
 ");
@@ -41,10 +41,10 @@ namespace Test
         }
 
         [Parameter]
-        RenderFragment<string> ChildContent { get; set; }
+        public RenderFragment<string> ChildContent { get; set; }
 
         [Parameter]
-        string Value { get; set; }
+        public string Value { get; set; }
     }
 }
 ");
@@ -64,19 +64,19 @@ namespace Test
         }
 
         [Parameter]
-        string Name { get; set; }
+        public string Name { get; set; }
 
         [Parameter]
-        RenderFragment<string> Header { get; set; }
+        public RenderFragment<string> Header { get; set; }
 
         [Parameter]
-        RenderFragment<string> ChildContent { get; set; }
+        public RenderFragment<string> ChildContent { get; set; }
 
         [Parameter]
-        RenderFragment Footer { get; set; }
+        public RenderFragment Footer { get; set; }
 
         [Parameter]
-        string Value { get; set; }
+        public string Value { get; set; }
     }
 }
 ");

--- a/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -174,10 +174,10 @@ namespace Test
 
     public class MyComponent : ComponentBase
     {
-        [Parameter] int IntProperty { get; set; }
-        [Parameter] bool BoolProperty { get; set; }
-        [Parameter] string StringProperty { get; set; }
-        [Parameter] SomeType ObjectProperty { get; set; }
+        [Parameter] public int IntProperty { get; set; }
+        [Parameter] public bool BoolProperty { get; set; }
+        [Parameter] public string StringProperty { get; set; }
+        [Parameter] public SomeType ObjectProperty { get; set; }
     }
 }
 "));
@@ -215,9 +215,9 @@ namespace Test
     </p>
 }
 @code {
-    [Parameter] TItem1 Item1 { get; set; }
-    [Parameter] List<TItem2> Items2 { get; set; }
-    [Parameter] RenderFragment<TItem2> ChildContent { get; set; }
+    [Parameter] public TItem1 Item1 { get; set; }
+    [Parameter] public List<TItem2> Items2 { get; set; }
+    [Parameter] public RenderFragment<TItem2> ChildContent { get; set; }
 }");
 
             // Assert
@@ -238,7 +238,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        string StringProperty { get; set; }
+        public string StringProperty { get; set; }
     }
 }
 "));
@@ -289,7 +289,7 @@ namespace Test
 {
     public class CoolnessMeter : ComponentBase
     {
-        [Parameter] private int Coolness { get; set; }
+        [Parameter] public int Coolness { get; set; }
     }
 }
 "));
@@ -415,10 +415,10 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        int Value { get; set; }
+        public int Value { get; set; }
 
         [Parameter]
-        Action<int> ValueChanged { get; set; }
+        public Action<int> ValueChanged { get; set; }
     }
 }"));
 
@@ -448,10 +448,10 @@ namespace Test
     public class InputText : ComponentBase
     {
         [Parameter]
-        string Value { get; set; }
+        public string Value { get; set; }
 
         [Parameter]
-        Action<string> ValueChanged { get; set; }
+        public Action<string> ValueChanged { get; set; }
     }
 }"));
 
@@ -495,10 +495,10 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        int Value { get; set; }
+        public int Value { get; set; }
 
         [Parameter]
-        Action<int> ValueChanged { get; set; }
+        public Action<int> ValueChanged { get; set; }
     }
 }"));
 
@@ -534,10 +534,10 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        int Value { get; set; }
+        public int Value { get; set; }
 
         [Parameter]
-        EventCallback<int> ValueChanged { get; set; }
+        public EventCallback<int> ValueChanged { get; set; }
     }
 }"));
 
@@ -567,10 +567,10 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        int Value { get; set; }
+        public int Value { get; set; }
 
         [Parameter]
-        EventCallback<int> ValueChanged { get; set; }
+        public EventCallback<int> ValueChanged { get; set; }
     }
 }"));
 
@@ -634,10 +634,10 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        int Value { get; set; }
+        public int Value { get; set; }
 
         [Parameter]
-        Action<int> OnChanged { get; set; }
+        public Action<int> OnChanged { get; set; }
     }
 }"));
             // Act
@@ -694,13 +694,13 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        int Value { get; set; }
+        public int Value { get; set; }
 
         [Parameter]
-        Action<int> ValueChanged { get; set; }
+        public Action<int> ValueChanged { get; set; }
 
         [Parameter]
-        Expression<Func<int>> ValueExpression { get; set; }
+        public Expression<Func<int>> ValueExpression { get; set; }
     }
 }"));
 
@@ -731,13 +731,13 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        int Value { get; set; }
+        public int Value { get; set; }
 
         [Parameter]
-        EventCallback<int> ValueChanged { get; set; }
+        public EventCallback<int> ValueChanged { get; set; }
 
         [Parameter]
-        Expression<Func<int>> ValueExpression { get; set; }
+        public Expression<Func<int>> ValueExpression { get; set; }
     }
 }"));
 
@@ -768,13 +768,13 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        int Value { get; set; }
+        public int Value { get; set; }
 
         [Parameter]
-        Action<int> ValueChanged { get; set; }
+        public Action<int> ValueChanged { get; set; }
 
         [Parameter]
-        Expression<Func<string>> ValueExpression { get; set; }
+        public Expression<Func<string>> ValueExpression { get; set; }
     }
 }"));
 
@@ -807,13 +807,13 @@ namespace Test
     public class MyComponent<T> : ComponentBase
     {
         [Parameter]
-        T SomeParam { get; set; }
+        public T SomeParam { get; set; }
 
         [Parameter]
-        Action<T> SomeParamChanged { get; set; }
+        public Action<T> SomeParamChanged { get; set; }
 
         [Parameter]
-        Expression<Func<T>> SomeParamExpression { get; set; }
+        public Expression<Func<T>> SomeParamExpression { get; set; }
     }
 }"));
 
@@ -844,13 +844,13 @@ namespace Test
     public class MyComponent<T> : ComponentBase
     {
         [Parameter]
-        T SomeParam { get; set; }
+        public T SomeParam { get; set; }
 
         [Parameter]
-        EventCallback<T> SomeParamChanged { get; set; }
+        public EventCallback<T> SomeParamChanged { get; set; }
 
         [Parameter]
-        Expression<Func<T>> SomeParamExpression { get; set; }
+        public Expression<Func<T>> SomeParamExpression { get; set; }
     }
 }"));
 
@@ -1372,10 +1372,10 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        string MyAttr { get; set; }
+        public string MyAttr { get; set; }
 
         [Parameter]
-        RenderFragment ChildContent { get; set; }
+        public RenderFragment ChildContent { get; set; }
     }
 }
 "));
@@ -1402,10 +1402,10 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        string MyAttr { get; set; }
+        public string MyAttr { get; set; }
 
         [Parameter]
-        RenderFragment<string> ChildContent { get; set; }
+        public RenderFragment<string> ChildContent { get; set; }
     }
 }
 "));
@@ -1433,10 +1433,10 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        string MyAttr { get; set; }
+        public string MyAttr { get; set; }
 
         [Parameter]
-        RenderFragment<string> ChildContent { get; set; }
+        public RenderFragment<string> ChildContent { get; set; }
     }
 }
 "));
@@ -1467,10 +1467,10 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        string MyAttr { get; set; }
+        public string MyAttr { get; set; }
 
         [Parameter]
-        RenderFragment<string> ChildContent { get; set; }
+        public RenderFragment<string> ChildContent { get; set; }
     }
 }
 "));
@@ -1501,7 +1501,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        RenderFragment ChildContent { get; set; }
+        public RenderFragment ChildContent { get; set; }
     }
 }
 "));
@@ -1528,7 +1528,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        RenderFragment ChildContent { get; set; }
+        public RenderFragment ChildContent { get; set; }
     }
 }
 "));
@@ -1555,7 +1555,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        RenderFragment<string> ChildContent { get; set; }
+        public RenderFragment<string> ChildContent { get; set; }
     }
 }
 "));
@@ -1582,10 +1582,10 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        RenderFragment Header { get; set; }
+        public RenderFragment Header { get; set; }
 
         [Parameter]
-        RenderFragment Footer { get; set; }
+        public RenderFragment Footer { get; set; }
     }
 }
 "));
@@ -1615,12 +1615,13 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        RenderFragment<string> Header { get; set; }
-
-        RenderFragment ChildContent { get; set; }
+        public RenderFragment<string> Header { get; set; }
 
         [Parameter]
-        RenderFragment Footer { get; set; }
+        public RenderFragment ChildContent { get; set; }
+
+        [Parameter]
+        public RenderFragment Footer { get; set; }
     }
 }
 "));
@@ -1650,13 +1651,13 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        RenderFragment<string> Header { get; set; }
+        public RenderFragment<string> Header { get; set; }
 
         [Parameter]
-        RenderFragment ChildContent { get; set; }
+        public RenderFragment ChildContent { get; set; }
 
         [Parameter]
-        RenderFragment Footer { get; set; }
+        public RenderFragment Footer { get; set; }
     }
 }
 "));
@@ -1849,7 +1850,7 @@ namespace Test
     public class HeaderComponent : ComponentBase
     {
         [Parameter]
-        RenderFragment Header { get; set; }
+        public RenderFragment Header { get; set; }
     }
 }
 
@@ -1858,7 +1859,7 @@ namespace AnotherTest
     public class FooterComponent : ComponentBase
     {
         [Parameter]
-        RenderFragment<DateTime> Footer { get; set; }
+        public RenderFragment<DateTime> Footer { get; set; }
     }
 }
 "));
@@ -1900,7 +1901,7 @@ namespace Test
     public class HeaderComponent : ComponentBase
     {
         [Parameter]
-        string Header { get; set; }
+        public string Header { get; set; }
     }
 }
 
@@ -1909,7 +1910,7 @@ namespace AnotherTest
     public class FooterComponent : ComponentBase
     {
         [Parameter]
-        string Footer { get; set; }
+        public string Footer { get; set; }
     }
 }
 "));
@@ -1948,7 +1949,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        EventCallback OnClick { get; set; }
+        public EventCallback OnClick { get; set; }
     }
 }
 "));
@@ -1983,7 +1984,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        EventCallback<UIMouseEventArgs> OnClick { get; set; }
+        public EventCallback<UIMouseEventArgs> OnClick { get; set; }
     }
 }
 "));
@@ -2018,7 +2019,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        EventCallback OnClick { get; set; }
+        public EventCallback OnClick { get; set; }
     }
 }
 "));
@@ -2053,7 +2054,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        EventCallback OnClick { get; set; }
+        public EventCallback OnClick { get; set; }
     }
 }
 "));
@@ -2088,7 +2089,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        EventCallback OnClick { get; set; }
+        public EventCallback OnClick { get; set; }
     }
 }
 "));
@@ -2124,7 +2125,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        EventCallback OnClick { get; set; }
+        public EventCallback OnClick { get; set; }
     }
 }
 "));
@@ -2160,7 +2161,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        EventCallback<UIMouseEventArgs> OnClick { get; set; }
+        public EventCallback<UIMouseEventArgs> OnClick { get; set; }
     }
 }
 "));
@@ -2195,7 +2196,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        EventCallback<UIMouseEventArgs> OnClick { get; set; }
+        public EventCallback<UIMouseEventArgs> OnClick { get; set; }
     }
 }
 "));
@@ -2230,7 +2231,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        EventCallback<UIMouseEventArgs> OnClick { get; set; }
+        public EventCallback<UIMouseEventArgs> OnClick { get; set; }
     }
 }
 "));
@@ -2266,7 +2267,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        EventCallback<UIMouseEventArgs> OnClick { get; set; }
+        public EventCallback<UIMouseEventArgs> OnClick { get; set; }
     }
 }
 "));
@@ -2302,7 +2303,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        EventCallback<UIMouseEventArgs> OnClick { get; set; }
+        public EventCallback<UIMouseEventArgs> OnClick { get; set; }
     }
 }
 "));
@@ -2346,7 +2347,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        Action<UIEventArgs> OnClick { get; set; }
+        public Action<UIEventArgs> OnClick { get; set; }
     }
 }
 "));
@@ -2413,7 +2414,7 @@ namespace Test
     public class MyComponent : ComponentBase
     {
         [Parameter]
-        Action<UIEventArgs> OnClick { get; set; }
+        public Action<UIEventArgs> OnClick { get; set; }
     }
 }
 "));
@@ -2664,7 +2665,7 @@ namespace Test
 {
     public class MyComponent<TItem> : ComponentBase
     {
-        [Parameter] TItem Item { get; set; }
+        [Parameter] public TItem Item { get; set; }
     }
 }
 "));
@@ -2690,7 +2691,7 @@ namespace Test
 {
     public class MyComponent<TItem> : ComponentBase
     {
-        [Parameter] TItem Item { get; set; }
+        [Parameter] public TItem Item { get; set; }
     }
 }
 "));
@@ -2716,7 +2717,7 @@ namespace Test
 {
     public class MyComponent<TItem> : ComponentBase
     {
-        [Parameter] TItem Item { get; set; }
+        [Parameter] public TItem Item { get; set; }
     }
 }
 "));
@@ -2744,7 +2745,7 @@ namespace Test
 {
     public class MyComponent<TItem> : ComponentBase
     {
-        [Parameter] TItem Item { get; set; }
+        [Parameter] public TItem Item { get; set; }
     }
 }
 "));
@@ -2770,7 +2771,7 @@ namespace Test
 {
     public class MyComponent<TItem> : ComponentBase
     {
-        [Parameter] TItem Item { get; set; }
+        [Parameter] public TItem Item { get; set; }
     }
 }
 "));
@@ -2798,10 +2799,10 @@ namespace Test
     public class MyComponent<TItem> : ComponentBase
     {
         [Parameter]
-        TItem Item { get; set; }
+        public TItem Item { get; set; }
 
         [Parameter]
-        Action<TItem> ItemChanged { get; set; }
+        public Action<TItem> ItemChanged { get; set; }
     }
 }
 "));
@@ -2832,10 +2833,10 @@ namespace Test
     public class MyComponent<TItem> : ComponentBase
     {
         [Parameter]
-        TItem Item { get; set; }
+        public TItem Item { get; set; }
 
         [Parameter]
-        Action<TItem> ItemChanged { get; set; }
+        public Action<TItem> ItemChanged { get; set; }
     }
 }
 "));
@@ -2895,7 +2896,7 @@ namespace Test
 {
     public class MyComponent<TItem> : ComponentBase
     {
-        [Parameter] TItem Value { get; set; }
+        [Parameter] public TItem Value { get; set; }
     }
 }
 "));
@@ -2924,9 +2925,9 @@ namespace Test
 {
     public class MyComponent<TItem> : ComponentBase
     {
-        [Parameter] TItem Item { get; set; }
+        [Parameter] public TItem Item { get; set; }
 
-        [Parameter] RenderFragment<TItem> ChildContent { get; set; }
+        [Parameter] public RenderFragment<TItem> ChildContent { get; set; }
     }
 }
 "));
@@ -2954,9 +2955,9 @@ namespace Test
 {
     public class MyComponent<TItem> : ComponentBase
     {
-        [Parameter] TItem Item { get; set; }
+        [Parameter] public TItem Item { get; set; }
 
-        [Parameter] RenderFragment<TItem> ChildContent { get; set; }
+        [Parameter] public RenderFragment<TItem> ChildContent { get; set; }
     }
 }
 "));
@@ -2984,11 +2985,11 @@ namespace Test
 {
     public class MyComponent<TItem> : ComponentBase
     {
-        [Parameter] TItem Item { get; set; }
+        [Parameter] public TItem Item { get; set; }
 
-        [Parameter] RenderFragment<TItem> GenericFragment { get; set; }
+        [Parameter] public RenderFragment<TItem> GenericFragment { get; set; }
 
-        [Parameter] RenderFragment<int> IntFragment { get; set; }
+        [Parameter] public RenderFragment<int> IntFragment { get; set; }
     }
 }
 "));
@@ -3017,9 +3018,9 @@ namespace Test
 {
     public class MyComponent<TItem> : ComponentBase
     {
-        [Parameter] TItem Item { get; set; }
+        [Parameter] public TItem Item { get; set; }
 
-        [Parameter] RenderFragment<TItem> ChildContent { get; set; }
+        [Parameter] public RenderFragment<TItem> ChildContent { get; set; }
     }
 }
 "));
@@ -3047,11 +3048,11 @@ namespace Test
 {
     public class MyComponent<TItem1, TItem2> : ComponentBase
     {
-        [Parameter] TItem1 Item { get; set; }
+        [Parameter] public TItem1 Item { get; set; }
 
-        [Parameter] RenderFragment<TItem1> ChildContent { get; set; }
+        [Parameter] public RenderFragment<TItem1> ChildContent { get; set; }
 
-        [Parameter] RenderFragment<Context> AnotherChildContent { get; set; }
+        [Parameter] public RenderFragment<Context> AnotherChildContent { get; set; }
 
         public class Context
         {
@@ -3088,13 +3089,13 @@ namespace Test
 {
     public class MyComponent<TItem1, TItem2> : ComponentBase
     {
-        [Parameter] TItem1 Item { get; set; }
+        [Parameter] public TItem1 Item { get; set; }
 
-        [Parameter] List<TItem2> Items { get; set; }
+        [Parameter] public List<TItem2> Items { get; set; }
 
-        [Parameter] RenderFragment<TItem1> ChildContent { get; set; }
+        [Parameter] public RenderFragment<TItem1> ChildContent { get; set; }
 
-        [Parameter] RenderFragment<Context> AnotherChildContent { get; set; }
+        [Parameter] public RenderFragment<Context> AnotherChildContent { get; set; }
 
         public class Context
         {
@@ -3130,7 +3131,7 @@ namespace Test
 {
     public class MyComponent<TItem> : ComponentBase
     {
-        [Parameter] TItem Item { get; set; }
+        [Parameter] public TItem Item { get; set; }
     }
 }
 "));
@@ -3161,7 +3162,7 @@ namespace Test
 {
     public class MyComponent<TItem> : ComponentBase
     {
-        [Parameter] TItem Item { get; set; }
+        [Parameter] public TItem Item { get; set; }
     }
 }
 "));
@@ -3192,7 +3193,7 @@ namespace Test
 {
     public class MyComponent<TItem> : ComponentBase
     {
-        [Parameter] TItem Item { get; set; }
+        [Parameter] public TItem Item { get; set; }
     }
 }
 "));
@@ -3253,7 +3254,7 @@ namespace Test
 {
     public class MyComponent<TItem> : ComponentBase
     {
-        [Parameter] TItem Item { get; set; }
+        [Parameter] public TItem Item { get; set; }
     }
 }
 "));
@@ -3318,8 +3319,8 @@ namespace Test
 {
     public class MyComponent<TItem> : ComponentBase
     {
-        [Parameter] TItem Item { get; set; }
-        [Parameter] MyClass Foo { get; set; }
+        [Parameter] public TItem Item { get; set; }
+        [Parameter] public MyClass Foo { get; set; }
     }
 }
 
@@ -3379,7 +3380,7 @@ namespace Test.Shared
 @code {
         private object someObject = new object();
 
-        [Parameter] protected int Min { get; set; }
+        [Parameter] public int Min { get; set; }
     }
 ");
 
@@ -3606,7 +3607,7 @@ namespace Test
 {
     public class MyComponent<T> : ComponentBase
     {
-        [Parameter] T Value { get; set;}
+        [Parameter] public T Value { get; set;}
     }
 }
 "));
@@ -3651,7 +3652,7 @@ namespace Test
 <input type=""text"" data-slider-min=""@Min"" @ref=""@_element"" />
 
 @code {
-        [Parameter] protected int Min { get; set; }
+        [Parameter] public int Min { get; set; }
     }
 ");
 
@@ -3874,7 +3875,7 @@ namespace Test
 {
     public class MyComponent : ComponentBase
     {
-        [Parameter] string Name { get; set; }
+        [Parameter] public string Name { get; set; }
     }
 }
 "));
@@ -3909,7 +3910,7 @@ namespace Test
 {
     public class MyComponent : ComponentBase
     {
-        [Parameter] string Name { get; set; }
+        [Parameter] public string Name { get; set; }
     }
 }
 "));
@@ -3947,7 +3948,7 @@ namespace Test
 {
     public class MyComponent : ComponentBase
     {
-        [Parameter] RenderFragment Template { get; set; }
+        [Parameter] public RenderFragment Template { get; set; }
     }
 }
 "));
@@ -3975,7 +3976,7 @@ namespace Test
 {
     public class MyComponent : ComponentBase
     {
-        [Parameter] RenderFragment<Person> PersonTemplate { get; set; }
+        [Parameter] public RenderFragment<Person> PersonTemplate { get; set; }
     }
 
     public class Person
@@ -4008,7 +4009,7 @@ namespace Test
 {
     public class MyComponent : ComponentBase
     {
-        [Parameter] RenderFragment<Context> Template { get; set; }
+        [Parameter] public RenderFragment<Context> Template { get; set; }
     }
 
     public class Context
@@ -4742,7 +4743,7 @@ namespace Test
 {
     public class SurveyPrompt : ComponentBase
     {
-        [Parameter] private string Title { get; set; }
+        [Parameter] public string Title { get; set; }
     }
 }
 "));
@@ -4780,7 +4781,7 @@ namespace Test
 {
     public class SurveyPrompt : ComponentBase
     {
-        [Parameter] private string Title { get; set; }
+        [Parameter] public string Title { get; set; }
     }
 }
 "));

--- a/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentDirectiveIntegrationTest.cs
+++ b/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentDirectiveIntegrationTest.cs
@@ -124,7 +124,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
         public class TestLayout : IComponent
         {
             [Parameter]
-            RenderFragment Body { get; set; }
+            public RenderFragment Body { get; set; }
 
             public void Configure(RenderHandle renderHandle)
             {

--- a/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentDiscoveryIntegrationTest.cs
+++ b/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentDiscoveryIntegrationTest.cs
@@ -91,7 +91,7 @@ namespace Test.AnotherNamespace
             var result = CompileToCSharp("UniqueName.cshtml", @"
 @typeparam TItem
 @functions {
-    [Parameter] TItem Item { get; set; }
+    [Parameter] public TItem Item { get; set; }
 }");
 
             // Assert
@@ -110,7 +110,7 @@ namespace Test.AnotherNamespace
 @typeparam TItem2
 @typeparam TItem3
 @functions {
-    [Parameter] TItem1 Item { get; set; }
+    [Parameter] public TItem1 Item { get; set; }
 }");
 
             // Assert

--- a/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentGenericTypeIntegrationTest.cs
+++ b/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentGenericTypeIntegrationTest.cs
@@ -39,10 +39,10 @@ namespace Test
         }
 
         [Parameter]
-        List<TItem> Items { get; set; }
+        public List<TItem> Items { get; set; }
 
         [Parameter]
-        RenderFragment<Context> ChildContent { get; set; }
+        public RenderFragment<Context> ChildContent { get; set; }
 
         public class Context
         {
@@ -68,13 +68,13 @@ namespace Test
         }
 
         [Parameter]
-        TItem1 Item1 { get; set; }
+        public TItem1 Item1 { get; set; }
 
         [Parameter]
-        TItem2 Item2 { get; set; }
+        public TItem2 Item2 { get; set; }
 
         [Parameter]
-        TItem3 Item3 { get; set; }
+        public TItem3 Item3 { get; set; }
     }
 }
 ");

--- a/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentTypingTest.cs
+++ b/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentTypingTest.cs
@@ -31,9 +31,9 @@ namespace Test
 {
     public class MyComponent : ComponentBase
     {
-        [Parameter] int Value { get; set; }
-        [Parameter] Action<int> ValueChanged { get; set; }
-        [Parameter] string AnotherValue { get; set; }
+        [Parameter] public int Value { get; set; }
+        [Parameter] public Action<int> ValueChanged { get; set; }
+        [Parameter] public string AnotherValue { get; set; }
     }
 
     public class ModelState
@@ -105,9 +105,9 @@ namespace Test
 {
     public class MyComponent : ComponentBase
     {
-        [Parameter] int Value { get; set; }
-        [Parameter] Action<int> ValueChanged { get; set; }
-        [Parameter] string AnotherValue { get; set; }
+        [Parameter] public int Value { get; set; }
+        [Parameter] public Action<int> ValueChanged { get; set; }
+        [Parameter] public string AnotherValue { get; set; }
     }
 
     public class ModelState

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.codegen.cs
@@ -75,9 +75,9 @@ __o = ChildContent(item2);
 #nullable restore
 #line 12 "x:\dir\subdir\Test\TestComponent.cshtml"
        
-    [Parameter] TItem1 Item1 { get; set; }
-    [Parameter] List<TItem2> Items2 { get; set; }
-    [Parameter] RenderFragment<TItem2> ChildContent { get; set; }
+    [Parameter] public TItem1 Item1 { get; set; }
+    [Parameter] public List<TItem2> Items2 { get; set; }
+    [Parameter] public RenderFragment<TItem2> ChildContent { get; set; }
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.ir.txt
@@ -38,5 +38,5 @@ Document -
                     IntermediateToken - (176:9,8 [3] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n}
                 HtmlContent - (179:10,1 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (179:10,1 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-            CSharpCode - (188:11,7 [164] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (188:11,7 [164] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    [Parameter] TItem1 Item1 { get; set; }\n    [Parameter] List<TItem2> Items2 { get; set; }\n    [Parameter] RenderFragment<TItem2> ChildContent { get; set; }\n
+            CSharpCode - (188:11,7 [185] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (188:11,7 [185] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    [Parameter] public TItem1 Item1 { get; set; }\n    [Parameter] public List<TItem2> Items2 { get; set; }\n    [Parameter] public RenderFragment<TItem2> ChildContent { get; set; }\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
@@ -34,16 +34,16 @@ Generated Location: (1729:66,8 [3] )
 |
 }|
 
-Source Location: (188:11,7 [164] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (188:11,7 [185] x:\dir\subdir\Test\TestComponent.cshtml)
 |
-    [Parameter] TItem1 Item1 { get; set; }
-    [Parameter] List<TItem2> Items2 { get; set; }
-    [Parameter] RenderFragment<TItem2> ChildContent { get; set; }
+    [Parameter] public TItem1 Item1 { get; set; }
+    [Parameter] public List<TItem2> Items2 { get; set; }
+    [Parameter] public RenderFragment<TItem2> ChildContent { get; set; }
 |
-Generated Location: (1911:76,7 [164] )
+Generated Location: (1911:76,7 [185] )
 |
-    [Parameter] TItem1 Item1 { get; set; }
-    [Parameter] List<TItem2> Items2 { get; set; }
-    [Parameter] RenderFragment<TItem2> ChildContent { get; set; }
+    [Parameter] public TItem1 Item1 { get; set; }
+    [Parameter] public List<TItem2> Items2 { get; set; }
+    [Parameter] public RenderFragment<TItem2> ChildContent { get; set; }
 |
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithKey_AndOtherAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithKey_AndOtherAttributes/TestComponent.codegen.cs
@@ -45,7 +45,7 @@ namespace Test
        
         private object someObject = new object();
 
-        [Parameter] protected int Min { get; set; }
+        [Parameter] public int Min { get; set; }
     
 
 #line default

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithKey_AndOtherAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithKey_AndOtherAttributes/TestComponent.ir.txt
@@ -24,7 +24,7 @@ Document -
                     SetKey - (49:0,49 [10] x:\dir\subdir\Test\TestComponent.cshtml) - someObject
                 HtmlContent - (63:0,63 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (63:0,63 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
-                HtmlContent - (187:6,5 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (187:6,5 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-            CSharpCode - (74:2,7 [112] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (74:2,7 [112] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n        private object someObject = new object();\n\n        [Parameter] protected int Min { get; set; }\n    
+                HtmlContent - (184:6,5 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (184:6,5 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (74:2,7 [109] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (74:2,7 [109] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n        private object someObject = new object();\n\n        [Parameter] public int Min { get; set; }\n    

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithKey_AndOtherAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithKey_AndOtherAttributes/TestComponent.mappings.txt
@@ -8,16 +8,16 @@ Source Location: (49:0,49 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1118:34,49 [10] )
 |someObject|
 
-Source Location: (74:2,7 [112] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (74:2,7 [109] x:\dir\subdir\Test\TestComponent.cshtml)
 |
         private object someObject = new object();
 
-        [Parameter] protected int Min { get; set; }
+        [Parameter] public int Min { get; set; }
     |
-Generated Location: (1322:44,7 [112] )
+Generated Location: (1322:44,7 [109] )
 |
         private object someObject = new object();
 
-        [Parameter] protected int Min { get; set; }
+        [Parameter] public int Min { get; set; }
     |
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.codegen.cs
@@ -46,7 +46,7 @@ namespace Test
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
        
-        [Parameter] protected int Min { get; set; }
+        [Parameter] public int Min { get; set; }
     
 
 #line default

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.ir.txt
@@ -25,7 +25,7 @@ Document -
                     ReferenceCapture - (49:0,49 [8] x:\dir\subdir\Test\TestComponent.cshtml) - _element
                 HtmlContent - (61:0,61 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (61:0,61 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
-                HtmlContent - (132:4,5 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (132:4,5 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-            CSharpCode - (72:2,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (72:2,7 [59] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n        [Parameter] protected int Min { get; set; }\n    
+                HtmlContent - (129:4,5 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (129:4,5 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (72:2,7 [56] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (72:2,7 [56] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n        [Parameter] public int Min { get; set; }\n    

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.mappings.txt
@@ -8,12 +8,12 @@ Source Location: (49:0,49 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1319:38,49 [8] )
 |_element|
 
-Source Location: (72:2,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (72:2,7 [56] x:\dir\subdir\Test\TestComponent.cshtml)
 |
-        [Parameter] protected int Min { get; set; }
+        [Parameter] public int Min { get; set; }
     |
-Generated Location: (1560:47,7 [59] )
+Generated Location: (1560:47,7 [56] )
 |
-        [Parameter] protected int Min { get; set; }
+        [Parameter] public int Min { get; set; }
     |
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.codegen.cs
@@ -55,9 +55,9 @@ using Microsoft.AspNetCore.Components;
 #nullable restore
 #line 12 "x:\dir\subdir\Test\TestComponent.cshtml"
        
-    [Parameter] TItem1 Item1 { get; set; }
-    [Parameter] List<TItem2> Items2 { get; set; }
-    [Parameter] RenderFragment<TItem2> ChildContent { get; set; }
+    [Parameter] public TItem1 Item1 { get; set; }
+    [Parameter] public List<TItem2> Items2 { get; set; }
+    [Parameter] public RenderFragment<TItem2> ChildContent { get; set; }
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.ir.txt
@@ -24,5 +24,5 @@ Document -
                     IntermediateToken - (176:9,8 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
                 CSharpCode - (178:10,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (178:10,0 [3] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - }\n
-            CSharpCode - (188:11,7 [164] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (188:11,7 [164] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    [Parameter] TItem1 Item1 { get; set; }\n    [Parameter] List<TItem2> Items2 { get; set; }\n    [Parameter] RenderFragment<TItem2> ChildContent { get; set; }\n
+            CSharpCode - (188:11,7 [185] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (188:11,7 [185] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    [Parameter] public TItem1 Item1 { get; set; }\n    [Parameter] public List<TItem2> Items2 { get; set; }\n    [Parameter] public RenderFragment<TItem2> ChildContent { get; set; }\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
@@ -14,16 +14,16 @@ Generated Location: (1407:51,0 [3] )
 |}
 |
 
-Source Location: (188:11,7 [164] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (188:11,7 [185] x:\dir\subdir\Test\TestComponent.cshtml)
 |
-    [Parameter] TItem1 Item1 { get; set; }
-    [Parameter] List<TItem2> Items2 { get; set; }
-    [Parameter] RenderFragment<TItem2> ChildContent { get; set; }
+    [Parameter] public TItem1 Item1 { get; set; }
+    [Parameter] public List<TItem2> Items2 { get; set; }
+    [Parameter] public RenderFragment<TItem2> ChildContent { get; set; }
 |
-Generated Location: (1587:60,7 [164] )
+Generated Location: (1587:60,7 [185] )
 |
-    [Parameter] TItem1 Item1 { get; set; }
-    [Parameter] List<TItem2> Items2 { get; set; }
-    [Parameter] RenderFragment<TItem2> ChildContent { get; set; }
+    [Parameter] public TItem1 Item1 { get; set; }
+    [Parameter] public List<TItem2> Items2 { get; set; }
+    [Parameter] public RenderFragment<TItem2> ChildContent { get; set; }
 |
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithKey_AndOtherAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithKey_AndOtherAttributes/TestComponent.codegen.cs
@@ -41,7 +41,7 @@ namespace Test
        
         private object someObject = new object();
 
-        [Parameter] protected int Min { get; set; }
+        [Parameter] public int Min { get; set; }
     
 
 #line default

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithKey_AndOtherAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithKey_AndOtherAttributes/TestComponent.ir.txt
@@ -15,5 +15,5 @@ Document -
                         CSharpExpressionAttributeValue - (36:0,36 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 
                             IntermediateToken - (37:0,37 [3] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Min
                     SetKey - (49:0,49 [10] x:\dir\subdir\Test\TestComponent.cshtml) - someObject
-            CSharpCode - (74:2,7 [112] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (74:2,7 [112] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n        private object someObject = new object();\n\n        [Parameter] protected int Min { get; set; }\n    
+            CSharpCode - (74:2,7 [109] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (74:2,7 [109] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n        private object someObject = new object();\n\n        [Parameter] public int Min { get; set; }\n    

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithKey_AndOtherAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithKey_AndOtherAttributes/TestComponent.mappings.txt
@@ -3,16 +3,16 @@ Source Location: (49:0,49 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (988:29,49 [10] )
 |someObject|
 
-Source Location: (74:2,7 [112] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (74:2,7 [109] x:\dir\subdir\Test\TestComponent.cshtml)
 |
         private object someObject = new object();
 
-        [Parameter] protected int Min { get; set; }
+        [Parameter] public int Min { get; set; }
     |
-Generated Location: (1229:40,7 [112] )
+Generated Location: (1229:40,7 [109] )
 |
         private object someObject = new object();
 
-        [Parameter] protected int Min { get; set; }
+        [Parameter] public int Min { get; set; }
     |
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.codegen.cs
@@ -45,7 +45,7 @@ namespace Test
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
        
-        [Parameter] protected int Min { get; set; }
+        [Parameter] public int Min { get; set; }
     
 
 #line default

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.ir.txt
@@ -16,5 +16,5 @@ Document -
                         CSharpExpressionAttributeValue - (36:0,36 [4] x:\dir\subdir\Test\TestComponent.cshtml) - 
                             IntermediateToken - (37:0,37 [3] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Min
                     ReferenceCapture - (49:0,49 [8] x:\dir\subdir\Test\TestComponent.cshtml) - _element
-            CSharpCode - (72:2,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (72:2,7 [59] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n        [Parameter] protected int Min { get; set; }\n    
+            CSharpCode - (72:2,7 [56] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (72:2,7 [56] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n        [Parameter] public int Min { get; set; }\n    

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.mappings.txt
@@ -3,12 +3,12 @@ Source Location: (49:0,49 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1255:34,49 [8] )
 |_element|
 
-Source Location: (72:2,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (72:2,7 [56] x:\dir\subdir\Test\TestComponent.cshtml)
 |
-        [Parameter] protected int Min { get; set; }
+        [Parameter] public int Min { get; set; }
     |
-Generated Location: (1520:46,7 [59] )
+Generated Location: (1520:46,7 [56] )
 |
-        [Parameter] protected int Min { get; set; }
+        [Parameter] public int Min { get; set; }
     |
 

--- a/src/Razor/test/testapps/ComponentLibrary/GenericComponent.razor
+++ b/src/Razor/test/testapps/ComponentLibrary/GenericComponent.razor
@@ -3,6 +3,6 @@
 <h1>@Title - @Item</h1>
 
 @functions {
-    [Parameter] TItem Item { get; set; }
-    [Parameter] string Title { get; set; }
+    [Parameter] public TItem Item { get; set; }
+    [Parameter] public string Title { get; set; }
 }


### PR DESCRIPTION
- Updated existing tests to use `public` accessibility for parameters. As part of this also updated baselines.
- We now recommend that `[Parameter]`'s should be `public`. In the future this will be a requirement.

aspnet/AspNetCore#8825