### PR TITLE
Do case insensitive comparison in DefaultRazorProjectFileSystem.GetItem

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectFileSystem.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectFileSystem.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var absolutePath = NormalizeAndEnsureValidPath(path);
 
             var file = new FileInfo(absolutePath);
-            if (!absolutePath.StartsWith(absoluteBasePath))
+            if (!absolutePath.StartsWith(absoluteBasePath, StringComparison.OrdinalIgnoreCase))
             {
                 throw new InvalidOperationException($"The file '{absolutePath}' is not a descendent of the base path '{absoluteBasePath}'.");
             }

--- a/src/Razor/test/RazorLanguage.Test/DefaultRazorProjectFileSystemTest.cs
+++ b/src/Razor/test/RazorLanguage.Test/DefaultRazorProjectFileSystemTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Language
@@ -255,6 +256,26 @@ namespace Microsoft.AspNetCore.Razor.Language
             Assert.Equal(filePath, item.FilePath);
             Assert.Equal("/", item.BasePath);
             Assert.Equal(Path.Combine(TestFolder, "Views", "About", "About.cshtml"), item.PhysicalPath);
+            Assert.Equal(Path.Combine("Views", "About", "About.cshtml"), item.RelativePhysicalPath);
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux, SkipReason = "This test does not makes sense for case sensitive Operating Systems.")]
+        public void GetItem_MismatchedCase_ReturnsFileFromDisk()
+        {
+            // Arrange
+            var filePath = "/Views/About/About.cshtml";
+            var lowerCaseTestFolder = TestFolder.ToLower();
+            var fileSystem = new DefaultRazorProjectFileSystem(lowerCaseTestFolder);
+
+            // Act
+            var item = fileSystem.GetItem(filePath, fileKind: null);
+
+            // Assert
+            Assert.True(item.Exists);
+            Assert.Equal(filePath, item.FilePath);
+            Assert.Equal("/", item.BasePath);
+            Assert.Equal(Path.Combine(lowerCaseTestFolder, "Views", "About", "About.cshtml"), item.PhysicalPath);
             Assert.Equal(Path.Combine("Views", "About", "About.cshtml"), item.RelativePhysicalPath);
         }
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/11486

We were doing a case sensitive matching here while we do case insensitive matching in other places in this file. I believe this was just an oversight that was missed. I'm still digging into why this bug never came up until now. But I think this is the right fix.