### PR TITLE
Fix a bug with ref and declaration phase

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Extensions/EliminateMethodBodyPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Extensions/EliminateMethodBodyPass.cs
@@ -8,8 +8,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
     internal sealed class EliminateMethodBodyPass : IntermediateNodePassBase, IRazorOptimizationPass
     {
-        // Run early in the optimization phase
-        public override int Order => int.MinValue;
+        // Run late in the optimization phase
+        public override int Order => int.MaxValue;
 
         protected override void ExecuteCore(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)
         {

--- a/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentDeclarationIntegrationTest.cs
+++ b/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentDeclarationIntegrationTest.cs
@@ -71,6 +71,21 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
         }
 
         [Fact]
+        public void DeclarationConfiguration_IncludesRef()
+        {
+            // Arrange & Act
+            var component = CompileToComponent(@"
+@using System.Text
+<div @ref=""myDiv"" />
+");
+
+            // Assert
+            var field = component.GetType().GetField("myDiv", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field);
+            Assert.Same(typeof(ElementRef), field.FieldType);
+        }
+
+        [Fact]
         public void DeclarationConfiguration_IncludesInherits()
         {
             // Arrange & Act


### PR DESCRIPTION
This fixes a regression in the new `@ref` support, where the build will
fail during the declaration pass.

The problem is that the EliminateMethodBodyPass runs really early and
wipes out the usage of `@ref` before we have a chance to see it. The
solution is to make it run really late. This makes sense because we
basically just use this pass to do cleanup.
