### PR TITLE
Unconditionally enable content in RCLs

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
@@ -80,12 +80,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <None Remove="**\*.razor" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <EnableRazorSdkContent Condition="'$(EnableRazorSdkContent)' =='' and '$(UsingMicrosoftNETSdkWeb)' == '' ">true</EnableRazorSdkContent>
-  </PropertyGroup>
-
-  <Import 
-    Project="$(MSBuildThisFileDirectory)..\..\Sdk\Sdk.Razor.StaticAssets.ProjectSystem.props"
-    Condition=" '$(EnableRazorSdkContent)' == 'true' " />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Sdk\Sdk.Razor.StaticAssets.ProjectSystem.props" />
 
 </Project>


### PR DESCRIPTION
This is the last cleanup from the SDK content definition move we did for static web assets from the web sdk into the razor sdk, we couldn't do it earlier because of sourcebuild (we did not have a new enough version of the web SDK here)