### PR TITLE
Explicitly reference Roslyn compiler toolset version that will ship in preview 7

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,4 +7,12 @@
   <PropertyGroup>
     <BundledNETCorePlatformsPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Track compiler separately from Arcade.-->
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset"
+        Version="$(MicrosoftNetCompilersToolsetVersion)"
+        PrivateAssets="all"
+        IsImplicitlyDefined="true" />
+  </ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,7 +11,7 @@
   <ItemGroup>
     <!-- Track compiler separately from Arcade.-->
     <PackageReference Include="Microsoft.Net.Compilers.Toolset"
-        Version="$(MicrosoftNetCompilersToolsetVersion)"
+        Version="$(MicrosoftNetCompilersToolsetPackageVersion)"
         PrivateAssets="all"
         IsImplicitlyDefined="true" />
   </ItemGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -37,7 +37,7 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>df2b1489de5d4b8211c5e132d299a83523ce742a</Sha>
     </Dependency>
-    <!-- 
+    <!--
       Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
       All Runtime.$rid packages should have the same version.
     -->
@@ -63,6 +63,10 @@
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19330.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>89fab80685c91024c8f9e21f1c37f62580f648f8</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.3.0-beta1-19351-01">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>c91adff42c488aef2c2c532a7b053fb55e0c16ea</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -41,7 +41,7 @@
       https://vside.myget.org/F/vsmac/api/v3/index.json;
       https://vside.myget.org/F/devcore/api/v3/index.json;
     </RestoreSources>
-    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true' AND $(MicrosoftNetCompilersToolsetVersion.Contains('-')) ">
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true' AND $(MicrosoftNetCompilersToolsetPackageVersion.Contains('-')) ">
       $(RestoreSources);
       https://dotnet.myget.org/F/roslyn/api/v3/index.json;
     </RestoreSources>
@@ -71,7 +71,7 @@
     <SystemTextEncodingsWebPackageVersion>4.6.0-preview7.19329.3</SystemTextEncodingsWebPackageVersion>
     <SystemReflectionMetadataPackageVersion>1.7.0-preview7.19329.3</SystemReflectionMetadataPackageVersion>
     <!-- Packages from dotnet/roslyn -->
-    <MicrosoftNetCompilersToolsetVersion>3.3.0-beta1-19351-01</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>3.3.0-beta1-19351-01</MicrosoftNetCompilersToolsetPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependency version settings">
     <!--

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,8 +6,6 @@
     <!-- Use .NET Framework reference assemblies from a nuget package so machine-global targeting packs do not need to be installed. -->
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
-    <!-- Opt-in to using the version of the Roslyn compiler bundled with Arcade. -->
-    <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
   </PropertyGroup>
   <!-- Opt out Arcade features -->
   <PropertyGroup>
@@ -43,6 +41,10 @@
       https://vside.myget.org/F/vsmac/api/v3/index.json;
       https://vside.myget.org/F/devcore/api/v3/index.json;
     </RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true' AND $(MicrosoftNetCompilersToolsetVersion.Contains('-')) ">
+      $(RestoreSources);
+      https://dotnet.myget.org/F/roslyn/api/v3/index.json;
+    </RestoreSources>
   </PropertyGroup>
   <!--
 
@@ -68,6 +70,8 @@
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.6.0-preview7.19329.3</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemTextEncodingsWebPackageVersion>4.6.0-preview7.19329.3</SystemTextEncodingsWebPackageVersion>
     <SystemReflectionMetadataPackageVersion>1.7.0-preview7.19329.3</SystemReflectionMetadataPackageVersion>
+    <!-- Packages from dotnet/roslyn -->
+    <MicrosoftNetCompilersToolsetVersion>3.3.0-beta1-19351-01</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependency version settings">
     <!--


### PR DESCRIPTION
- see also aspnet/EntityFrameworkCore#16370 and aspnet/EntityFrameworkCore#16385 discussions
- grab latest from the '.NET Core 3 Release' channel