### PR TITLE
Update NuGet.config feed list

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,5 +4,11 @@
     <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="aspnet-extensions" value="https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json" />
+    <add key="myget-roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
+    <add key="myget-roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
+    <add key="myget-vssdk" value="https://vside.myget.org/F/vssdk/api/v3/index.json" />
+    <add key="myget-vsmac" value="https://vside.myget.org/F/vsmac/api/v3/index.json" />
+    <add key="myget-devcore" value="https://vside.myget.org/F/devcore/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
We need all restore sources to be located in NuGet.config since internal feeds can only be restored from there. More details including next steps [here](https://github.com/dotnet/arcade/blob/master/Documentation/RestoreSourcesUpdateStatus.md)

/cc @riarenas @jcagme