### PR TITLE
Reactions to API review changes + Globalisation support

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentsApi.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentsApi.cs
@@ -99,7 +99,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static class RuntimeHelpers
         {
-            public static readonly string TypeCheck = "Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck";
+            public static readonly string TypeCheck = "Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck";
+            public static readonly string CreateInferredEventCallback = "Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback";
         }
 
         public static class RouteAttribute
@@ -115,17 +116,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         public static class BindInputElementAttribute
         {
             public static readonly string FullTypeName = "Microsoft.AspNetCore.Components.BindInputElementAttribute";
-        }
-
-        public static class BindMethods
-        {
-            public static readonly string FullTypeName = "Microsoft.AspNetCore.Components.BindMethods";
-
-            public static readonly string GetValue = "Microsoft.AspNetCore.Components.BindMethods.GetValue";
-
-            public static readonly string GetEventHandlerValue = "Microsoft.AspNetCore.Components.BindMethods.GetEventHandlerValue";
-
-            public static readonly string SetValueHandler = "Microsoft.AspNetCore.Components.BindMethods.SetValueHandler";
         }
 
         public static class EventHandlerAttribute
@@ -154,8 +144,13 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         public static class EventCallbackFactory
         {
             public static readonly string CreateMethod = "Create";
-            public static readonly string CreateInferredMethod = "CreateInferred";
             public static readonly string CreateBinderMethod = "CreateBinder";
+        }
+
+        public static class BindConverter
+        {
+            public static readonly string FullTypeName = "Microsoft.AspNetCore.Components.BindConverter";
+            public static readonly string FormatValue = "Microsoft.AspNetCore.Components.BindConverter.FormatValue";
         }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/BindTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/BindTagHelperDescriptorProvider.cs
@@ -93,10 +93,10 @@ namespace Microsoft.CodeAnalysis.Razor
                 return;
             }
 
-            var bindMethods = compilation.GetTypeByMetadataName(ComponentsApi.BindMethods.FullTypeName);
+            var bindMethods = compilation.GetTypeByMetadataName(ComponentsApi.BindConverter.FullTypeName);
             if (bindMethods == null)
             {
-                // If we can't find BindMethods, then just bail. We won't be able to compile the
+                // If we can't find BindConverter, then just bail. We won't be able to compile the
                 // generated code anyway.
                 return;
             }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/EventHandlerTagHelperDescriptorProvider.cs
@@ -27,10 +27,10 @@ namespace Microsoft.CodeAnalysis.Razor
                 return;
             }
 
-            var bindMethods = compilation.GetTypeByMetadataName(ComponentsApi.BindMethods.FullTypeName);
+            var bindMethods = compilation.GetTypeByMetadataName(ComponentsApi.IComponent.FullTypeName);
             if (bindMethods == null)
             {
-                // If we can't find BindMethods, then just bail. We won't be able to compile the
+                // If we can't find ICOmponent, then just bail. We won't be able to compile the
                 // generated code anyway.
                 return;
             }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/EventHandlerTagHelperDescriptorProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Razor
             var bindMethods = compilation.GetTypeByMetadataName(ComponentsApi.IComponent.FullTypeName);
             if (bindMethods == null)
             {
-                // If we can't find ICOmponent, then just bail. We won't be able to compile the
+                // If we can't find IComponent, then just bail. We won't be able to compile the
                 // generated code anyway.
                 return;
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Globalization;
-
 namespace Microsoft.AspNetCore.Components
 {
     public partial class AuthenticationState
@@ -27,6 +25,53 @@ namespace Microsoft.AspNetCore.Components
     public static partial class BindAttributes
     {
     }
+    public static partial class BindConverter
+    {
+        public static bool FormatValue(bool value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(System.DateTime value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(System.DateTime value, string format, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(System.DateTimeOffset value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(System.DateTimeOffset value, string format, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(decimal value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(double value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(int value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(long value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static bool? FormatValue(bool? value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(System.DateTimeOffset? value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(System.DateTimeOffset? value, string format, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(System.DateTime? value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(System.DateTime? value, string format, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(decimal? value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(double? value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(int? value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(long? value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(float? value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(float value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(string value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static object FormatValue<T>(T value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static bool TryConvertToBool(object obj, System.Globalization.CultureInfo culture, out bool value) { throw null; }
+        public static bool TryConvertToDateTime(object obj, System.Globalization.CultureInfo culture, out System.DateTime value) { throw null; }
+        public static bool TryConvertToDateTime(object obj, System.Globalization.CultureInfo culture, string format, out System.DateTime value) { throw null; }
+        public static bool TryConvertToDateTimeOffset(object obj, System.Globalization.CultureInfo culture, out System.DateTimeOffset value) { throw null; }
+        public static bool TryConvertToDateTimeOffset(object obj, System.Globalization.CultureInfo culture, string format, out System.DateTimeOffset value) { throw null; }
+        public static bool TryConvertToDecimal(object obj, System.Globalization.CultureInfo culture, out decimal value) { throw null; }
+        public static bool TryConvertToDouble(object obj, System.Globalization.CultureInfo culture, out double value) { throw null; }
+        public static bool TryConvertToFloat(object obj, System.Globalization.CultureInfo culture, out float value) { throw null; }
+        public static bool TryConvertToInt(object obj, System.Globalization.CultureInfo culture, out int value) { throw null; }
+        public static bool TryConvertToLong(object obj, System.Globalization.CultureInfo culture, out long value) { throw null; }
+        public static bool TryConvertToNullableBool(object obj, System.Globalization.CultureInfo culture, out bool? value) { throw null; }
+        public static bool TryConvertToNullableDateTime(object obj, System.Globalization.CultureInfo culture, out System.DateTime? value) { throw null; }
+        public static bool TryConvertToNullableDateTime(object obj, System.Globalization.CultureInfo culture, string format, out System.DateTime? value) { throw null; }
+        public static bool TryConvertToNullableDateTimeOffset(object obj, System.Globalization.CultureInfo culture, out System.DateTimeOffset? value) { throw null; }
+        public static bool TryConvertToNullableDateTimeOffset(object obj, System.Globalization.CultureInfo culture, string format, out System.DateTimeOffset? value) { throw null; }
+        public static bool TryConvertToNullableDecimal(object obj, System.Globalization.CultureInfo culture, out decimal? value) { throw null; }
+        public static bool TryConvertToNullableDouble(object obj, System.Globalization.CultureInfo culture, out double? value) { throw null; }
+        public static bool TryConvertToNullableFloat(object obj, System.Globalization.CultureInfo culture, out float? value) { throw null; }
+        public static bool TryConvertToNullableInt(object obj, System.Globalization.CultureInfo culture, out int? value) { throw null; }
+        public static bool TryConvertToNullableLong(object obj, System.Globalization.CultureInfo culture, out long? value) { throw null; }
+        public static bool TryConvertToString(object obj, System.Globalization.CultureInfo culture, out string value) { throw null; }
+        public static bool TryConvertTo<T>(object obj, System.Globalization.CultureInfo culture, out T value) { throw null; }
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
     public sealed partial class BindElementAttribute : System.Attribute
     {
@@ -48,35 +93,7 @@ namespace Microsoft.AspNetCore.Components
         public bool IsInvariantCulture { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string Format { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
-    public static partial class BindMethods
-    {
-        public static Microsoft.AspNetCore.Components.EventCallback GetEventHandlerValue<T>(Microsoft.AspNetCore.Components.EventCallback value) where T : Microsoft.AspNetCore.Components.UIEventArgs { throw null; }
-        public static Microsoft.AspNetCore.Components.EventCallback<T> GetEventHandlerValue<T>(Microsoft.AspNetCore.Components.EventCallback<T> value) where T : Microsoft.AspNetCore.Components.UIEventArgs { throw null; }
-        public static System.MulticastDelegate GetEventHandlerValue<T>(System.Action value) where T : Microsoft.AspNetCore.Components.UIEventArgs { throw null; }
-        public static System.MulticastDelegate GetEventHandlerValue<T>(System.Action<T> value) where T : Microsoft.AspNetCore.Components.UIEventArgs { throw null; }
-        public static System.MulticastDelegate GetEventHandlerValue<T>(System.Func<System.Threading.Tasks.Task> value) where T : Microsoft.AspNetCore.Components.UIEventArgs { throw null; }
-        public static System.MulticastDelegate GetEventHandlerValue<T>(System.Func<T, System.Threading.Tasks.Task> value) where T : Microsoft.AspNetCore.Components.UIEventArgs { throw null; }
-        public static string GetEventHandlerValue<T>(string value) where T : Microsoft.AspNetCore.Components.UIEventArgs { throw null; }
-        public static string GetValue(System.DateTime value, string format, System.Globalization.CultureInfo culture = null) { throw null; }
-        public static T GetValue<T>(T value, System.Globalization.CultureInfo culture = null) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<bool> setter, bool existingValue) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<System.DateTime> setter, System.DateTime existingValue) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<System.DateTime> setter, System.DateTime existingValue, string format) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<decimal> setter, decimal existingValue) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<double> setter, double existingValue) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<int> setter, int existingValue) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<long> setter, long existingValue) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<bool?> setter, bool? existingValue) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<decimal?> setter, decimal? existingValue) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<double?> setter, double? existingValue) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<int?> setter, int? existingValue) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<long?> setter, long? existingValue) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<float?> setter, float? existingValue) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<float> setter, float existingValue) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<string> setter, string existingValue) { throw null; }
-        public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler<T>(System.Action<T> setter, T existingValue) { throw null; }
-    }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false, Inherited=false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
     public sealed partial class CascadingParameterAttribute : System.Attribute
     {
         public CascadingParameterAttribute() { }
@@ -86,15 +103,15 @@ namespace Microsoft.AspNetCore.Components
     {
         public ComponentBase() { }
         protected virtual void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
-        protected System.Threading.Tasks.Task Invoke(System.Action workItem) { throw null; }
+        protected System.Threading.Tasks.Task InvokeAsync(System.Action workItem) { throw null; }
         protected System.Threading.Tasks.Task InvokeAsync(System.Func<System.Threading.Tasks.Task> workItem) { throw null; }
         void Microsoft.AspNetCore.Components.IComponent.Configure(Microsoft.AspNetCore.Components.RenderHandle renderHandle) { }
         System.Threading.Tasks.Task Microsoft.AspNetCore.Components.IHandleAfterRender.OnAfterRenderAsync() { throw null; }
         System.Threading.Tasks.Task Microsoft.AspNetCore.Components.IHandleEvent.HandleEventAsync(Microsoft.AspNetCore.Components.EventCallbackWorkItem callback, object arg) { throw null; }
         protected virtual void OnAfterRender() { }
         protected virtual System.Threading.Tasks.Task OnAfterRenderAsync() { throw null; }
-        protected virtual void OnInit() { }
-        protected virtual System.Threading.Tasks.Task OnInitAsync() { throw null; }
+        protected virtual void OnInitialized() { }
+        protected virtual System.Threading.Tasks.Task OnInitializedAsync() { throw null; }
         protected virtual void OnParametersSet() { }
         protected virtual System.Threading.Tasks.Task OnParametersSetAsync() { throw null; }
         public virtual System.Threading.Tasks.Task SetParametersAsync(Microsoft.AspNetCore.Components.ParameterCollection parameters) { throw null; }
@@ -109,6 +126,17 @@ namespace Microsoft.AspNetCore.Components
         public string[] Files { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Components.UIDataTransferItem[] Items { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string[] Types { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
+    public abstract partial class Dispatcher
+    {
+        protected Dispatcher() { }
+        public abstract bool CheckAccess();
+        public static Microsoft.AspNetCore.Components.Dispatcher CreateDefault() { throw null; }
+        public abstract System.Threading.Tasks.Task InvokeAsync(System.Action workItem);
+        public abstract System.Threading.Tasks.Task InvokeAsync(System.Func<System.Threading.Tasks.Task> workItem);
+        public abstract System.Threading.Tasks.Task<TResult> InvokeAsync<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> workItem);
+        public abstract System.Threading.Tasks.Task<TResult> InvokeAsync<TResult>(System.Func<TResult> workItem);
+        protected void OnUnhandledException(System.UnhandledExceptionEventArgs e) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ElementRef
@@ -148,20 +176,23 @@ namespace Microsoft.AspNetCore.Components
         public Microsoft.AspNetCore.Components.EventCallback<T> Create<T>(object receiver, System.Action<T> callback) { throw null; }
         public Microsoft.AspNetCore.Components.EventCallback<T> Create<T>(object receiver, System.Func<System.Threading.Tasks.Task> callback) { throw null; }
         public Microsoft.AspNetCore.Components.EventCallback<T> Create<T>(object receiver, System.Func<T, System.Threading.Tasks.Task> callback) { throw null; }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public string Create<T>(object receiver, string callback) { throw null; }
     }
     public static partial class EventCallbackFactoryBinderExtensions
     {
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<bool> setter, bool existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<System.DateTimeOffset> setter, System.DateTimeOffset existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<System.DateTimeOffset> setter, System.DateTimeOffset existingValue, string format, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<System.DateTime> setter, System.DateTime existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
-        public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<System.DateTime> setter, System.DateTime existingValue, string format = null, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<System.DateTime> setter, System.DateTime existingValue, string format, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<decimal> setter, decimal existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<double> setter, double existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<int> setter, int existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<long> setter, long existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<bool?> setter, bool? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<System.DateTimeOffset?> setter, System.DateTimeOffset? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<System.DateTimeOffset?> setter, System.DateTimeOffset? existingValue, string format, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<System.DateTime?> setter, System.DateTime? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<System.DateTime?> setter, System.DateTime? existingValue, string format, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<decimal?> setter, decimal? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<double?> setter, double? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<int?> setter, int? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
@@ -199,9 +230,9 @@ namespace Microsoft.AspNetCore.Components
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIWheelEventArgs> Create(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Func<Microsoft.AspNetCore.Components.UIWheelEventArgs, System.Threading.Tasks.Task> callback) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct EventCallbackWorkItem
+    public readonly partial struct EventCallbackWorkItem
     {
-        private object _dummy;
+        private readonly object _dummy;
         public static readonly Microsoft.AspNetCore.Components.EventCallbackWorkItem Empty;
         public EventCallbackWorkItem(System.MulticastDelegate @delegate) { throw null; }
         public System.Threading.Tasks.Task InvokeAsync(object arg) { throw null; }
@@ -210,6 +241,7 @@ namespace Microsoft.AspNetCore.Components
     public readonly partial struct EventCallback<T>
     {
         private readonly object _dummy;
+        public static readonly Microsoft.AspNetCore.Components.EventCallback<T> Empty;
         public EventCallback(Microsoft.AspNetCore.Components.IHandleEvent receiver, System.MulticastDelegate @delegate) { throw null; }
         public bool HasDelegate { get { throw null; } }
         public System.Threading.Tasks.Task InvokeAsync(T arg) { throw null; }
@@ -332,8 +364,8 @@ namespace Microsoft.AspNetCore.Components
     {
         System.Threading.Tasks.Task HandleEventAsync(Microsoft.AspNetCore.Components.EventCallbackWorkItem item, object arg);
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false)]
-    public partial class InjectAttribute : System.Attribute
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
+    public sealed partial class InjectAttribute : System.Attribute
     {
         public InjectAttribute() { }
     }
@@ -346,6 +378,18 @@ namespace Microsoft.AspNetCore.Components
         void NavigateTo(string uri, bool forceLoad);
         System.Uri ToAbsoluteUri(string href);
         string ToBaseRelativePath(string baseUri, string locationAbsolute);
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
+    public sealed partial class LayoutAttribute : System.Attribute
+    {
+        public LayoutAttribute(System.Type layoutType) { }
+        public System.Type LayoutType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+    }
+    public abstract partial class LayoutComponentBase : Microsoft.AspNetCore.Components.ComponentBase
+    {
+        protected LayoutComponentBase() { }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        protected Microsoft.AspNetCore.Components.RenderFragment Body { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MarkupString
@@ -370,7 +414,7 @@ namespace Microsoft.AspNetCore.Components
         public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public object Value { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false, Inherited=false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
     public sealed partial class ParameterAttribute : System.Attribute
     {
         public ParameterAttribute() { }
@@ -408,20 +452,15 @@ namespace Microsoft.AspNetCore.Components
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
+        public Microsoft.AspNetCore.Components.Dispatcher Dispatcher { get { throw null; } }
         public bool IsInitialized { get { throw null; } }
-        public System.Threading.Tasks.Task Invoke(System.Action workItem) { throw null; }
-        public System.Threading.Tasks.Task InvokeAsync(System.Func<System.Threading.Tasks.Task> workItem) { throw null; }
         public void Render(Microsoft.AspNetCore.Components.RenderFragment renderFragment) { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
-    public partial class RouteAttribute : System.Attribute
+    public sealed partial class RouteAttribute : System.Attribute
     {
         public RouteAttribute(string template) { }
         public string Template { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-    }
-    public static partial class RuntimeHelpers
-    {
-        public static T TypeCheck<T>(T value) { throw null; }
     }
     public partial class UIChangeEventArgs : Microsoft.AspNetCore.Components.UIEventArgs
     {
@@ -456,31 +495,6 @@ namespace Microsoft.AspNetCore.Components
         public static readonly Microsoft.AspNetCore.Components.UIEventArgs Empty;
         public UIEventArgs() { }
         public string Type { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-    }
-    public static partial class UIEventArgsRenderTreeBuilderExtensions
-    {
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Action<Microsoft.AspNetCore.Components.UIChangeEventArgs> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Action<Microsoft.AspNetCore.Components.UIClipboardEventArgs> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Action<Microsoft.AspNetCore.Components.UIDragEventArgs> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Action<Microsoft.AspNetCore.Components.UIErrorEventArgs> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Action<Microsoft.AspNetCore.Components.UIFocusEventArgs> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Action<Microsoft.AspNetCore.Components.UIKeyboardEventArgs> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Action<Microsoft.AspNetCore.Components.UIMouseEventArgs> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Action<Microsoft.AspNetCore.Components.UIPointerEventArgs> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Action<Microsoft.AspNetCore.Components.UIProgressEventArgs> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Action<Microsoft.AspNetCore.Components.UITouchEventArgs> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Action<Microsoft.AspNetCore.Components.UIWheelEventArgs> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Func<Microsoft.AspNetCore.Components.UIChangeEventArgs, System.Threading.Tasks.Task> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Func<Microsoft.AspNetCore.Components.UIClipboardEventArgs, System.Threading.Tasks.Task> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Func<Microsoft.AspNetCore.Components.UIDragEventArgs, System.Threading.Tasks.Task> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Func<Microsoft.AspNetCore.Components.UIErrorEventArgs, System.Threading.Tasks.Task> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Func<Microsoft.AspNetCore.Components.UIFocusEventArgs, System.Threading.Tasks.Task> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Func<Microsoft.AspNetCore.Components.UIKeyboardEventArgs, System.Threading.Tasks.Task> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Func<Microsoft.AspNetCore.Components.UIMouseEventArgs, System.Threading.Tasks.Task> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Func<Microsoft.AspNetCore.Components.UIPointerEventArgs, System.Threading.Tasks.Task> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Func<Microsoft.AspNetCore.Components.UIProgressEventArgs, System.Threading.Tasks.Task> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Func<Microsoft.AspNetCore.Components.UITouchEventArgs, System.Threading.Tasks.Task> value) { }
-        public static void AddAttribute(this Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, int sequence, string name, System.Func<Microsoft.AspNetCore.Components.UIWheelEventArgs, System.Threading.Tasks.Task> value) { }
     }
     public partial class UIFocusEventArgs : Microsoft.AspNetCore.Components.UIEventArgs
     {
@@ -581,6 +595,15 @@ namespace Microsoft.AspNetCore.Components
         protected void TriggerOnLocationChanged(bool isinterceptedLink) { }
     }
 }
+namespace Microsoft.AspNetCore.Components.CompilerServices
+{
+    public static partial class RuntimeHelpers
+    {
+        public static Microsoft.AspNetCore.Components.EventCallback<T> CreateInferredEventCallback<T>(object receiver, System.Action<T> callback, T value) { throw null; }
+        public static Microsoft.AspNetCore.Components.EventCallback<T> CreateInferredEventCallback<T>(object receiver, System.Func<T, System.Threading.Tasks.Task> callback, T value) { throw null; }
+        public static T TypeCheck<T>(T value) { throw null; }
+    }
+}
 namespace Microsoft.AspNetCore.Components.Forms
 {
     public sealed partial class EditContext
@@ -656,85 +679,20 @@ namespace Microsoft.AspNetCore.Components.Forms
         internal ValidationStateChangedEventArgs() { }
     }
 }
-namespace Microsoft.AspNetCore.Components
-{
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
-    public partial class LayoutAttribute : System.Attribute
-    {
-        public LayoutAttribute(System.Type layoutType) { }
-        public System.Type LayoutType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-    }
-    public abstract partial class LayoutComponentBase : Microsoft.AspNetCore.Components.ComponentBase
-    {
-        protected LayoutComponentBase() { }
-        [Microsoft.AspNetCore.Components.ParameterAttribute]
-        protected Microsoft.AspNetCore.Components.RenderFragment Body { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-    }
-}
-namespace Microsoft.AspNetCore.Components.Rendering
+namespace Microsoft.AspNetCore.Components.RenderTree
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct ComponentRenderedText
+    public readonly partial struct ArrayBuilderSegment<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public int ComponentId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public System.Collections.Generic.IEnumerable<string> Tokens { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public T[] Array { get { throw null; } }
+        public int Count { get { throw null; } }
+        public T this[int index] { get { throw null; } }
+        public int Offset { get { throw null; } }
+        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
     }
-    public partial class EventFieldInfo
-    {
-        public EventFieldInfo() { }
-        public int ComponentId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public object FieldValue { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-    }
-    public partial class HtmlRenderer : Microsoft.AspNetCore.Components.Rendering.Renderer
-    {
-        public HtmlRenderer(System.IServiceProvider serviceProvider, System.Func<string, string> htmlEncoder, Microsoft.AspNetCore.Components.Rendering.IDispatcher dispatcher) : base (default(System.IServiceProvider)) { }
-        protected override void HandleException(System.Exception exception) { }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
-        public System.Threading.Tasks.Task<Microsoft.AspNetCore.Components.Rendering.ComponentRenderedText> RenderComponentAsync(System.Type componentType, Microsoft.AspNetCore.Components.ParameterCollection initialParameters) { throw null; }
-        public System.Threading.Tasks.Task<Microsoft.AspNetCore.Components.Rendering.ComponentRenderedText> RenderComponentAsync<TComponent>(Microsoft.AspNetCore.Components.ParameterCollection initialParameters) where TComponent : Microsoft.AspNetCore.Components.IComponent { throw null; }
-        protected override System.Threading.Tasks.Task UpdateDisplayAsync(in Microsoft.AspNetCore.Components.Rendering.RenderBatch renderBatch) { throw null; }
-    }
-    public partial interface IDispatcher
-    {
-        System.Threading.Tasks.Task Invoke(System.Action action);
-        System.Threading.Tasks.Task InvokeAsync(System.Func<System.Threading.Tasks.Task> asyncAction);
-        System.Threading.Tasks.Task<TResult> InvokeAsync<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> asyncFunction);
-        System.Threading.Tasks.Task<TResult> Invoke<TResult>(System.Func<TResult> function);
-    }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct RenderBatch
-    {
-        private readonly object _dummy;
-        public Microsoft.AspNetCore.Components.RenderTree.ArrayRange<int> DisposedComponentIDs { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public Microsoft.AspNetCore.Components.RenderTree.ArrayRange<int> DisposedEventHandlerIDs { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public Microsoft.AspNetCore.Components.RenderTree.ArrayRange<Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame> ReferenceFrames { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public Microsoft.AspNetCore.Components.RenderTree.ArrayRange<Microsoft.AspNetCore.Components.RenderTree.RenderTreeDiff> UpdatedComponents { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-    }
-    public abstract partial class Renderer : System.IDisposable
-    {
-        public Renderer(System.IServiceProvider serviceProvider) { }
-        public Renderer(System.IServiceProvider serviceProvider, Microsoft.AspNetCore.Components.Rendering.IDispatcher dispatcher) { }
-        public event System.UnhandledExceptionEventHandler UnhandledSynchronizationException { add { } remove { } }
-        protected internal virtual void AddToRenderQueue(int componentId, Microsoft.AspNetCore.Components.RenderFragment renderFragment) { }
-        protected internal int AssignRootComponentId(Microsoft.AspNetCore.Components.IComponent component) { throw null; }
-        public static Microsoft.AspNetCore.Components.Rendering.IDispatcher CreateDefaultDispatcher() { throw null; }
-        public virtual System.Threading.Tasks.Task DispatchEventAsync(int eventHandlerId, Microsoft.AspNetCore.Components.Rendering.EventFieldInfo fieldInfo, Microsoft.AspNetCore.Components.UIEventArgs eventArgs) { throw null; }
-        public void Dispose() { }
-        protected virtual void Dispose(bool disposing) { }
-        protected abstract void HandleException(System.Exception exception);
-        protected Microsoft.AspNetCore.Components.IComponent InstantiateComponent(System.Type componentType) { throw null; }
-        public virtual System.Threading.Tasks.Task Invoke(System.Action workItem) { throw null; }
-        public virtual System.Threading.Tasks.Task InvokeAsync(System.Func<System.Threading.Tasks.Task> workItem) { throw null; }
-        protected System.Threading.Tasks.Task RenderRootComponentAsync(int componentId) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
-        protected System.Threading.Tasks.Task RenderRootComponentAsync(int componentId, Microsoft.AspNetCore.Components.ParameterCollection initialParameters) { throw null; }
-        protected abstract System.Threading.Tasks.Task UpdateDisplayAsync(in Microsoft.AspNetCore.Components.Rendering.RenderBatch renderBatch);
-    }
-}
-namespace Microsoft.AspNetCore.Components.RenderTree
-{
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ArrayRange<T>
     {
@@ -746,13 +704,10 @@ namespace Microsoft.AspNetCore.Components.RenderTree
     public partial class RenderTreeBuilder
     {
         public const string ChildContent = "ChildContent";
-        public RenderTreeBuilder(Microsoft.AspNetCore.Components.Rendering.Renderer renderer) { }
         public void AddAttribute(int sequence, in Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame frame) { }
         public void AddAttribute(int sequence, string name, Microsoft.AspNetCore.Components.EventCallback value) { }
         public void AddAttribute(int sequence, string name, System.Action value) { }
-        public void AddAttribute(int sequence, string name, System.Action<Microsoft.AspNetCore.Components.UIEventArgs> value) { }
         public void AddAttribute(int sequence, string name, bool value) { }
-        public void AddAttribute(int sequence, string name, System.Func<Microsoft.AspNetCore.Components.UIEventArgs, System.Threading.Tasks.Task> value) { }
         public void AddAttribute(int sequence, string name, System.Func<System.Threading.Tasks.Task> value) { }
         public void AddAttribute(int sequence, string name, System.MulticastDelegate value) { }
         public void AddAttribute(int sequence, string name, object value) { }
@@ -781,7 +736,7 @@ namespace Microsoft.AspNetCore.Components.RenderTree
     public readonly partial struct RenderTreeDiff
     {
         public readonly int ComponentId;
-        public readonly System.ArraySegment<Microsoft.AspNetCore.Components.RenderTree.RenderTreeEdit> Edits;
+        public readonly Microsoft.AspNetCore.Components.RenderTree.ArrayBuilderSegment<Microsoft.AspNetCore.Components.RenderTree.RenderTreeEdit> Edits;
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Explicit)]
     public readonly partial struct RenderTreeEdit

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -28,10 +28,10 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.Int32>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.Int32>(this, 
-            Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue)));
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Func<System.Int32>>>(() => ParentValue);
+            );
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.Int32>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.Int32>(this, 
+            Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)));
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Func<System.Int32>>>(() => ParentValue);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.ir.txt
@@ -17,12 +17,10 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue)
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueExpression - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - () => ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1013:25,26 [11] )
+Generated Location: (977:25,26 [11] )
 |ParentValue|
 
 Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (2034:48,7 [50] )
+Generated Location: (2054:48,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                               ParentValue
@@ -28,8 +28,8 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ), -1, Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
-            Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue)), -1, () => ParentValue);
+            , -1, Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
+            Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)), -1, () => ParentValue);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 __o = typeof(MyComponent<>);

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
@@ -17,12 +17,10 @@ Document -
                 Component - (0:0,0 [45] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - SomeParam - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - SomeParamChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue)
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - SomeParamExpression - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - () => ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1019:25,30 [11] )
+Generated Location: (966:25,30 [11] )
 |ParentValue|
 
 Source Location: (54:1,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |
-Generated Location: (1607:43,7 [65] )
+Generated Location: (1576:43,7 [65] )
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -28,9 +28,9 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.Int32>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.Int32>(this, 
-            Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue)));
+            );
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.Int32>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.Int32>(this, 
+            Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)));
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
@@ -17,12 +17,10 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue)
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)
                 HtmlContent - (41:0,41 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (41:0,41 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
             CSharpCode - (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1013:25,26 [11] )
+Generated Location: (977:25,26 [11] )
 |ParentValue|
 
 Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1875:47,7 [50] )
+Generated Location: (1878:47,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -28,9 +28,9 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.Int32>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.Int32>(this, 
-            Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue)));
+            );
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.Int32>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.Int32>(this, 
+            Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)));
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
@@ -17,12 +17,10 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue)
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)
                 HtmlContent - (41:0,41 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (41:0,41 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
             CSharpCode - (50:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1013:25,26 [11] )
+Generated Location: (977:25,26 [11] )
 |ParentValue|
 
 Source Location: (50:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "42";
 |
-Generated Location: (1875:47,7 [55] )
+Generated Location: (1878:47,7 [55] )
 |
     public string ParentValue { get; set; } = "42";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -28,7 +28,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
+            );
             __o = new System.Action<System.Int32>(
             __value => ParentValue = __value);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
@@ -17,9 +17,7 @@ Document -
                 Component - (0:0,0 [71] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - OnChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => ParentValue = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1013:25,26 [11] )
+Generated Location: (977:25,26 [11] )
 |ParentValue|
 
 Source Location: (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1618:47,7 [50] )
+Generated Location: (1581:47,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
@@ -17,7 +17,7 @@ Document -
                 Component - (0:0,0 [71] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - OnChanged - AttributeStructure.DoubleQuotes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (942:25,26 [11] )
+Generated Location: (947:25,26 [11] )
 |ParentValue|
 
 Source Location: (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1586:46,7 [50] )
+Generated Location: (1591:46,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -28,10 +28,10 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
+            );
             __o = new System.Action<System.Int32>(
             __value => ParentValue = __value);
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Func<System.Int32>>>(() => ParentValue);
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Func<System.Int32>>>(() => ParentValue);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.ir.txt
@@ -17,9 +17,7 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => ParentValue = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1013:25,26 [11] )
+Generated Location: (977:25,26 [11] )
 |ParentValue|
 
 Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1777:48,7 [50] )
+Generated Location: (1757:48,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                               ParentValue
@@ -28,7 +28,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ), -1, 
+            , -1, 
             __value => ParentValue = __value, -1, () => ParentValue);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
@@ -17,9 +17,7 @@ Document -
                 Component - (0:0,0 [45] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - SomeParam - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - SomeParamChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => ParentValue = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1019:25,30 [11] )
+Generated Location: (966:25,30 [11] )
 |ParentValue|
 
 Source Location: (54:1,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |
-Generated Location: (1450:43,7 [65] )
+Generated Location: (1396:43,7 [65] )
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -28,7 +28,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
+            );
             __o = new System.Action<System.Int32>(
             __value => ParentValue = __value);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
@@ -17,9 +17,7 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => ParentValue = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1013:25,26 [11] )
+Generated Location: (977:25,26 [11] )
 |ParentValue|
 
 Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1618:47,7 [50] )
+Generated Location: (1581:47,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
@@ -17,7 +17,7 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (942:25,26 [11] )
+Generated Location: (947:25,26 [11] )
 |ParentValue|
 
 Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1586:46,7 [50] )
+Generated Location: (1591:46,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -28,7 +28,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
+            );
             __o = new System.Action<System.Int32>(
             __value => ParentValue = __value);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
@@ -17,9 +17,7 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => ParentValue = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1013:25,26 [11] )
+Generated Location: (977:25,26 [11] )
 |ParentValue|
 
 Source Location: (50:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "42";
 |
-Generated Location: (1618:47,7 [55] )
+Generated Location: (1581:47,7 [55] )
 |
     public string ParentValue { get; set; } = "42";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                         person.Name
@@ -28,7 +28,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
+            );
             __o = new System.Action<System.String>(
             __value => person.Name = __value);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.ir.txt
@@ -17,9 +17,7 @@ Document -
                 Component - (0:0,0 [39] x:\dir\subdir\Test\TestComponent.cshtml) - InputText
                     ComponentAttribute - (24:0,24 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (24:0,24 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - person.Name
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (24:0,24 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => person.Name = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (24:0,24 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |person.Name|
-Generated Location: (1012:25,24 [11] )
+Generated Location: (976:25,24 [11] )
 |person.Name|
 
 Source Location: (57:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     Person person = new Person();
 |
-Generated Location: (1610:47,1 [37] )
+Generated Location: (1573:47,1 [37] )
 |
     Person person = new Person();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.codegen.cs
@@ -27,7 +27,7 @@ using System.Globalization;
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                    ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.ir.txt
@@ -20,7 +20,7 @@ Document -
                 MarkupElement - (29:1,0 [114] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (47:1,18 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (48:1,19 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - , culture: 
                             IntermediateToken - (111:1,82 [28] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CultureInfo.InvariantCulture

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.mappings.txt
@@ -5,19 +5,19 @@ Generated Location: (320:12,0 [26] )
 
 Source Location: (48:1,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1084:32,19 [11] )
+Generated Location: (1089:32,19 [11] )
 |ParentValue|
 
 Source Location: (111:1,82 [28] x:\dir\subdir\Test\TestComponent.cshtml)
 |CultureInfo.InvariantCulture|
-Generated Location: (1324:40,82 [28] )
+Generated Location: (1329:40,82 [28] )
 |CultureInfo.InvariantCulture|
 
 Source Location: (152:2,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1725:51,7 [55] )
+Generated Location: (1730:51,7 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                  CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -20,7 +20,7 @@ Document -
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
                     HtmlAttribute - (32:0,32 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (33:0,33 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (33:0,33 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (949:25,33 [11] )
+Generated Location: (954:25,33 [11] )
 |CurrentDate|
 
 Source Location: (113:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1328:36,7 [77] )
+Generated Location: (1333:36,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                  ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
@@ -20,7 +20,7 @@ Document -
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
                     HtmlAttribute - (32:0,32 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (33:0,33 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (32:0,32 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (33:0,33 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (949:25,33 [11] )
+Generated Location: (954:25,33 [11] )
 |ParentValue|
 
 Source Location: (86:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1294:36,7 [50] )
+Generated Location: (1299:36,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithCulture/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithCulture/TestComponent.codegen.cs
@@ -27,7 +27,7 @@ using System.Globalization;
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                    ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithCulture/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithCulture/TestComponent.ir.txt
@@ -20,7 +20,7 @@ Document -
                 MarkupElement - (29:1,0 [118] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (47:1,18 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (48:1,19 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - , culture: 
                             IntermediateToken - (115:1,86 [28] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CultureInfo.InvariantCulture

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithCulture/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithCulture/TestComponent.mappings.txt
@@ -5,19 +5,19 @@ Generated Location: (320:12,0 [26] )
 
 Source Location: (48:1,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1084:32,19 [11] )
+Generated Location: (1089:32,19 [11] )
 |ParentValue|
 
 Source Location: (115:1,86 [28] x:\dir\subdir\Test\TestComponent.cshtml)
 |CultureInfo.InvariantCulture|
-Generated Location: (1328:40,86 [28] )
+Generated Location: (1333:40,86 [28] )
 |CultureInfo.InvariantCulture|
 
 Source Location: (156:2,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1729:51,7 [55] )
+Generated Location: (1734:51,7 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_OverridesEvent/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_OverridesEvent/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                    ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_OverridesEvent/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_OverridesEvent/TestComponent.ir.txt
@@ -17,7 +17,7 @@ Document -
                 MarkupElement - (0:0,0 [67] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (18:0,18 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (19:0,19 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (18:0,18 [12] x:\dir\subdir\Test\TestComponent.cshtml) - anotherevent=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_OverridesEvent/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_OverridesEvent/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (19:0,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (935:25,19 [11] )
+Generated Location: (940:25,19 [11] )
 |ParentValue|
 
 Source Location: (76:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1280:36,7 [55] )
+Generated Location: (1285:36,7 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                    ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.ir.txt
@@ -17,7 +17,7 @@ Document -
                 MarkupElement - (0:0,0 [34] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (18:0,18 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (19:0,19 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (18:0,18 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (19:0,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (935:25,19 [11] )
+Generated Location: (940:25,19 [11] )
 |ParentValue|
 
 Source Location: (43:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1280:36,7 [55] )
+Generated Location: (1285:36,7 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                   ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.ir.txt
@@ -17,7 +17,7 @@ Document -
                 MarkupElement - (0:0,0 [33] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (18:0,18 [11] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (18:0,18 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (18:0,18 [11] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (18:0,18 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (934:25,18 [11] )
+Generated Location: (939:25,18 [11] )
 |ParentValue|
 
 Source Location: (42:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1279:36,7 [55] )
+Generated Location: (1284:36,7 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
              ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.ir.txt
@@ -17,7 +17,7 @@ Document -
                 MarkupElement - (0:0,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (12:0,12 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (13:0,13 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (12:0,12 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (13:0,13 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (929:25,13 [11] )
+Generated Location: (934:25,13 [11] )
 |ParentValue|
 
 Source Location: (37:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1274:36,7 [55] )
+Generated Location: (1279:36,7 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.codegen.cs
@@ -27,7 +27,7 @@ using System.Globalization;
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                    ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.ir.txt
@@ -23,7 +23,7 @@ Document -
                             IntermediateToken - (42:1,13 [6] x:\dir\subdir\Test\TestComponent.cshtml) - Html - custom
                     HtmlAttribute - (63:1,34 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (64:1,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (63:1,34 [12] x:\dir\subdir\Test\TestComponent.cshtml) - anotherevent=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.mappings.txt
@@ -5,14 +5,14 @@ Generated Location: (320:12,0 [26] )
 
 Source Location: (64:1,35 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1100:32,35 [11] )
+Generated Location: (1105:32,35 [11] )
 |ParentValue|
 
 Source Location: (121:2,7 [44] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; }
 |
-Generated Location: (1445:43,7 [44] )
+Generated Location: (1450:43,7 [44] )
 |
     public int ParentValue { get; set; }
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.codegen.cs
@@ -27,7 +27,7 @@ using System.Globalization;
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                    ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.ir.txt
@@ -23,7 +23,7 @@ Document -
                             IntermediateToken - (42:1,13 [6] x:\dir\subdir\Test\TestComponent.cshtml) - Html - custom
                     HtmlAttribute - (63:1,34 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (64:1,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - , culture: 
                             IntermediateToken - (131:1,102 [26] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CultureInfo.CurrentCulture

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.mappings.txt
@@ -5,19 +5,19 @@ Generated Location: (320:12,0 [26] )
 
 Source Location: (64:1,35 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1100:32,35 [11] )
+Generated Location: (1105:32,35 [11] )
 |ParentValue|
 
 Source Location: (131:1,102 [26] x:\dir\subdir\Test\TestComponent.cshtml)
 |CultureInfo.CurrentCulture|
-Generated Location: (1360:40,102 [26] )
+Generated Location: (1365:40,102 [26] )
 |CultureInfo.CurrentCulture|
 
 Source Location: (170:2,7 [44] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; }
 |
-Generated Location: (1757:51,7 [44] )
+Generated Location: (1762:51,7 [44] )
 |
     public int ParentValue { get; set; }
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                Enabled

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.ir.txt
@@ -20,7 +20,7 @@ Document -
                             IntermediateToken - (13:0,13 [8] x:\dir\subdir\Test\TestComponent.cshtml) - Html - checkbox
                     HtmlAttribute - (30:0,30 [8] x:\dir\subdir\Test\TestComponent.cshtml) - checked=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (31:0,31 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Enabled
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (30:0,30 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (31:0,31 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |Enabled|
-Generated Location: (947:25,31 [7] )
+Generated Location: (952:25,31 [7] )
 |Enabled|
 
 Source Location: (51:1,7 [41] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public bool Enabled { get; set; }
 |
-Generated Location: (1280:36,7 [41] )
+Generated Location: (1285:36,7 [41] )
 |
     public bool Enabled { get; set; }
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.ir.txt
@@ -17,7 +17,7 @@ Document -
                 MarkupElement - (0:0,0 [73] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (14:0,14 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (15:0,15 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (15:0,15 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (931:25,15 [11] )
+Generated Location: (936:25,15 [11] )
 |CurrentDate|
 
 Source Location: (82:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1310:36,7 [77] )
+Generated Location: (1315:36,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                            CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
@@ -20,7 +20,7 @@ Document -
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
                     HtmlAttribute - (26:0,26 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (27:0,27 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken - (55:0,55 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Format

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
@@ -1,11 +1,11 @@
 Source Location: (27:0,27 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (943:25,27 [11] )
+Generated Location: (948:25,27 [11] )
 |CurrentDate|
 
 Source Location: (55:0,55 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |Format|
-Generated Location: (1155:33,55 [6] )
+Generated Location: (1160:33,55 [6] )
 |Format|
 
 Source Location: (73:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -14,7 +14,7 @@ Source Location: (73:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public string Format { get; set; } = "MM/dd/yyyy";
 |
-Generated Location: (1511:44,7 [135] )
+Generated Location: (1516:44,7 [135] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                            CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -20,7 +20,7 @@ Document -
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
                     HtmlAttribute - (26:0,26 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (27:0,27 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd/yyyy"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (27:0,27 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (943:25,27 [11] )
+Generated Location: (948:25,27 [11] )
 |CurrentDate|
 
 Source Location: (76:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1332:36,7 [77] )
+Generated Location: (1337:36,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                            ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.ir.txt
@@ -20,7 +20,7 @@ Document -
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
                     HtmlAttribute - (26:0,26 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (27:0,27 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (26:0,26 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (27:0,27 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (943:25,27 [11] )
+Generated Location: (948:25,27 [11] )
 |ParentValue|
 
 Source Location: (51:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1288:36,7 [50] )
+Generated Location: (1293:36,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultCultureAndDefaultFormat_Override/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultCultureAndDefaultFormat_Override/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                              CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultCultureAndDefaultFormat_Override/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultCultureAndDefaultFormat_Override/TestComponent.ir.txt
@@ -20,7 +20,7 @@ Document -
                             IntermediateToken - (13:0,13 [6] x:\dir\subdir\Test\TestComponent.cshtml) - Html - custom
                     HtmlAttribute - (28:0,28 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd/yyyy"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultCultureAndDefaultFormat_Override/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultCultureAndDefaultFormat_Override/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (945:25,29 [11] )
+Generated Location: (950:25,29 [11] )
 |CurrentDate|
 
 Source Location: (78:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1470:36,7 [77] )
+Generated Location: (1475:36,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                              CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat/TestComponent.ir.txt
@@ -20,7 +20,7 @@ Document -
                             IntermediateToken - (13:0,13 [6] x:\dir\subdir\Test\TestComponent.cshtml) - Html - custom
                     HtmlAttribute - (28:0,28 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (945:25,29 [11] )
+Generated Location: (950:25,29 [11] )
 |CurrentDate|
 
 Source Location: (53:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1324:36,7 [77] )
+Generated Location: (1329:36,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat_Override/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat_Override/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                              CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat_Override/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat_Override/TestComponent.ir.txt
@@ -20,7 +20,7 @@ Document -
                             IntermediateToken - (13:0,13 [6] x:\dir\subdir\Test\TestComponent.cshtml) - Html - custom
                     HtmlAttribute - (28:0,28 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd/yyyy"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat_Override/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat_Override/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (945:25,29 [11] )
+Generated Location: (950:25,29 [11] )
 |CurrentDate|
 
 Source Location: (78:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1334:36,7 [77] )
+Generated Location: (1339:36,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                      CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.ir.txt
@@ -17,7 +17,7 @@ Document -
                 MarkupElement - (0:0,0 [63] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (20:0,20 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (21:0,21 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (21:0,21 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (937:25,21 [11] )
+Generated Location: (942:25,21 [11] )
 |CurrentDate|
 
 Source Location: (72:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1316:36,7 [77] )
+Generated Location: (1321:36,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix_CanOverrideEvent/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix_CanOverrideEvent/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                      CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix_CanOverrideEvent/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix_CanOverrideEvent/TestComponent.ir.txt
@@ -17,7 +17,7 @@ Document -
                 MarkupElement - (0:0,0 [91] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (20:0,20 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (21:0,21 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix_CanOverrideEvent/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix_CanOverrideEvent/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (21:0,21 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (937:25,21 [11] )
+Generated Location: (942:25,21 [11] )
 |CurrentDate|
 
 Source Location: (100:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1316:36,7 [77] )
+Generated Location: (1321:36,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.ir.txt
@@ -17,7 +17,7 @@ Document -
                 MarkupElement - (0:0,0 [30] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (14:0,14 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (15:0,15 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (14:0,14 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (15:0,15 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (931:25,15 [11] )
+Generated Location: (936:25,15 [11] )
 |ParentValue|
 
 Source Location: (39:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1276:36,7 [50] )
+Generated Location: (1281:36,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic/TestComponent.codegen.cs
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<string>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<string>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                   "hi"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_Generic/TestComponent.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (889:25,19 [6] )
 
 Source Location: (34:0,34 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hi"|
-Generated Location: (1152:34,34 [4] )
+Generated Location: (1169:34,34 [4] )
 |"hi"|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.codegen.cs
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<string>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<string>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                      Value
@@ -37,7 +37,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
+            );
             __o = new System.Action<string>(
             __value => Value = __value);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.ir.txt
@@ -19,9 +19,7 @@ Document -
                         IntermediateToken - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - string
                     ComponentAttribute - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => Value = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.mappings.txt
@@ -5,14 +5,14 @@ Generated Location: (889:25,19 [6] )
 
 Source Location: (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1208:34,37 [5] )
+Generated Location: (1172:34,37 [5] )
 |Value|
 
 Source Location: (53:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1797:56,7 [21] )
+Generated Location: (1760:56,7 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.codegen.cs
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                      Value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.ir.txt
@@ -19,7 +19,7 @@ Document -
                         IntermediateToken - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - string
                     ComponentAttribute - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.mappings.txt
@@ -5,14 +5,14 @@ Generated Location: (889:25,19 [6] )
 
 Source Location: (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1143:34,37 [5] )
+Generated Location: (1148:34,37 [5] )
 |Value|
 
 Source Location: (53:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1771:55,7 [21] )
+Generated Location: (1776:55,7 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.codegen.cs
@@ -28,7 +28,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            , -1, Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            , -1, Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                         Value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.ir.txt
@@ -20,7 +20,7 @@ Document -
                             IntermediateToken - (38:0,38 [2] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - 18
                     ComponentAttribute - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.mappings.txt
@@ -5,14 +5,14 @@ Generated Location: (974:25,38 [2] )
 
 Source Location: (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1195:33,24 [5] )
+Generated Location: (1200:33,24 [5] )
 |Value|
 
 Source Location: (52:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1658:50,7 [21] )
+Generated Location: (1663:50,7 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, -1, -1, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                         Value
@@ -28,7 +28,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ), -1, 
+            , -1, 
             __value => Value = __value);
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
@@ -37,7 +37,7 @@ __o = typeof(MyComponent<>);
 #line default
 #line hidden
 #nullable disable
-            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_1(builder, -1, -1, Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_1(builder, -1, -1, 
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                         Value
@@ -45,7 +45,7 @@ __o = typeof(MyComponent<>);
 #line default
 #line hidden
 #nullable disable
-            ), -1, 
+            , -1, 
             __value => Value = __value);
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.ir.txt
@@ -17,9 +17,7 @@ Document -
                 Component - (0:0,0 [31] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => Value = __value
@@ -28,9 +26,7 @@ Document -
                 Component - (33:1,0 [31] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (57:1,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (57:1,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (57:1,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => Value = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1013:25,24 [5] )
+Generated Location: (960:25,24 [5] )
 |Value|
 
 Source Location: (57:1,24 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1523:42,24 [5] )
+Generated Location: (1416:42,24 [5] )
 |Value|
 
 Source Location: (73:2,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1919:60,7 [21] )
+Generated Location: (1811:60,7 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.codegen.cs
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<string>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<string>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                   "hi"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.mappings.txt
@@ -5,11 +5,11 @@ Generated Location: (889:25,19 [6] )
 
 Source Location: (34:0,34 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hi"|
-Generated Location: (1152:34,34 [4] )
+Generated Location: (1169:34,34 [4] )
 |"hi"|
 
 Source Location: (51:1,8 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLower()|
-Generated Location: (1442:43,8 [17] )
+Generated Location: (1459:43,8 [17] )
 |context.ToLower()|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.codegen.cs
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<string>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<string>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                   "hi"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.mappings.txt
@@ -5,11 +5,11 @@ Generated Location: (889:25,19 [6] )
 
 Source Location: (34:0,34 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hi"|
-Generated Location: (1152:34,34 [4] )
+Generated Location: (1169:34,34 [4] )
 |"hi"|
 
 Source Location: (50:0,50 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |17|
-Generated Location: (1364:43,50 [2] )
+Generated Location: (1381:43,50 [2] )
 |17|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.codegen.cs
@@ -38,7 +38,7 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<string>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<string>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                               "hi"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.mappings.txt
@@ -10,16 +10,16 @@ Generated Location: (1095:34,34 [3] )
 
 Source Location: (46:0,46 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hi"|
-Generated Location: (1367:43,46 [4] )
+Generated Location: (1384:43,46 [4] )
 |"hi"|
 
 Source Location: (77:1,22 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLower()|
-Generated Location: (1671:52,22 [17] )
+Generated Location: (1688:52,22 [17] )
 |context.ToLower()|
 
 Source Location: (158:3,3 [29] x:\dir\subdir\Test\TestComponent.cshtml)
 |System.Math.Max(0, item.Item)|
-Generated Location: (2024:62,6 [29] )
+Generated Location: (2041:62,6 [29] )
 |System.Math.Max(0, item.Item)|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                42.ToString()

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (31:0,31 [13] x:\dir\subdir\Test\TestComponent.cshtml)
 |42.ToString()|
-Generated Location: (966:25,31 [13] )
+Generated Location: (983:25,31 [13] )
 |42.ToString()|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                  123
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Boolean>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Boolean>(
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
                   true
@@ -39,7 +39,7 @@ namespace Test
 #nullable disable
             );
             __o = "";
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Test.SomeType>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Test.SomeType>(
 #nullable restore
 #line 5 "x:\dir\subdir\Test\TestComponent.cshtml"
                     new SomeType()

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (32:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |123|
-Generated Location: (951:25,17 [3] )
+Generated Location: (968:25,17 [3] )
 |123|
 
 Source Location: (56:2,18 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |true|
-Generated Location: (1203:34,18 [4] )
+Generated Location: (1237:34,18 [4] )
 |true|
 
 Source Location: (115:4,20 [14] x:\dir\subdir\Test\TestComponent.cshtml)
 |new SomeType()|
-Generated Location: (1480:44,20 [14] )
+Generated Location: (1531:44,20 [14] )
 |new SomeType()|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                            "very-cool"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (27:0,27 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |"very-cool"|
-Generated Location: (961:25,27 [11] )
+Generated Location: (978:25,27 [11] )
 |"very-cool"|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_MatchingIsCaseSensitive/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_MatchingIsCaseSensitive/TestComponent.codegen.cs
@@ -31,7 +31,7 @@ __o = typeof(MyComponent);
 #line hidden
 #nullable disable
             __o = "";
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Boolean>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Boolean>(
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
                                            true

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_MatchingIsCaseSensitive/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_MatchingIsCaseSensitive/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (77:2,43 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |true|
-Generated Location: (1301:36,43 [4] )
+Generated Location: (1318:36,43 [4] )
 |true|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_MultipleComponentsDifferByCase/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_MultipleComponentsDifferByCase/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           1
@@ -39,7 +39,7 @@ __o = typeof(MyComponent);
 #line default
 #line hidden
 #nullable disable
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                           2

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_MultipleComponentsDifferByCase/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_MultipleComponentsDifferByCase/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (26:0,26 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |1|
-Generated Location: (960:25,26 [1] )
+Generated Location: (977:25,26 [1] )
 |1|
 
 Source Location: (59:1,26 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |2|
-Generated Location: (1515:44,26 [1] )
+Generated Location: (1549:44,26 [1] )
 |2|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithSplat/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithSplat/TestComponent.codegen.cs
@@ -21,7 +21,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             __o = "";
-            builder.AddMultipleAttributes(-1, Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
+            builder.AddMultipleAttributes(-1, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                    someAttributes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithSplat/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithSplat/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (51:0,51 [14] x:\dir\subdir\Test\TestComponent.cshtml)
 |someAttributes|
-Generated Location: (1135:26,51 [14] )
+Generated Location: (1152:26,51 [14] )
 |someAttributes|
 
 Source Location: (103:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |
-Generated Location: (1666:47,7 [93] )
+Generated Location: (1683:47,7 [93] )
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithSplat_ExplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithSplat_ExplicitExpression/TestComponent.codegen.cs
@@ -21,7 +21,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             __o = "";
-            builder.AddMultipleAttributes(-1, Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
+            builder.AddMultipleAttributes(-1, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                      someAttributes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithSplat_ExplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithSplat_ExplicitExpression/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (53:0,53 [14] x:\dir\subdir\Test\TestComponent.cshtml)
 |someAttributes|
-Generated Location: (1137:26,53 [14] )
+Generated Location: (1154:26,53 [14] )
 |someAttributes|
 
 Source Location: (106:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |
-Generated Location: (1668:47,7 [93] )
+Generated Location: (1685:47,7 [93] )
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithSplat_ImplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithSplat_ImplicitExpression/TestComponent.codegen.cs
@@ -21,7 +21,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             __o = "";
-            builder.AddMultipleAttributes(-1, Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
+            builder.AddMultipleAttributes(-1, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                     someAttributes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithSplat_ImplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithSplat_ImplicitExpression/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (52:0,52 [14] x:\dir\subdir\Test\TestComponent.cshtml)
 |someAttributes|
-Generated Location: (1136:26,52 [14] )
+Generated Location: (1153:26,52 [14] )
 |someAttributes|
 
 Source Location: (104:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |
-Generated Location: (1667:47,7 [93] )
+Generated Location: (1684:47,7 [93] )
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessage/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessage/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        message
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                 message
@@ -37,10 +37,10 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, 
-            Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => message = __value, message)));
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(() => message);
+            );
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, 
+            Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => message = __value, message)));
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(() => message);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessage/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessage/TestComponent.ir.txt
@@ -20,12 +20,10 @@ Document -
                             IntermediateToken - (23:0,23 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - message
                     ComponentAttribute - (47:0,47 [8] x:\dir\subdir\Test\TestComponent.cshtml) - Message - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (48:0,48 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - message
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (47:0,47 [8] x:\dir\subdir\Test\TestComponent.cshtml) - MessageChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => message = __value, message)
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => message = __value, message)
                     ComponentAttribute - (47:0,47 [8] x:\dir\subdir\Test\TestComponent.cshtml) - MessageExpression - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - () => message

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessage/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessage/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (23:0,23 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |message|
-Generated Location: (958:25,23 [7] )
+Generated Location: (975:25,23 [7] )
 |message|
 
 Source Location: (48:0,48 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |message|
-Generated Location: (1296:34,48 [7] )
+Generated Location: (1277:34,48 [7] )
 |message|
 
 Source Location: (73:1,12 [30] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string message = "hi";
 |
-Generated Location: (2311:57,12 [30] )
+Generated Location: (2348:57,12 [30] )
 |
     string message = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageChanged/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageChanged/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, 
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                (s) => {}
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                            message
@@ -37,10 +37,10 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, 
-            Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => message = __value, message)));
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(() => message);
+            );
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, 
+            Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => message = __value, message)));
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(() => message);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageChanged/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageChanged/TestComponent.ir.txt
@@ -20,12 +20,10 @@ Document -
                             IntermediateToken - (31:0,31 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - (s) => {}
                     ComponentAttribute - (58:0,58 [8] x:\dir\subdir\Test\TestComponent.cshtml) - Message - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (59:0,59 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - message
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (58:0,58 [8] x:\dir\subdir\Test\TestComponent.cshtml) - MessageChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => message = __value, message)
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => message = __value, message)
                     ComponentAttribute - (58:0,58 [8] x:\dir\subdir\Test\TestComponent.cshtml) - MessageExpression - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - () => message

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageChanged/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageChanged/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (31:0,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |(s) => {}|
-Generated Location: (1095:25,31 [9] )
+Generated Location: (1112:25,31 [9] )
 |(s) => {}|
 
 Source Location: (59:0,59 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |message|
-Generated Location: (1447:34,59 [7] )
+Generated Location: (1428:34,59 [7] )
 |message|
 
 Source Location: (84:1,12 [30] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string message = "hi";
 |
-Generated Location: (2462:57,12 [30] )
+Generated Location: (2499:57,12 [30] )
 |
     string message = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageExpression/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                            (s) => {}
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                              message
@@ -37,10 +37,10 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, 
-            Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => message = __value, message)));
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(() => message);
+            );
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, 
+            Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => message = __value, message)));
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(() => message);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageExpression/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageExpression/TestComponent.ir.txt
@@ -20,12 +20,10 @@ Document -
                             IntermediateToken - (59:0,59 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - (s) => {}
                     ComponentAttribute - (28:0,28 [8] x:\dir\subdir\Test\TestComponent.cshtml) - Message - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (29:0,29 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - message
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (28:0,28 [8] x:\dir\subdir\Test\TestComponent.cshtml) - MessageChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => message = __value, message)
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => message = __value, message)
                     ComponentAttribute - (28:0,28 [8] x:\dir\subdir\Test\TestComponent.cshtml) - MessageExpression - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - () => message

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageExpression/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (59:0,59 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |(s) => {}|
-Generated Location: (1045:25,59 [9] )
+Generated Location: (1062:25,59 [9] )
 |(s) => {}|
 
 Source Location: (29:0,29 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |message|
-Generated Location: (1366:34,29 [7] )
+Generated Location: (1347:34,29 [7] )
 |message|
 
 Source Location: (87:1,12 [30] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string message = "hi";
 |
-Generated Location: (2381:57,12 [30] )
+Generated Location: (2418:57,12 [30] )
 |
     string message = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                         text

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.ir.txt
@@ -26,7 +26,7 @@ Document -
                                 IntermediateToken - (35:1,28 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - 17
                         HtmlAttribute - (46:1,39 [5] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                             CSharpExpressionAttributeValue -  - 
-                                IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                                IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                                 IntermediateToken - (47:1,40 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - text
                                 IntermediateToken -  - CSharp - )
                         HtmlAttribute - (46:1,39 [5] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (47:1,40 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |text|
-Generated Location: (956:25,40 [4] )
+Generated Location: (961:25,40 [4] )
 |text|
 
 Source Location: (83:3,12 [35] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private string text = "hi";
 |
-Generated Location: (1285:36,12 [35] )
+Generated Location: (1290:36,12 [35] )
 |
     private string text = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.codegen.cs
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                    text

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.ir.txt
@@ -28,7 +28,7 @@ Document -
                                 IntermediateToken -  - CSharp - )
                         HtmlAttribute - (41:1,34 [5] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                             CSharpExpressionAttributeValue -  - 
-                                IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                                IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                                 IntermediateToken - (42:1,35 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - text
                                 IntermediateToken -  - CSharp - )
                         HtmlAttribute - (41:1,34 [5] x:\dir\subdir\Test\TestComponent.cshtml) - oninput=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.mappings.txt
@@ -5,14 +5,14 @@ Generated Location: (1060:25,79 [8] )
 
 Source Location: (42:1,35 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |text|
-Generated Location: (1314:34,35 [4] )
+Generated Location: (1319:34,35 [4] )
 |text|
 
 Source Location: (126:3,12 [35] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private string text = "hi";
 |
-Generated Location: (1643:45,12 [35] )
+Generated Location: (1648:45,12 [35] )
 |
     private string text = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                         text

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.ir.txt
@@ -26,7 +26,7 @@ Document -
                                 IntermediateToken - (35:1,28 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - 17
                         HtmlAttribute - (46:1,39 [5] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                             CSharpExpressionAttributeValue -  - 
-                                IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                                IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                                 IntermediateToken - (47:1,40 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - text
                                 IntermediateToken -  - CSharp - )
                         HtmlAttribute - (46:1,39 [5] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (47:1,40 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |text|
-Generated Location: (956:25,40 [4] )
+Generated Location: (961:25,40 [4] )
 |text|
 
 Source Location: (83:3,12 [35] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private string text = "hi";
 |
-Generated Location: (1285:36,12 [35] )
+Generated Location: (1290:36,12 [35] )
 |
     private string text = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithSplat/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithSplat/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            builder.AddMultipleAttributes(-1, Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
+            builder.AddMultipleAttributes(-1, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                             someAttributes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithSplat/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithSplat/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (44:0,44 [14] x:\dir\subdir\Test\TestComponent.cshtml)
 |someAttributes|
-Generated Location: (1105:25,44 [14] )
+Generated Location: (1122:25,44 [14] )
 |someAttributes|
 
 Source Location: (106:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |
-Generated Location: (1314:35,7 [93] )
+Generated Location: (1331:35,7 [93] )
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithSplat_ExplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithSplat_ExplicitExpression/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            builder.AddMultipleAttributes(-1, Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
+            builder.AddMultipleAttributes(-1, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                               someAttributes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithSplat_ExplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithSplat_ExplicitExpression/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (46:0,46 [14] x:\dir\subdir\Test\TestComponent.cshtml)
 |someAttributes|
-Generated Location: (1107:25,46 [14] )
+Generated Location: (1124:25,46 [14] )
 |someAttributes|
 
 Source Location: (109:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |
-Generated Location: (1316:35,7 [93] )
+Generated Location: (1333:35,7 [93] )
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithSplat_ImplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithSplat_ImplicitExpression/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            builder.AddMultipleAttributes(-1, Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
+            builder.AddMultipleAttributes(-1, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                              someAttributes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithSplat_ImplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithSplat_ImplicitExpression/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (45:0,45 [14] x:\dir\subdir\Test\TestComponent.cshtml)
 |someAttributes|
-Generated Location: (1106:25,45 [14] )
+Generated Location: (1123:25,45 [14] )
 |someAttributes|
 
 Source Location: (107:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |
-Generated Location: (1315:35,7 [93] )
+Generated Location: (1332:35,7 [93] )
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                         EventCallback.Factory.Create<UIMouseEventArgs>(this, Increment)

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (24:0,24 [63] x:\dir\subdir\Test\TestComponent.cshtml)
 |EventCallback.Factory.Create<UIMouseEventArgs>(this, Increment)|
-Generated Location: (1158:25,24 [63] )
+Generated Location: (1175:25,24 [63] )
 |EventCallback.Factory.Create<UIMouseEventArgs>(this, Increment)|
 
 Source Location: (102:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (102:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1715:45,7 [87] )
+Generated Location: (1732:45,7 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1157:25,23 [9] )
+Generated Location: (1174:25,23 [9] )
 |Increment|
 
 Source Location: (46:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (46:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1660:45,7 [87] )
+Generated Location: (1677:45,7 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1157:25,23 [9] )
+Generated Location: (1174:25,23 [9] )
 |Increment|
 
 Source Location: (46:2,7 [105] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (46:2,7 [105] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1660:45,7 [105] )
+Generated Location: (1677:45,7 [105] )
 |
     private int counter;
     private void Increment(UIMouseEventArgs e) {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1157:25,23 [9] )
+Generated Location: (1174:25,23 [9] )
 |Increment|
 
 Source Location: (46:2,7 [141] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -11,7 +11,7 @@ Source Location: (46:2,7 [141] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1660:45,7 [141] )
+Generated Location: (1677:45,7 [141] )
 |
     private int counter;
     private Task Increment(UIMouseEventArgs e) {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1157:25,23 [9] )
+Generated Location: (1174:25,23 [9] )
 |Increment|
 
 Source Location: (46:2,7 [123] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -11,7 +11,7 @@ Source Location: (46:2,7 [123] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1660:45,7 [123] )
+Generated Location: (1677:45,7 [123] )
 |
     private int counter;
     private Task Increment() {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1157:25,23 [9] )
+Generated Location: (1174:25,23 [9] )
 |Increment|
 
 Source Location: (46:2,7 [106] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (46:2,7 [106] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1660:45,7 [106] )
+Generated Location: (1677:45,7 [106] )
 |
     private int counter;
     private void Increment(UIChangeEventArgs e) {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                         EventCallback.Factory.Create(this, Increment)

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (24:0,24 [45] x:\dir\subdir\Test\TestComponent.cshtml)
 |EventCallback.Factory.Create(this, Increment)|
-Generated Location: (1058:25,24 [45] )
+Generated Location: (1075:25,24 [45] )
 |EventCallback.Factory.Create(this, Increment)|
 
 Source Location: (84:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (84:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1597:45,7 [87] )
+Generated Location: (1614:45,7 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1057:25,23 [9] )
+Generated Location: (1074:25,23 [9] )
 |Increment|
 
 Source Location: (46:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (46:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1560:45,7 [87] )
+Generated Location: (1577:45,7 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1057:25,23 [9] )
+Generated Location: (1074:25,23 [9] )
 |Increment|
 
 Source Location: (46:2,7 [95] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (46:2,7 [95] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1560:45,7 [95] )
+Generated Location: (1577:45,7 [95] )
 |
     private int counter;
     private void Increment(object e) {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1057:25,23 [9] )
+Generated Location: (1074:25,23 [9] )
 |Increment|
 
 Source Location: (46:2,7 [123] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -11,7 +11,7 @@ Source Location: (46:2,7 [123] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1560:45,7 [123] )
+Generated Location: (1577:45,7 [123] )
 |
     private int counter;
     private Task Increment() {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1057:25,23 [9] )
+Generated Location: (1074:25,23 [9] )
 |Increment|
 
 Source Location: (46:2,7 [131] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -11,7 +11,7 @@ Source Location: (46:2,7 [131] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1560:45,7 [131] )
+Generated Location: (1577:45,7 [131] )
 |
     private int counter;
     private Task Increment(object e) {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef_SuppressField/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef_SuppressField/TestComponent.codegen.cs
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<int>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<int>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                              3

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef_SuppressField/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef_SuppressField/TestComponent.mappings.txt
@@ -5,12 +5,12 @@ Generated Location: (889:25,19 [3] )
 
 Source Location: (29:0,29 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |3|
-Generated Location: (1141:34,29 [1] )
+Generated Location: (1158:34,29 [1] )
 |3|
 
 Source Location: (38:0,38 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |_my|
-Generated Location: (1469:45,38 [3] )
+Generated Location: (1486:45,38 [3] )
 |_my|
 
 Source Location: (73:1,7 [72] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -18,7 +18,7 @@ Source Location: (73:1,7 [72] x:\dir\subdir\Test\TestComponent.cshtml)
     MyComponent<int> _my;
     void DoStuff() { GC.KeepAlive(_my); }
 |
-Generated Location: (1834:61,7 [72] )
+Generated Location: (1851:61,7 [72] )
 |
     MyComponent<int> _my;
     void DoStuff() { GC.KeepAlive(_my); }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithKey/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithKey/TestComponent.codegen.cs
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<int>(
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<int>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                              3

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithKey/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithKey/TestComponent.mappings.txt
@@ -5,19 +5,19 @@ Generated Location: (889:25,19 [3] )
 
 Source Location: (29:0,29 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |3|
-Generated Location: (1141:34,29 [1] )
+Generated Location: (1158:34,29 [1] )
 |3|
 
 Source Location: (38:0,38 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |_someKey|
-Generated Location: (1498:46,38 [8] )
+Generated Location: (1515:46,38 [8] )
 |_someKey|
 
 Source Location: (61:2,7 [47] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private object _someKey = new object();
 |
-Generated Location: (1850:63,7 [47] )
+Generated Location: (1867:63,7 [47] )
 |
     private object _someKey = new object();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.codegen.cs
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             (builder2) => {
-                __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(
+                __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                                      person.Name

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.mappings.txt
@@ -7,13 +7,13 @@ Generated Location: (845:24,2 [45] )
 
 Source Location: (73:1,69 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |person.Name|
-Generated Location: (1206:34,69 [11] )
+Generated Location: (1223:34,69 [11] )
 |person.Name|
 
 Source Location: (93:1,89 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |;
 |
-Generated Location: (1775:53,89 [3] )
+Generated Location: (1792:53,89 [3] )
 |;
 |
 
@@ -24,7 +24,7 @@ Source Location: (106:3,7 [76] x:\dir\subdir\Test\TestComponent.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (1954:62,7 [76] )
+Generated Location: (1971:62,7 [76] )
 |
     class Person
     {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.codegen.cs
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             (builder2) => {
-                __o = Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(
+                __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                                      person.Name

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.mappings.txt
@@ -7,19 +7,19 @@ Generated Location: (845:24,2 [45] )
 
 Source Location: (73:1,69 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |person.Name|
-Generated Location: (1206:34,69 [11] )
+Generated Location: (1223:34,69 [11] )
 |person.Name|
 
 Source Location: (93:1,89 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |;
 |
-Generated Location: (1775:53,89 [3] )
+Generated Location: (1792:53,89 [3] )
 |;
 |
 
 Source Location: (116:4,2 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hello, world!"|
-Generated Location: (2023:61,6 [15] )
+Generated Location: (2040:61,6 [15] )
 |"hello, world!"|
 
 Source Location: (159:7,7 [76] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -29,7 +29,7 @@ Source Location: (159:7,7 [76] x:\dir\subdir\Test\TestComponent.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (2397:79,7 [76] )
+Generated Location: (2414:79,7 [76] )
 |
     class Person
     {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                   y

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
@@ -17,7 +17,7 @@ Document -
                 Component - (0:0,0 [23] x:\dir\subdir\Test\TestComponent.cshtml) - Counter
                     ComponentAttribute - (18:0,18 [1] x:\dir\subdir\Test\TestComponent.cshtml) - v - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (18:0,18 [1] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - y
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (18:0,18 [1] x:\dir\subdir\Test\TestComponent.cshtml) - vChanged - AttributeStructure.DoubleQuotes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (18:0,18 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |y|
-Generated Location: (934:25,18 [1] )
+Generated Location: (939:25,18 [1] )
 |y|
 
 Source Location: (32:1,7 [24] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string y = null;
 |
-Generated Location: (1544:46,7 [24] )
+Generated Location: (1549:46,7 [24] )
 |
     string y = null;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                    UserName
@@ -30,7 +30,7 @@ namespace Test
 #nullable disable
             );
             __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => UserName = __value, UserName);
-            __o = Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                               UserIsActive

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.ir.txt
@@ -17,7 +17,7 @@ Document -
                 Component - (0:0,0 [62] x:\dir\subdir\Test\TestComponent.cshtml) - User
                     ComponentAttribute - (18:0,18 [9] x:\dir\subdir\Test\TestComponent.cshtml) - Name - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (19:0,19 [8] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UserName
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (18:0,18 [9] x:\dir\subdir\Test\TestComponent.cshtml) - NameChanged - AttributeStructure.DoubleQuotes
@@ -27,7 +27,7 @@ Document -
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (45:0,45 [13] x:\dir\subdir\Test\TestComponent.cshtml) - IsActive - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (46:0,46 [12] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UserIsActive
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (45:0,45 [13] x:\dir\subdir\Test\TestComponent.cshtml) - IsActiveChanged - AttributeStructure.DoubleQuotes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.mappings.txt
@@ -1,11 +1,11 @@
 Source Location: (19:0,19 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |UserName|
-Generated Location: (935:25,19 [8] )
+Generated Location: (940:25,19 [8] )
 |UserName|
 
 Source Location: (46:0,46 [12] x:\dir\subdir\Test\TestComponent.cshtml)
 |UserIsActive|
-Generated Location: (1334:35,46 [12] )
+Generated Location: (1344:35,46 [12] )
 |UserIsActive|
 
 Source Location: (73:2,7 [88] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -13,7 +13,7 @@ Source Location: (73:2,7 [88] x:\dir\subdir\Test\TestComponent.cshtml)
     public string UserName { get; set; }
     public bool UserIsActive { get; set; }
 |
-Generated Location: (1974:56,7 [88] )
+Generated Location: (1984:56,7 [88] )
 |
     public string UserName { get; set; }
     public bool UserIsActive { get; set; }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -22,9 +22,9 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            )));
-            builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.Int32>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.Int32>(this, Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue))));
-            builder.AddAttribute(3, "ValueExpression", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Func<System.Int32>>>(() => ParentValue));
+            ));
+            builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.Int32>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.Int32>(this, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue))));
+            builder.AddAttribute(3, "ValueExpression", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Func<System.Int32>>>(() => ParentValue));
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.ir.txt
@@ -10,12 +10,10 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue)
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueExpression - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - () => ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1650:32,7 [50] )
+Generated Location: (1670:32,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
@@ -13,7 +13,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                               ParentValue
@@ -21,7 +21,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ), 2, Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue)), 3, () => ParentValue);
+            , 2, Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)), 3, () => ParentValue);
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
@@ -10,12 +10,10 @@ Document -
                 Component - (0:0,0 [45] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - SomeParam - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - SomeParamChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue)
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - SomeParamExpression - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - () => ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (54:1,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |
-Generated Location: (1171:28,7 [65] )
+Generated Location: (1140:28,7 [65] )
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -22,8 +22,8 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            )));
-            builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.Int32>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.Int32>(this, Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue))));
+            ));
+            builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.Int32>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.Int32>(this, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue))));
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
@@ -10,11 +10,9 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue)
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)
             CSharpCode - (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
                 IntermediateToken - (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public int ParentValue { get; set; } = 42;\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1453:31,7 [50] )
+Generated Location: (1456:31,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -22,8 +22,8 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            )));
-            builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.Int32>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.Int32>(this, Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue))));
+            ));
+            builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.Int32>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.Int32>(this, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue))));
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
@@ -10,11 +10,9 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => ParentValue = __value, ParentValue)
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)
             CSharpCode - (50:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
                 IntermediateToken - (50:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public string ParentValue { get; set; } = "42";\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (50:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "42";
 |
-Generated Location: (1453:31,7 [55] )
+Generated Location: (1456:31,7 [55] )
 |
     public string ParentValue { get; set; } = "42";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -22,7 +22,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            )));
+            ));
             builder.AddAttribute(2, "OnChanged", new System.Action<System.Int32>(__value => ParentValue = __value));
             builder.CloseComponent();
         }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
@@ -10,9 +10,7 @@ Document -
                 Component - (0:0,0 [71] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - OnChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => ParentValue = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1193:31,7 [50] )
+Generated Location: (1156:31,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
@@ -10,7 +10,7 @@ Document -
                 Component - (0:0,0 [71] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - OnChanged - AttributeStructure.DoubleQuotes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1175:31,7 [50] )
+Generated Location: (1180:31,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -22,9 +22,9 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            )));
+            ));
             builder.AddAttribute(2, "ValueChanged", new System.Action<System.Int32>(__value => ParentValue = __value));
-            builder.AddAttribute(3, "ValueExpression", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Func<System.Int32>>>(() => ParentValue));
+            builder.AddAttribute(3, "ValueExpression", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Func<System.Int32>>>(() => ParentValue));
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.ir.txt
@@ -10,9 +10,7 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => ParentValue = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1393:32,7 [50] )
+Generated Location: (1373:32,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.codegen.cs
@@ -13,7 +13,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                               ParentValue
@@ -21,7 +21,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ), 2, __value => ParentValue = __value, 3, () => ParentValue);
+            , 2, __value => ParentValue = __value, 3, () => ParentValue);
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.ir.txt
@@ -10,9 +10,7 @@ Document -
                 Component - (0:0,0 [45] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - SomeParam - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - SomeParamChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => ParentValue = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (54:1,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |
-Generated Location: (1014:28,7 [65] )
+Generated Location: (960:28,7 [65] )
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -22,7 +22,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            )));
+            ));
             builder.AddAttribute(2, "ValueChanged", new System.Action<System.Int32>(__value => ParentValue = __value));
             builder.CloseComponent();
         }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
@@ -10,9 +10,7 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => ParentValue = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1196:31,7 [50] )
+Generated Location: (1159:31,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
@@ -10,7 +10,7 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1178:31,7 [50] )
+Generated Location: (1183:31,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -22,7 +22,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            )));
+            ));
             builder.AddAttribute(2, "ValueChanged", new System.Action<System.Int32>(__value => ParentValue = __value));
             builder.CloseComponent();
         }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.ir.txt
@@ -10,9 +10,7 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => ParentValue = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (50:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "42";
 |
-Generated Location: (1196:31,7 [55] )
+Generated Location: (1159:31,7 [55] )
 |
     public string ParentValue { get; set; } = "42";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.InputText>(0);
-            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                         person.Name
@@ -22,7 +22,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            )));
+            ));
             builder.AddAttribute(2, "ValueChanged", new System.Action<System.String>(__value => person.Name = __value));
             builder.CloseComponent();
         }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.ir.txt
@@ -10,9 +10,7 @@ Document -
                 Component - (0:0,0 [39] x:\dir\subdir\Test\TestComponent.cshtml) - InputText
                     ComponentAttribute - (24:0,24 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (24:0,24 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - person.Name
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (24:0,24 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => person.Name = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (57:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     Person person = new Person();
 |
-Generated Location: (1188:31,1 [37] )
+Generated Location: (1151:31,1 [37] )
 |
     Person person = new Person();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.codegen.cs
@@ -21,7 +21,7 @@ using System.Globalization;
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenElement(0, "div");
-            builder.AddAttribute(1, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                    ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.ir.txt
@@ -11,7 +11,7 @@ Document -
                 MarkupElement - (29:1,0 [114] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (47:1,18 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (48:1,19 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - , culture: 
                             IntermediateToken - (111:1,82 [28] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CultureInfo.InvariantCulture

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (152:2,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1652:47,7 [55] )
+Generated Location: (1657:47,7 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "text");
-            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                  CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -13,7 +13,7 @@ Document -
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
                     HtmlAttribute - (32:0,32 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (33:0,33 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (113:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1311:33,7 [77] )
+Generated Location: (1316:33,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "text");
-            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                  ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
@@ -13,7 +13,7 @@ Document -
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
                     HtmlAttribute - (32:0,32 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (33:0,33 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (32:0,32 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (86:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1277:33,7 [50] )
+Generated Location: (1282:33,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithCulture/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithCulture/TestComponent.codegen.cs
@@ -21,7 +21,7 @@ using System.Globalization;
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenElement(0, "div");
-            builder.AddAttribute(1, "myvalue", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "myvalue", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                    ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithCulture/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithCulture/TestComponent.ir.txt
@@ -11,7 +11,7 @@ Document -
                 MarkupElement - (29:1,0 [118] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (47:1,18 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (48:1,19 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - , culture: 
                             IntermediateToken - (115:1,86 [28] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CultureInfo.InvariantCulture

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithCulture/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithCulture/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (156:2,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1664:47,7 [55] )
+Generated Location: (1669:47,7 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_OverridesEvent/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_OverridesEvent/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenElement(0, "div");
-            builder.AddAttribute(1, "myvalue", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "myvalue", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                    ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_OverridesEvent/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_OverridesEvent/TestComponent.ir.txt
@@ -10,7 +10,7 @@ Document -
                 MarkupElement - (0:0,0 [67] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (18:0,18 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (19:0,19 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (18:0,18 [12] x:\dir\subdir\Test\TestComponent.cshtml) - anotherevent=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_OverridesEvent/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_OverridesEvent/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (76:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1215:32,7 [55] )
+Generated Location: (1220:32,7 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenElement(0, "div");
-            builder.AddAttribute(1, "myvalue", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "myvalue", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                    ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.ir.txt
@@ -10,7 +10,7 @@ Document -
                 MarkupElement - (0:0,0 [34] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (18:0,18 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (19:0,19 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (18:0,18 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (43:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1210:32,7 [55] )
+Generated Location: (1215:32,7 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenElement(0, "div");
-            builder.AddAttribute(1, "myvalue", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "myvalue", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                   ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.ir.txt
@@ -10,7 +10,7 @@ Document -
                 MarkupElement - (0:0,0 [33] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (18:0,18 [11] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (18:0,18 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (18:0,18 [11] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (42:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1209:32,7 [55] )
+Generated Location: (1214:32,7 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenElement(0, "div");
-            builder.AddAttribute(1, "myvalue", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "myvalue", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
              ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.ir.txt
@@ -10,7 +10,7 @@ Document -
                 MarkupElement - (0:0,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - div
                     HtmlAttribute - (12:0,12 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myvalue=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (13:0,13 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (12:0,12 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (37:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1204:32,7 [55] )
+Generated Location: (1209:32,7 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.codegen.cs
@@ -22,7 +22,7 @@ using System.Globalization;
         {
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "custom");
-            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                    ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.ir.txt
@@ -14,7 +14,7 @@ Document -
                             IntermediateToken - (42:1,13 [6] x:\dir\subdir\Test\TestComponent.cshtml) - Html - custom
                     HtmlAttribute - (63:1,34 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (64:1,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (63:1,34 [12] x:\dir\subdir\Test\TestComponent.cshtml) - anotherevent=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (121:2,7 [44] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; }
 |
-Generated Location: (1434:40,7 [44] )
+Generated Location: (1439:40,7 [44] )
 |
     public int ParentValue { get; set; }
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.codegen.cs
@@ -22,7 +22,7 @@ using System.Globalization;
         {
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "custom");
-            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                    ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.ir.txt
@@ -14,7 +14,7 @@ Document -
                             IntermediateToken - (42:1,13 [6] x:\dir\subdir\Test\TestComponent.cshtml) - Html - custom
                     HtmlAttribute - (63:1,34 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (64:1,35 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - , culture: 
                             IntermediateToken - (131:1,102 [26] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CultureInfo.CurrentCulture

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (170:2,7 [44] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; }
 |
-Generated Location: (1746:48,7 [44] )
+Generated Location: (1751:48,7 [44] )
 |
     public int ParentValue { get; set; }
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "checkbox");
-            builder.AddAttribute(2, "checked", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(2, "checked", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                Enabled

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.ir.txt
@@ -13,7 +13,7 @@ Document -
                             IntermediateToken - (13:0,13 [8] x:\dir\subdir\Test\TestComponent.cshtml) - Html - checkbox
                     HtmlAttribute - (30:0,30 [8] x:\dir\subdir\Test\TestComponent.cshtml) - checked=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (31:0,31 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Enabled
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (30:0,30 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (51:1,7 [41] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public bool Enabled { get; set; }
 |
-Generated Location: (1271:33,7 [41] )
+Generated Location: (1276:33,7 [41] )
 |
     public bool Enabled { get; set; }
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenElement(0, "input");
-            builder.AddAttribute(1, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.ir.txt
@@ -10,7 +10,7 @@ Document -
                 MarkupElement - (0:0,0 [73] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (14:0,14 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (15:0,15 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (82:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1238:32,7 [77] )
+Generated Location: (1243:32,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "text");
-            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                            CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
@@ -13,7 +13,7 @@ Document -
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
                     HtmlAttribute - (26:0,26 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (27:0,27 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken - (55:0,55 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Format

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
@@ -4,7 +4,7 @@ Source Location: (73:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public string Format { get; set; } = "MM/dd/yyyy";
 |
-Generated Location: (1494:41,7 [135] )
+Generated Location: (1499:41,7 [135] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "text");
-            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                            CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -13,7 +13,7 @@ Document -
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
                     HtmlAttribute - (26:0,26 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (27:0,27 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd/yyyy"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (76:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1315:33,7 [77] )
+Generated Location: (1320:33,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "text");
-            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                            ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.ir.txt
@@ -13,7 +13,7 @@ Document -
                             IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - text
                     HtmlAttribute - (26:0,26 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (27:0,27 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (26:0,26 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (51:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1271:33,7 [50] )
+Generated Location: (1276:33,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultCultureAndDefaultFormat_Override/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultCultureAndDefaultFormat_Override/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "custom");
-            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                              CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultCultureAndDefaultFormat_Override/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultCultureAndDefaultFormat_Override/TestComponent.ir.txt
@@ -13,7 +13,7 @@ Document -
                             IntermediateToken - (13:0,13 [6] x:\dir\subdir\Test\TestComponent.cshtml) - Html - custom
                     HtmlAttribute - (28:0,28 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd/yyyy"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultCultureAndDefaultFormat_Override/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultCultureAndDefaultFormat_Override/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (78:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1455:33,7 [77] )
+Generated Location: (1460:33,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "custom");
-            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                              CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat/TestComponent.ir.txt
@@ -13,7 +13,7 @@ Document -
                             IntermediateToken - (13:0,13 [6] x:\dir\subdir\Test\TestComponent.cshtml) - Html - custom
                     HtmlAttribute - (28:0,28 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (53:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1309:33,7 [77] )
+Generated Location: (1314:33,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat_Override/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat_Override/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "custom");
-            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                              CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat_Override/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat_Override/TestComponent.ir.txt
@@ -13,7 +13,7 @@ Document -
                             IntermediateToken - (13:0,13 [6] x:\dir\subdir\Test\TestComponent.cshtml) - Html - custom
                     HtmlAttribute - (28:0,28 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd/yyyy"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat_Override/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat_Override/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (78:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1319:33,7 [77] )
+Generated Location: (1324:33,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenElement(0, "input");
-            builder.AddAttribute(1, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                      CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.ir.txt
@@ -10,7 +10,7 @@ Document -
                 MarkupElement - (0:0,0 [63] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (20:0,20 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (21:0,21 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (72:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1245:32,7 [77] )
+Generated Location: (1250:32,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix_CanOverrideEvent/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix_CanOverrideEvent/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenElement(0, "input");
-            builder.AddAttribute(1, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                      CurrentDate

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix_CanOverrideEvent/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix_CanOverrideEvent/TestComponent.ir.txt
@@ -10,7 +10,7 @@ Document -
                 MarkupElement - (0:0,0 [91] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (20:0,20 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (21:0,21 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - CurrentDate
                             IntermediateToken -  - CSharp - , format: 
                             IntermediateToken -  - CSharp - "MM/dd"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix_CanOverrideEvent/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix_CanOverrideEvent/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (100:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1244:32,7 [77] )
+Generated Location: (1249:32,7 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenElement(0, "input");
-            builder.AddAttribute(1, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                ParentValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.ir.txt
@@ -10,7 +10,7 @@ Document -
                 MarkupElement - (0:0,0 [30] x:\dir\subdir\Test\TestComponent.cshtml) - input
                     HtmlAttribute - (14:0,14 [12] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                         CSharpExpressionAttributeValue -  - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (15:0,15 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )
                     HtmlAttribute - (14:0,14 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (39:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1205:32,7 [50] )
+Generated Location: (1210:32,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent<string>>(0);
-            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<string>(
+            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<string>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                   "hi"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent<string>>(0);
-            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<string>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<string>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                      Value
@@ -22,7 +22,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            )));
+            ));
             builder.AddAttribute(2, "ItemChanged", new System.Action<string>(__value => Value = __value));
             builder.CloseComponent();
         }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.ir.txt
@@ -12,9 +12,7 @@ Document -
                         IntermediateToken - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - string
                     ComponentAttribute - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => Value = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (53:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1189:31,7 [21] )
+Generated Location: (1152:31,7 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent<string>>(0);
-            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                      Value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.ir.txt
@@ -12,7 +12,7 @@ Document -
                         IntermediateToken - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - string
                     ComponentAttribute - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (53:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1177:31,7 [21] )
+Generated Location: (1182:31,7 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.codegen.cs
@@ -21,7 +21,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            , 2, Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            , 2, Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                         Value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.ir.txt
@@ -13,7 +13,7 @@ Document -
                             IntermediateToken - (38:0,38 [2] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - 18
                     ComponentAttribute - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (52:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1236:36,7 [21] )
+Generated Location: (1241:36,7 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.codegen.cs
@@ -13,7 +13,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_0(builder, 0, 1, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                         Value
@@ -21,9 +21,9 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ), 2, __value => Value = __value);
+            , 2, __value => Value = __value);
             builder.AddMarkupContent(3, "\r\n");
-            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_1(builder, 4, 5, Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            __Blazor.Test.TestComponent.TypeInference.CreateMyComponent_1(builder, 4, 5, 
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                         Value
@@ -31,7 +31,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ), 6, __value => Value = __value);
+            , 6, __value => Value = __value);
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.ir.txt
@@ -10,9 +10,7 @@ Document -
                 Component - (0:0,0 [31] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => Value = __value
@@ -21,9 +19,7 @@ Document -
                 Component - (33:1,0 [31] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (57:1,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (57:1,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (57:1,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => Value = __value

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (73:2,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1367:38,7 [21] )
+Generated Location: (1259:38,7 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent<string>>(0);
-            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<string>(
+            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<string>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                   "hi"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent<string>>(0);
-            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<string>(
+            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<string>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                   "hi"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent<string, int>>(0);
-            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<string>(
+            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<string>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                               "hi"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "StringProperty", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(
+            builder.AddAttribute(1, "StringProperty", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                42.ToString()

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "IntProperty", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(
+            builder.AddAttribute(1, "IntProperty", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                  123
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            builder.AddAttribute(2, "BoolProperty", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Boolean>(
+            builder.AddAttribute(2, "BoolProperty", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Boolean>(
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
                   true
@@ -33,7 +33,7 @@ namespace Test
 #nullable disable
             ));
             builder.AddAttribute(3, "StringProperty", "My string");
-            builder.AddAttribute(4, "ObjectProperty", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Test.SomeType>(
+            builder.AddAttribute(4, "ObjectProperty", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Test.SomeType>(
 #nullable restore
 #line 5 "x:\dir\subdir\Test\TestComponent.cshtml"
                     new SomeType()

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.CoolnessMeter>(0);
-            builder.AddAttribute(1, "Coolness", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(
+            builder.AddAttribute(1, "Coolness", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                            "very-cool"

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_MatchingIsCaseSensitive/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_MatchingIsCaseSensitive/TestComponent.codegen.cs
@@ -18,7 +18,7 @@ namespace Test
             builder.AddMarkupContent(1, "\r\n<mycomponent></mycomponent>\r\n");
             builder.OpenComponent<Test.MyComponent>(2);
             builder.AddAttribute(3, "intproperty", "1");
-            builder.AddAttribute(4, "BoolProperty", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Boolean>(
+            builder.AddAttribute(4, "BoolProperty", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Boolean>(
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
                                            true

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_MultipleComponentsDifferByCase/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_MultipleComponentsDifferByCase/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "IntProperty", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(
+            builder.AddAttribute(1, "IntProperty", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           1
@@ -26,7 +26,7 @@ namespace Test
             builder.CloseComponent();
             builder.AddMarkupContent(2, "\r\n");
             builder.OpenComponent<Test.Mycomponent>(3);
-            builder.AddAttribute(4, "IntProperty", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Int32>(
+            builder.AddAttribute(4, "IntProperty", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                           2

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "AttributeBefore", "before");
-            builder.AddMultipleAttributes(2, Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
+            builder.AddMultipleAttributes(2, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                    someAttributes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (103:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |
-Generated Location: (1280:32,7 [93] )
+Generated Location: (1297:32,7 [93] )
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat_ExplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat_ExplicitExpression/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "AttributeBefore", "before");
-            builder.AddMultipleAttributes(2, Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
+            builder.AddMultipleAttributes(2, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                      someAttributes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat_ExplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat_ExplicitExpression/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (106:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |
-Generated Location: (1282:32,7 [93] )
+Generated Location: (1299:32,7 [93] )
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat_ImplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat_ImplicitExpression/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "AttributeBefore", "before");
-            builder.AddMultipleAttributes(2, Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
+            builder.AddMultipleAttributes(2, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                     someAttributes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat_ImplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat_ImplicitExpression/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (104:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |
-Generated Location: (1281:32,7 [93] )
+Generated Location: (1298:32,7 [93] )
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessage/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessage/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "Message", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(
+            builder.AddAttribute(1, "Message", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        message
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            builder.AddAttribute(2, "Message", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(2, "Message", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                 message
@@ -31,9 +31,9 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            )));
-            builder.AddAttribute(3, "MessageChanged", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => message = __value, message))));
-            builder.AddAttribute(4, "MessageExpression", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(() => message));
+            ));
+            builder.AddAttribute(3, "MessageChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => message = __value, message))));
+            builder.AddAttribute(4, "MessageExpression", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(() => message));
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessage/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessage/TestComponent.ir.txt
@@ -13,12 +13,10 @@ Document -
                             IntermediateToken - (23:0,23 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - message
                     ComponentAttribute - (47:0,47 [8] x:\dir\subdir\Test\TestComponent.cshtml) - Message - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (48:0,48 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - message
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (47:0,47 [8] x:\dir\subdir\Test\TestComponent.cshtml) - MessageChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => message = __value, message)
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => message = __value, message)
                     ComponentAttribute - (47:0,47 [8] x:\dir\subdir\Test\TestComponent.cshtml) - MessageExpression - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - () => message

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessage/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessage/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (73:1,12 [30] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string message = "hi";
 |
-Generated Location: (1963:41,12 [30] )
+Generated Location: (2000:41,12 [30] )
 |
     string message = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageChanged/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageChanged/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "MessageChanged", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, 
+            builder.AddAttribute(1, "MessageChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                (s) => {}
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             )));
-            builder.AddAttribute(2, "Message", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(2, "Message", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                            message
@@ -31,9 +31,9 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            )));
-            builder.AddAttribute(3, "MessageChanged", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => message = __value, message))));
-            builder.AddAttribute(4, "MessageExpression", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(() => message));
+            ));
+            builder.AddAttribute(3, "MessageChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => message = __value, message))));
+            builder.AddAttribute(4, "MessageExpression", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(() => message));
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageChanged/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageChanged/TestComponent.ir.txt
@@ -13,12 +13,10 @@ Document -
                             IntermediateToken - (31:0,31 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - (s) => {}
                     ComponentAttribute - (58:0,58 [8] x:\dir\subdir\Test\TestComponent.cshtml) - Message - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (59:0,59 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - message
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (58:0,58 [8] x:\dir\subdir\Test\TestComponent.cshtml) - MessageChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => message = __value, message)
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => message = __value, message)
                     ComponentAttribute - (58:0,58 [8] x:\dir\subdir\Test\TestComponent.cshtml) - MessageExpression - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - () => message

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageChanged/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageChanged/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (84:1,12 [30] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string message = "hi";
 |
-Generated Location: (2121:41,12 [30] )
+Generated Location: (2158:41,12 [30] )
 |
     string message = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageExpression/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "MessageExpression", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(
+            builder.AddAttribute(1, "MessageExpression", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                            (s) => {}
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            builder.AddAttribute(2, "Message", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(2, "Message", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                              message
@@ -31,9 +31,9 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            )));
-            builder.AddAttribute(3, "MessageChanged", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => message = __value, message))));
-            builder.AddAttribute(4, "MessageExpression", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(() => message));
+            ));
+            builder.AddAttribute(3, "MessageChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<System.String>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<System.String>(this, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => message = __value, message))));
+            builder.AddAttribute(4, "MessageExpression", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Action<System.String>>>(() => message));
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageExpression/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageExpression/TestComponent.ir.txt
@@ -13,12 +13,10 @@ Document -
                             IntermediateToken - (59:0,59 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - (s) => {}
                     ComponentAttribute - (28:0,28 [8] x:\dir\subdir\Test\TestComponent.cshtml) - Message - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
                             IntermediateToken - (29:0,29 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - message
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (28:0,28 [8] x:\dir\subdir\Test\TestComponent.cshtml) - MessageChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateInferred(this, __value => message = __value, message)
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => message = __value, message)
                     ComponentAttribute - (28:0,28 [8] x:\dir\subdir\Test\TestComponent.cshtml) - MessageExpression - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - () => message

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageExpression/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (87:1,12 [30] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string message = "hi";
 |
-Generated Location: (2043:41,12 [30] )
+Generated Location: (2080:41,12 [30] )
 |
     string message = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.codegen.cs
@@ -18,7 +18,7 @@ namespace Test
             builder.OpenElement(2, "input");
             builder.AddAttribute(3, "type", "text");
             builder.AddAttribute(4, "Value", "17");
-            builder.AddAttribute(5, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(5, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                         text

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.ir.txt
@@ -19,7 +19,7 @@ Document -
                                 IntermediateToken - (35:1,28 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - 17
                         HtmlAttribute - (46:1,39 [5] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                             CSharpExpressionAttributeValue -  - 
-                                IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                                IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                                 IntermediateToken - (47:1,40 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - text
                                 IntermediateToken -  - CSharp - )
                         HtmlAttribute - (46:1,39 [5] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (83:3,12 [35] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private string text = "hi";
 |
-Generated Location: (1504:38,12 [35] )
+Generated Location: (1509:38,12 [35] )
 |
     private string text = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.codegen.cs
@@ -26,7 +26,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            builder.AddAttribute(5, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(5, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                    text

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.ir.txt
@@ -21,7 +21,7 @@ Document -
                                 IntermediateToken -  - CSharp - )
                         HtmlAttribute - (41:1,34 [5] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                             CSharpExpressionAttributeValue -  - 
-                                IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                                IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                                 IntermediateToken - (42:1,35 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - text
                                 IntermediateToken -  - CSharp - )
                         HtmlAttribute - (41:1,34 [5] x:\dir\subdir\Test\TestComponent.cshtml) - oninput=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (126:3,12 [35] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private string text = "hi";
 |
-Generated Location: (1838:46,12 [35] )
+Generated Location: (1843:46,12 [35] )
 |
     private string text = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.codegen.cs
@@ -18,7 +18,7 @@ namespace Test
             builder.OpenElement(2, "input");
             builder.AddAttribute(3, "type", "text");
             builder.AddAttribute(4, "value", "17");
-            builder.AddAttribute(5, "value", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(5, "value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                         text

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.ir.txt
@@ -19,7 +19,7 @@ Document -
                                 IntermediateToken - (35:1,28 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - 17
                         HtmlAttribute - (46:1,39 [5] x:\dir\subdir\Test\TestComponent.cshtml) - value=" - "
                             CSharpExpressionAttributeValue -  - 
-                                IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                                IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                                 IntermediateToken - (47:1,40 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - text
                                 IntermediateToken -  - CSharp - )
                         HtmlAttribute - (46:1,39 [5] x:\dir\subdir\Test\TestComponent.cshtml) - onchange=" - "

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (83:3,12 [35] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private string text = "hi";
 |
-Generated Location: (1504:38,12 [35] )
+Generated Location: (1509:38,12 [35] )
 |
     private string text = "hi";
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
             builder.OpenElement(0, "elem");
             builder.AddAttribute(1, "attributebefore", "before");
-            builder.AddMultipleAttributes(2, Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
+            builder.AddMultipleAttributes(2, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                             someAttributes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (106:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |
-Generated Location: (1304:33,7 [93] )
+Generated Location: (1321:33,7 [93] )
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat_ExplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat_ExplicitExpression/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
             builder.OpenElement(0, "elem");
             builder.AddAttribute(1, "attributebefore", "before");
-            builder.AddMultipleAttributes(2, Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
+            builder.AddMultipleAttributes(2, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                               someAttributes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat_ExplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat_ExplicitExpression/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (109:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |
-Generated Location: (1306:33,7 [93] )
+Generated Location: (1323:33,7 [93] )
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat_ImplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat_ImplicitExpression/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
             builder.OpenElement(0, "elem");
             builder.AddAttribute(1, "attributebefore", "before");
-            builder.AddMultipleAttributes(2, Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
+            builder.AddMultipleAttributes(2, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                              someAttributes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat_ImplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat_ImplicitExpression/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (107:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |
-Generated Location: (1305:33,7 [93] )
+Generated Location: (1322:33,7 [93] )
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
+            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                         EventCallback.Factory.Create<UIMouseEventArgs>(this, Increment)

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (102:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1274:30,7 [87] )
+Generated Location: (1291:30,7 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
+            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (46:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1219:30,7 [87] )
+Generated Location: (1236:30,7 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
+            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (46:2,7 [105] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1219:30,7 [105] )
+Generated Location: (1236:30,7 [105] )
 |
     private int counter;
     private void Increment(UIMouseEventArgs e) {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
+            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.mappings.txt
@@ -6,7 +6,7 @@ Source Location: (46:2,7 [141] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1219:30,7 [141] )
+Generated Location: (1236:30,7 [141] )
 |
     private int counter;
     private Task Increment(UIMouseEventArgs e) {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
+            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.mappings.txt
@@ -6,7 +6,7 @@ Source Location: (46:2,7 [123] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1219:30,7 [123] )
+Generated Location: (1236:30,7 [123] )
 |
     private int counter;
     private Task Increment() {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
+            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.UIMouseEventArgs>>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.UIMouseEventArgs>(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (46:2,7 [106] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1219:30,7 [106] )
+Generated Location: (1236:30,7 [106] )
 |
     private int counter;
     private void Increment(UIChangeEventArgs e) {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
+            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                         EventCallback.Factory.Create(this, Increment)

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (84:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1156:30,7 [87] )
+Generated Location: (1173:30,7 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
+            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (46:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1119:30,7 [87] )
+Generated Location: (1136:30,7 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
+            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (46:2,7 [95] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1119:30,7 [95] )
+Generated Location: (1136:30,7 [95] )
 |
     private int counter;
     private void Increment(object e) {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
+            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.mappings.txt
@@ -6,7 +6,7 @@ Source Location: (46:2,7 [123] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1119:30,7 [123] )
+Generated Location: (1136:30,7 [123] )
 |
     private int counter;
     private Task Increment() {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
+            builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<Microsoft.AspNetCore.Components.EventCallback>(Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.mappings.txt
@@ -6,7 +6,7 @@ Source Location: (46:2,7 [131] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1119:30,7 [131] )
+Generated Location: (1136:30,7 [131] )
 |
     private int counter;
     private Task Increment(object e) {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_SuppressField/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_SuppressField/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent<int>>(0);
-            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<int>(
+            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<int>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                              3

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_SuppressField/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_SuppressField/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (38:0,38 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |_my|
-Generated Location: (1020:28,38 [3] )
+Generated Location: (1037:28,38 [3] )
 |_my|
 
 Source Location: (73:1,7 [72] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -8,7 +8,7 @@ Source Location: (73:1,7 [72] x:\dir\subdir\Test\TestComponent.cshtml)
     MyComponent<int> _my;
     void DoStuff() { GC.KeepAlive(_my); }
 |
-Generated Location: (1305:40,7 [72] )
+Generated Location: (1322:40,7 [72] )
 |
     MyComponent<int> _my;
     void DoStuff() { GC.KeepAlive(_my); }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithKey/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithKey/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent<int>>(0);
-            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<int>(
+            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<int>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                              3

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithKey/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithKey/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (38:0,38 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |_someKey|
-Generated Location: (981:28,38 [8] )
+Generated Location: (998:28,38 [8] )
 |_someKey|
 
 Source Location: (61:2,7 [47] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private object _someKey = new object();
 |
-Generated Location: (1222:39,7 [47] )
+Generated Location: (1239:39,7 [47] )
 |
     private object _someKey = new object();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.codegen.cs
@@ -24,7 +24,7 @@ namespace Test
             (builder2) => {
                 builder2.OpenElement(0, "div");
                 builder2.OpenComponent<Test.MyComponent>(1);
-                builder2.AddAttribute(2, "Name", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(
+                builder2.AddAttribute(2, "Name", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                                      person.Name

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.mappings.txt
@@ -8,7 +8,7 @@ Generated Location: (577:17,2 [45] )
 Source Location: (93:1,89 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |;
 |
-Generated Location: (1420:40,89 [3] )
+Generated Location: (1437:40,89 [3] )
 |;
 |
 
@@ -19,7 +19,7 @@ Source Location: (106:3,7 [76] x:\dir\subdir\Test\TestComponent.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (1599:49,7 [76] )
+Generated Location: (1616:49,7 [76] )
 |
     class Person
     {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.codegen.cs
@@ -24,7 +24,7 @@ namespace Test
             (builder2) => {
                 builder2.OpenElement(0, "div");
                 builder2.OpenComponent<Test.MyComponent>(1);
-                builder2.AddAttribute(2, "Name", Microsoft.AspNetCore.Components.RuntimeHelpers.TypeCheck<System.String>(
+                builder2.AddAttribute(2, "Name", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.String>(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                                      person.Name

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.mappings.txt
@@ -8,7 +8,7 @@ Generated Location: (577:17,2 [45] )
 Source Location: (93:1,89 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |;
 |
-Generated Location: (1420:40,89 [3] )
+Generated Location: (1437:40,89 [3] )
 |;
 |
 
@@ -19,7 +19,7 @@ Source Location: (159:7,7 [76] x:\dir\subdir\Test\TestComponent.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (2155:65,7 [76] )
+Generated Location: (2172:65,7 [76] )
 |
     class Person
     {

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.Counter>(0);
-            builder.AddAttribute(1, "v", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "v", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                   y

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
@@ -10,7 +10,7 @@ Document -
                 Component - (0:0,0 [23] x:\dir\subdir\Test\TestComponent.cshtml) - Counter
                     ComponentAttribute - (18:0,18 [1] x:\dir\subdir\Test\TestComponent.cshtml) - v - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (18:0,18 [1] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - y
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (18:0,18 [1] x:\dir\subdir\Test\TestComponent.cshtml) - vChanged - AttributeStructure.DoubleQuotes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (32:1,7 [24] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string y = null;
 |
-Generated Location: (1128:31,7 [24] )
+Generated Location: (1133:31,7 [24] )
 |
     string y = null;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.User>(0);
-            builder.AddAttribute(1, "Name", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(1, "Name", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                    UserName
@@ -24,7 +24,7 @@ namespace Test
 #nullable disable
             ));
             builder.AddAttribute(2, "NameChanged", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => UserName = __value, UserName));
-            builder.AddAttribute(3, "IsActive", Microsoft.AspNetCore.Components.BindMethods.GetValue(
+            builder.AddAttribute(3, "IsActive", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                               UserIsActive

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.ir.txt
@@ -10,7 +10,7 @@ Document -
                 Component - (0:0,0 [62] x:\dir\subdir\Test\TestComponent.cshtml) - User
                     ComponentAttribute - (18:0,18 [9] x:\dir\subdir\Test\TestComponent.cshtml) - Name - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (19:0,19 [8] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UserName
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (18:0,18 [9] x:\dir\subdir\Test\TestComponent.cshtml) - NameChanged - AttributeStructure.DoubleQuotes
@@ -20,7 +20,7 @@ Document -
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (45:0,45 [13] x:\dir\subdir\Test\TestComponent.cshtml) - IsActive - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindMethods.GetValue(
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (46:0,46 [12] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UserIsActive
                             IntermediateToken -  - CSharp - )
                     ComponentAttribute - (45:0,45 [13] x:\dir\subdir\Test\TestComponent.cshtml) - IsActiveChanged - AttributeStructure.DoubleQuotes

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.mappings.txt
@@ -3,7 +3,7 @@ Source Location: (73:2,7 [88] x:\dir\subdir\Test\TestComponent.cshtml)
     public string UserName { get; set; }
     public bool UserIsActive { get; set; }
 |
-Generated Location: (1633:41,7 [88] )
+Generated Location: (1643:41,7 [88] )
 |
     public string UserName { get; set; }
     public bool UserIsActive { get; set; }

--- a/src/Razor/test/testapps/ComponentApp/Components/Pages/FetchData.razor
+++ b/src/Razor/test/testapps/ComponentApp/Components/Pages/FetchData.razor
@@ -38,7 +38,7 @@ else
 @functions {
     WeatherForecast[] forecasts;
 
-    protected override async Task OnInitAsync()
+    protected override async Task OnInitializedAsync()
     {
         forecasts = await ForecastService.GetForecastAsync(DateTime.Now);
     }


### PR DESCRIPTION
There are some small reaction changes here to API review. Basically we've moved all of the compiler-helper parts of the runtime to `Components.CompilerServices` if they are purely implementation details of the runtime.

The exception to this is most of the functionality for `@bind...` because we want that to be callable by user-code.

----

The other part of this is that we're using a new `BindConverter` set of APIs for `bind`. This is part of the new globalisation functionality because these APIs treat culture correctly as a parameter. This is a more full-featured replacements for `BindMethods` which is being removed.

----

Make sure to look at commits because the baseline updates are pretty large. 

The generated code for `bind-Value` (on a component) has been simplified.