### PR TITLE
React to Roslyn rename of `NullableContextOptions` to `Nullable` - Take 2

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Compilation.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Compilation.targets
@@ -153,7 +153,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          NoLogo="$(NoLogo)"
          NoStandardLib="$(NoCompilerStandardLib)"
          NoWin32Manifest="$(NoWin32Manifest)"
-         NullableContextOptions="$(NullableContextOptions)"
+         Nullable="$(Nullable)"
          Optimize="$(Optimize)"
          Deterministic="$(Deterministic)"
          PublicSign="$(PublicSign)"

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Component.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Component.targets
@@ -220,7 +220,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          NoLogo="$(NoLogo)"
          NoStandardLib="$(NoCompilerStandardLib)"
          NoWin32Manifest="$(NoWin32Manifest)"
-         NullableContextOptions="$(NullableContextOptions)"
+         Nullable="$(Nullable)"
          Optimize="$(Optimize)"
          Deterministic="$(Deterministic)"
          PublicSign="$(PublicSign)"

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntegrationTest.cs
@@ -629,7 +629,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         {
             var result = await DotnetMSBuild(
                 "Build",
-                "/p:LangVersion=8.0 /p:NullableContextOptions=enable");
+                "/p:LangVersion=8.0 /p:Nullable=enable");
             var indexFilePath = Path.Combine(RazorIntermediateOutputPath, "Views", "Home", "Index.cshtml.g.cs");
 
             Assert.BuildPassed(result, allowWarnings: true);
@@ -644,7 +644,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         {
             var result = await DotnetMSBuild(
                 "Build",
-                "/p:LangVersion=8.0 /p:NullableContextOptions=enable",
+                "/p:LangVersion=8.0 /p:Nullable=enable",
                 suppressBuildServer: true);
             var indexFilePath = Path.Combine(RazorIntermediateOutputPath, "Views", "Home", "Index.cshtml.g.cs");
 


### PR DESCRIPTION
- Verified the fix with VS16.2-preview2 + latest CLI with modified `Nullable` entry on disk
- Updated tests.
- Note: This change will not pass the build until we have a new CLI that has an updated Roslyn that understands `Nullable`.

aspnet/AspNetCore#10218

Starting a second PR with these changes to see if we've already pulled in the appropriate dependencies from Roslyn