### PR TITLE
Add support for overriding downloaded AddIn

### DIFF
--- a/eng/MPack.props
+++ b/eng/MPack.props
@@ -1,5 +1,8 @@
 <Project>
   <PropertyGroup>
     <ArtifactsMPackDir>$(ArtifactsDir)MPack\$(Configuration)\</ArtifactsMPackDir>
+    <_MonoDevelopPath>$(MSBuildThisFileDirectory)..\..\monodevelop\</_MonoDevelopPath>
+    <_MDLocalConfigDir>$(_MonoDevelopPath)local-config\</_MDLocalConfigDir>
+    <_VSMXamarinExtensionsPathBundled>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..\..\md-addins\external-addins\))</_VSMXamarinExtensionsPathBundled>
   </PropertyGroup>
 </Project>

--- a/eng/MPack.targets
+++ b/eng/MPack.targets
@@ -75,4 +75,14 @@
     </ItemGroup>
   </Target>
 
+  <!--This Target is used when this AddIn is built side-by-side with monodevelop folder so it "injects" itself as AddIn instead of downloaded AddIn-->
+  <Target Name="RegisterAddin" AfterTargets="Build" Condition="Exists ('$(_MonoDevelopPath)')" >
+    <MakeDir Directories="$(_MDLocalConfigDir)" />
+    <PropertyGroup>
+      <MPackDirectoryInclude>%3CDirectory include-subdirs='true'%3E$(OutputPath)%3C/Directory%3E</MPackDirectoryInclude>
+      <BundledMPackExclude>%3CExclude%3E$(_VSMXamarinExtensionsPathBundled)razor/%3C/Exclude%3E</BundledMPackExclude>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(_MDLocalConfigDir)xamarin-addins_$(AssemblyName).addins" Lines="%3CAddins%3E $(MPackDirectoryInclude) $(BundledMPackExclude) %3C/Addins%3E" Overwrite="true" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
This is useful when building/debugging locally. When this repo is cloned side-by-side with monodevelop repo. Building this project will tell monodevelop to load our AddIn instead of original one.