### PR TITLE
Fix weakly-typed component bind

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentBindLoweringPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentBindLoweringPass.cs
@@ -333,21 +333,26 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             var changeExpressionTokens = new List<IntermediateToken>();
 
             // DOM-based event handlers use EventCallback, so if we see a delegate here it's a component.
-            if (changeAttribute != null && changeAttribute.IsDelegateProperty())
+            if (parent is ComponentIntermediateNode && changeAttribute != null && changeAttribute.IsDelegateProperty())
             {
                 RewriteNodesForComponentDelegateBind(
                     original,
                     valueExpressionTokens,
                     changeExpressionTokens);
             }
+            else if (parent is ComponentIntermediateNode)
+            {
+                RewriteNodesForComponentEventCallbackBind(
+                    original,
+                    valueExpressionTokens,
+                    changeExpressionTokens);
+            }
             else
             {
-                RewriteNodesForEventCallbackBind(
+                RewriteNodesForElementEventCallbackBind(
                     original,
                     format,
                     culture,
-                    valueAttribute,
-                    changeAttribute,
                     valueExpressionTokens,
                     changeExpressionTokens);
             }
@@ -609,62 +614,65 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             });
         }
 
-        private void RewriteNodesForEventCallbackBind(
+        private void RewriteNodesForComponentEventCallbackBind(
             IntermediateToken original,
-            IntermediateToken format,
-            IntermediateToken culture,
-            BoundAttributeDescriptor valueAttribute,
-            BoundAttributeDescriptor changeAttribute,
             List<IntermediateToken> valueExpressionTokens,
             List<IntermediateToken> changeExpressionTokens)
         {
-            if (changeAttribute == null)
+            valueExpressionTokens.Add(original);
+
+            changeExpressionTokens.Add(new IntermediateToken()
             {
-                // This is bind on a markup element. We use FormatValue to transform the value in the correct way
-                // according to format and culture.
-                //
-                // Now rewrite the content of the value node to look like:
-                //
-                // BindConverter.FormatValue(<code>, format: <format>, culture: <culture>)
+                Content = $"{ComponentsApi.RuntimeHelpers.CreateInferredEventCallback}(this, __value => {original.Content} = __value, {original.Content})",
+                Kind = TokenKind.CSharp
+            });
+        }
+
+        private void RewriteNodesForElementEventCallbackBind(
+            IntermediateToken original,
+            IntermediateToken format,
+            IntermediateToken culture,
+            List<IntermediateToken> valueExpressionTokens,
+            List<IntermediateToken> changeExpressionTokens)
+        {
+            // This is bind on a markup element. We use FormatValue to transform the value in the correct way
+            // according to format and culture.
+            //
+            // Now rewrite the content of the value node to look like:
+            //
+            // BindConverter.FormatValue(<code>, format: <format>, culture: <culture>)
+            valueExpressionTokens.Add(new IntermediateToken()
+            {
+                Content = $"{ComponentsApi.BindConverter.FormatValue}(",
+                Kind = TokenKind.CSharp
+            });
+            valueExpressionTokens.Add(original);
+
+            if (!string.IsNullOrEmpty(format?.Content))
+            {
                 valueExpressionTokens.Add(new IntermediateToken()
                 {
-                    Content = $"{ComponentsApi.BindConverter.FormatValue}(",
-                    Kind = TokenKind.CSharp
-                });
-                valueExpressionTokens.Add(original);
-
-                if (!string.IsNullOrEmpty(format?.Content))
-                {
-                    valueExpressionTokens.Add(new IntermediateToken()
-                    {
-                        Content = ", format: ",
-                        Kind = TokenKind.CSharp,
-                    });
-                    valueExpressionTokens.Add(format);
-                }
-
-                if (!string.IsNullOrEmpty(culture?.Content))
-                {
-                    valueExpressionTokens.Add(new IntermediateToken()
-                    {
-                        Content = ", culture: ",
-                        Kind = TokenKind.CSharp,
-                    });
-                    valueExpressionTokens.Add(culture);
-                }
-
-                valueExpressionTokens.Add(new IntermediateToken()
-                {
-                    Content = ")",
+                    Content = ", format: ",
                     Kind = TokenKind.CSharp,
                 });
+                valueExpressionTokens.Add(format);
             }
-            else
+
+            if (!string.IsNullOrEmpty(culture?.Content))
             {
-                // This is a component. We can just use the value as-is, since we know its type
-                // we can type-check it.
-                valueExpressionTokens.Add(original);
+                valueExpressionTokens.Add(new IntermediateToken()
+                {
+                    Content = ", culture: ",
+                    Kind = TokenKind.CSharp,
+                });
+                valueExpressionTokens.Add(culture);
             }
+
+            valueExpressionTokens.Add(new IntermediateToken()
+            {
+                Content = ")",
+                Kind = TokenKind.CSharp,
+            });
 
             // Now rewrite the content of the change-handler node. There are two cases we care about
             // here. If it's a component attribute, then don't use the 'CreateBinder' wrapper. We expect
@@ -683,53 +691,41 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             // EventCallbackFactory.CreateBinder(this, __value => <code> = __value, <code>, format: <format>, culture: <culture>)
             //
             // Note that the linemappings here are applied to the value attribute, not the change attribute.
-            if (changeAttribute == null)
+            changeExpressionTokens.Add(new IntermediateToken()
+            {
+                Content = $"{ComponentsApi.EventCallback.FactoryAccessor}.{ComponentsApi.EventCallbackFactory.CreateBinderMethod}(this, __value => {original.Content} = __value, ",
+                Kind = TokenKind.CSharp
+            });
+
+            changeExpressionTokens.Add(new IntermediateToken()
+            {
+                Content = original.Content,
+                Kind = TokenKind.CSharp
+            });
+
+            if (format != null)
             {
                 changeExpressionTokens.Add(new IntermediateToken()
                 {
-                    Content = $"{ComponentsApi.EventCallback.FactoryAccessor}.{ComponentsApi.EventCallbackFactory.CreateBinderMethod}(this, __value => {original.Content} = __value, ",
+                    Content = $", format: {format.Content}",
                     Kind = TokenKind.CSharp
-                });
-
-                changeExpressionTokens.Add(new IntermediateToken()
-                {
-                    Content = original.Content,
-                    Kind = TokenKind.CSharp
-                });
-
-                if (format != null)
-                {
-                    changeExpressionTokens.Add(new IntermediateToken()
-                    {
-                        Content = $", format: {format.Content}",
-                        Kind = TokenKind.CSharp
-                    });
-                }
-
-                if (culture != null)
-                {
-                    changeExpressionTokens.Add(new IntermediateToken()
-                    {
-                        Content = $", culture: {culture.Content}",
-                        Kind = TokenKind.CSharp
-                    });
-                }
-
-                changeExpressionTokens.Add(new IntermediateToken()
-                {
-                    Content = ")",
-                    Kind = TokenKind.CSharp,
                 });
             }
-            else
+
+            if (culture != null)
             {
-                // Component
                 changeExpressionTokens.Add(new IntermediateToken()
                 {
-                    Content = $"{ComponentsApi.RuntimeHelpers.CreateInferredEventCallback}(this, __value => {original.Content} = __value, {original.Content})",
+                    Content = $", culture: {culture.Content}",
                     Kind = TokenKind.CSharp
                 });
             }
+
+            changeExpressionTokens.Add(new IntermediateToken()
+            {
+                Content = ")",
+                Kind = TokenKind.CSharp,
+            });
         }
 
         private static IntermediateToken GetAttributeContent(IntermediateNode node)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentBindLoweringPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Components/ComponentBindLoweringPass.cs
@@ -332,7 +332,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             var valueExpressionTokens = new List<IntermediateToken>();
             var changeExpressionTokens = new List<IntermediateToken>();
 
-            // DOM-based event handlers use EventCallback, so if we see a delegate here it's a component.
+            // There are a few cases to handle for @bind:
+            // 1. This is a component using a delegate (int Value & Action<int> Value)
+            // 2. This is a component using EventCallback (int value & EventCallback<int>)
+            // 3. This is an element
             if (parent is ComponentIntermediateNode && changeAttribute != null && changeAttribute.IsDelegateProperty())
             {
                 RewriteNodesForComponentDelegateBind(
@@ -601,6 +604,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             List<IntermediateToken> valueExpressionTokens,
             List<IntermediateToken> changeExpressionTokens)
         {
+            // For a component using @bind we want to:
+            //  - use the value as-is
+            //  - create a delegate to handle changes
             valueExpressionTokens.Add(original);
 
             // Now rewrite the content of the change-handler node. Since it's a component attribute,
@@ -619,6 +625,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             List<IntermediateToken> valueExpressionTokens,
             List<IntermediateToken> changeExpressionTokens)
         {
+            // For a component using @bind we want to:
+            //  - use the value as-is
+            //  - create a delegate to handle changes
             valueExpressionTokens.Add(original);
 
             changeExpressionTokens.Add(new IntermediateToken()

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+            __o = 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -28,8 +28,8 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            );
-            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue);
+            ;
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
@@ -17,14 +17,10 @@ Document -
                 Component - (0:0,0 [71] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - OnChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, 
-                            IntermediateToken -  - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)
                 HtmlContent - (71:0,71 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (71:0,71 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
             CSharpCode - (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (947:25,26 [11] )
+Generated Location: (889:25,26 [11] )
 |ParentValue|
 
 Source Location: (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1591:46,7 [50] )
+Generated Location: (1557:46,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+            __o = 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -28,8 +28,8 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            );
-            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue);
+            ;
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
@@ -17,14 +17,10 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, 
-                            IntermediateToken -  - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)
                 HtmlContent - (41:0,41 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (41:0,41 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
             CSharpCode - (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (947:25,26 [11] )
+Generated Location: (889:25,26 [11] )
 |ParentValue|
 
 Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1591:46,7 [50] )
+Generated Location: (1557:46,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.codegen.cs
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+            __o = 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                      Value
@@ -37,8 +37,8 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            );
-            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => Value = __value, Value);
+            ;
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => Value = __value, Value);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.ir.txt
@@ -19,14 +19,10 @@ Document -
                         IntermediateToken - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - string
                     ComponentAttribute - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => Value = __value, 
-                            IntermediateToken -  - CSharp - Value
-                            IntermediateToken -  - CSharp - )
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => Value = __value, Value)
                 HtmlContent - (44:0,44 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (44:0,44 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
             CSharpCode - (53:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.mappings.txt
@@ -5,14 +5,14 @@ Generated Location: (889:25,19 [6] )
 
 Source Location: (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1148:34,37 [5] )
+Generated Location: (1090:34,37 [5] )
 |Value|
 
 Source Location: (53:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1776:55,7 [21] )
+Generated Location: (1742:55,7 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.codegen.cs
@@ -28,7 +28,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            , -1, Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+            , -1, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                         Value
@@ -36,7 +36,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ), -1, Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => Value = __value, Value));
+            , -1, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => Value = __value, Value));
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 __o = typeof(MyComponent<>);

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.ir.txt
@@ -20,14 +20,10 @@ Document -
                             IntermediateToken - (38:0,38 [2] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - 18
                     ComponentAttribute - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => Value = __value, 
-                            IntermediateToken -  - CSharp - Value
-                            IntermediateToken -  - CSharp - )
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => Value = __value, Value)
                 HtmlContent - (43:0,43 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (43:0,43 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
             CSharpCode - (52:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.mappings.txt
@@ -5,14 +5,14 @@ Generated Location: (974:25,38 [2] )
 
 Source Location: (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1200:33,24 [5] )
+Generated Location: (1142:33,24 [5] )
 |Value|
 
 Source Location: (52:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1663:50,7 [21] )
+Generated Location: (1629:50,7 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+            __o = 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                   y
@@ -28,8 +28,8 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            );
-            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => y = __value, y);
+            ;
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => y = __value, y);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
@@ -17,14 +17,10 @@ Document -
                 Component - (0:0,0 [23] x:\dir\subdir\Test\TestComponent.cshtml) - Counter
                     ComponentAttribute - (18:0,18 [1] x:\dir\subdir\Test\TestComponent.cshtml) - v - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (18:0,18 [1] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - y
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (18:0,18 [1] x:\dir\subdir\Test\TestComponent.cshtml) - vChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => y = __value, 
-                            IntermediateToken -  - CSharp - y
-                            IntermediateToken -  - CSharp - )
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => y = __value, y)
                 HtmlContent - (23:0,23 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (23:0,23 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
                 HtmlContent - (57:3,1 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (18:0,18 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |y|
-Generated Location: (939:25,18 [1] )
+Generated Location: (881:25,18 [1] )
 |y|
 
 Source Location: (32:1,7 [24] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string y = null;
 |
-Generated Location: (1549:46,7 [24] )
+Generated Location: (1515:46,7 [24] )
 |
     string y = null;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.codegen.cs
@@ -20,7 +20,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
-            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+            __o = 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                    UserName
@@ -28,9 +28,9 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            );
-            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => UserName = __value, UserName);
-            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+            ;
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => UserName = __value, UserName);
+            __o = 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                               UserIsActive
@@ -38,8 +38,8 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            );
-            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => UserIsActive = __value, UserIsActive);
+            ;
+            __o = Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => UserIsActive = __value, UserIsActive);
             builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((builder2) => {
             }
             ));

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.ir.txt
@@ -17,24 +17,16 @@ Document -
                 Component - (0:0,0 [62] x:\dir\subdir\Test\TestComponent.cshtml) - User
                     ComponentAttribute - (18:0,18 [9] x:\dir\subdir\Test\TestComponent.cshtml) - Name - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (19:0,19 [8] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UserName
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (18:0,18 [9] x:\dir\subdir\Test\TestComponent.cshtml) - NameChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => UserName = __value, 
-                            IntermediateToken -  - CSharp - UserName
-                            IntermediateToken -  - CSharp - )
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => UserName = __value, UserName)
                     ComponentAttribute - (45:0,45 [13] x:\dir\subdir\Test\TestComponent.cshtml) - IsActive - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (46:0,46 [12] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UserIsActive
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (45:0,45 [13] x:\dir\subdir\Test\TestComponent.cshtml) - IsActiveChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => UserIsActive = __value, 
-                            IntermediateToken -  - CSharp - UserIsActive
-                            IntermediateToken -  - CSharp - )
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => UserIsActive = __value, UserIsActive)
                 HtmlContent - (62:0,62 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (62:0,62 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
                 HtmlContent - (162:5,1 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_609/TestComponent.mappings.txt
@@ -1,11 +1,11 @@
 Source Location: (19:0,19 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |UserName|
-Generated Location: (940:25,19 [8] )
+Generated Location: (882:25,19 [8] )
 |UserName|
 
 Source Location: (46:0,46 [12] x:\dir\subdir\Test\TestComponent.cshtml)
 |UserIsActive|
-Generated Location: (1344:35,46 [12] )
+Generated Location: (1252:35,46 [12] )
 |UserIsActive|
 
 Source Location: (73:2,7 [88] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -13,7 +13,7 @@ Source Location: (73:2,7 [88] x:\dir\subdir\Test\TestComponent.cshtml)
     public string UserName { get; set; }
     public bool UserIsActive { get; set; }
 |
-Generated Location: (1984:56,7 [88] )
+Generated Location: (1916:56,7 [88] )
 |
     public string UserName { get; set; }
     public bool UserIsActive { get; set; }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+            builder.AddAttribute(1, "Value", 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -22,8 +22,8 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
-            builder.AddAttribute(2, "OnChanged", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue));
+            );
+            builder.AddAttribute(2, "OnChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue));
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
@@ -10,13 +10,9 @@ Document -
                 Component - (0:0,0 [71] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - OnChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, 
-                            IntermediateToken -  - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)
             CSharpCode - (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
                 IntermediateToken - (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public int ParentValue { get; set; } = 42;\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1180:31,7 [50] )
+Generated Location: (1146:31,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+            builder.AddAttribute(1, "Value", 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                           ParentValue
@@ -22,8 +22,8 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
-            builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, ParentValue));
+            );
+            builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue));
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
@@ -10,13 +10,9 @@ Document -
                 Component - (0:0,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Value - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => ParentValue = __value, 
-                            IntermediateToken -  - CSharp - ParentValue
-                            IntermediateToken -  - CSharp - )
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => ParentValue = __value, ParentValue)
             CSharpCode - (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
                 IntermediateToken - (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public int ParentValue { get; set; } = 42;\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1183:31,7 [50] )
+Generated Location: (1149:31,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.MyComponent<string>>(0);
-            builder.AddAttribute(1, "Item", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+            builder.AddAttribute(1, "Item", 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                      Value
@@ -22,8 +22,8 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
-            builder.AddAttribute(2, "ItemChanged", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => Value = __value, Value));
+            );
+            builder.AddAttribute(2, "ItemChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => Value = __value, Value));
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.ir.txt
@@ -12,13 +12,9 @@ Document -
                         IntermediateToken - (19:0,19 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - string
                     ComponentAttribute - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => Value = __value, 
-                            IntermediateToken -  - CSharp - Value
-                            IntermediateToken -  - CSharp - )
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => Value = __value, Value)
             CSharpCode - (53:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
                 IntermediateToken - (53:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    string Value;\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (53:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1182:31,7 [21] )
+Generated Location: (1148:31,7 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.codegen.cs
@@ -21,7 +21,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            , 2, Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+            , 2, 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                         Value
@@ -29,7 +29,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ), 3, Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => Value = __value, Value));
+            , 3, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => Value = __value, Value));
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.ir.txt
@@ -13,14 +13,10 @@ Document -
                             IntermediateToken - (38:0,38 [2] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - 18
                     ComponentAttribute - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Item - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Value
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - ItemChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => Value = __value, 
-                            IntermediateToken -  - CSharp - Value
-                            IntermediateToken -  - CSharp - )
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => Value = __value, Value)
             CSharpCode - (52:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
                 IntermediateToken - (52:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    string Value;\n
     NamespaceDeclaration -  - __Blazor.Test.TestComponent

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (52:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1241:36,7 [21] )
+Generated Location: (1207:36,7 [21] )
 |
     string Value;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.Counter>(0);
-            builder.AddAttribute(1, "v", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+            builder.AddAttribute(1, "v", 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                   y
@@ -22,8 +22,8 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
-            builder.AddAttribute(2, "vChanged", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => y = __value, y));
+            );
+            builder.AddAttribute(2, "vChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => y = __value, y));
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
@@ -10,13 +10,9 @@ Document -
                 Component - (0:0,0 [23] x:\dir\subdir\Test\TestComponent.cshtml) - Counter
                     ComponentAttribute - (18:0,18 [1] x:\dir\subdir\Test\TestComponent.cshtml) - v - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (18:0,18 [1] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - y
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (18:0,18 [1] x:\dir\subdir\Test\TestComponent.cshtml) - vChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => y = __value, 
-                            IntermediateToken -  - CSharp - y
-                            IntermediateToken -  - CSharp - )
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => y = __value, y)
             CSharpCode - (32:1,7 [24] x:\dir\subdir\Test\TestComponent.cshtml)
                 IntermediateToken - (32:1,7 [24] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    string y = null;\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (32:1,7 [24] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string y = null;
 |
-Generated Location: (1133:31,7 [24] )
+Generated Location: (1099:31,7 [24] )
 |
     string y = null;
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder)
         {
             builder.OpenComponent<Test.User>(0);
-            builder.AddAttribute(1, "Name", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+            builder.AddAttribute(1, "Name", 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                    UserName
@@ -22,9 +22,9 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
-            builder.AddAttribute(2, "NameChanged", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => UserName = __value, UserName));
-            builder.AddAttribute(3, "IsActive", Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+            );
+            builder.AddAttribute(2, "NameChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => UserName = __value, UserName));
+            builder.AddAttribute(3, "IsActive", 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                               UserIsActive
@@ -32,8 +32,8 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            ));
-            builder.AddAttribute(4, "IsActiveChanged", Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => UserIsActive = __value, UserIsActive));
+            );
+            builder.AddAttribute(4, "IsActiveChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => UserIsActive = __value, UserIsActive));
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.ir.txt
@@ -10,23 +10,15 @@ Document -
                 Component - (0:0,0 [62] x:\dir\subdir\Test\TestComponent.cshtml) - User
                     ComponentAttribute - (18:0,18 [9] x:\dir\subdir\Test\TestComponent.cshtml) - Name - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (19:0,19 [8] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UserName
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (18:0,18 [9] x:\dir\subdir\Test\TestComponent.cshtml) - NameChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => UserName = __value, 
-                            IntermediateToken -  - CSharp - UserName
-                            IntermediateToken -  - CSharp - )
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => UserName = __value, UserName)
                     ComponentAttribute - (45:0,45 [13] x:\dir\subdir\Test\TestComponent.cshtml) - IsActive - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.BindConverter.FormatValue(
                             IntermediateToken - (46:0,46 [12] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UserIsActive
-                            IntermediateToken -  - CSharp - )
                     ComponentAttribute - (45:0,45 [13] x:\dir\subdir\Test\TestComponent.cshtml) - IsActiveChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => UserIsActive = __value, 
-                            IntermediateToken -  - CSharp - UserIsActive
-                            IntermediateToken -  - CSharp - )
+                            IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => UserIsActive = __value, UserIsActive)
             CSharpCode - (73:2,7 [88] x:\dir\subdir\Test\TestComponent.cshtml)
                 IntermediateToken - (73:2,7 [88] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public string UserName { get; set; }\n    public bool UserIsActive { get; set; }\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.mappings.txt
@@ -3,7 +3,7 @@ Source Location: (73:2,7 [88] x:\dir\subdir\Test\TestComponent.cshtml)
     public string UserName { get; set; }
     public bool UserIsActive { get; set; }
 |
-Generated Location: (1643:41,7 [88] )
+Generated Location: (1575:41,7 [88] )
 |
     public string UserName { get; set; }
     public bool UserIsActive { get; set; }


### PR DESCRIPTION
The globalization change regressed this. For weakly typed component bind
we don't want to do any conversions, we need the values to match
exactly.

Note that there's no compiler-generated type checks because its
weakly-typed.

