### PR TITLE
Make WorkspaceProjectStateChangeDetector tests reliable.

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServices.Razor.Test;
@@ -153,7 +154,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
             var detector = new WorkspaceProjectStateChangeDetector(workspaceStateGenerator)
             {
-                EnqueueDelay = 50,
+                EnqueueDelay = 1,
+                BlockDelayedUpdateWorkEnqueue = new ManualResetEventSlim(initialState: false),
             };
 
             var projectManager = new TestProjectSnapshotManager(new[] { detector }, Workspace);
@@ -170,6 +172,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             // The change hasn't come through yet.
             Assert.Empty(workspaceStateGenerator.UpdateQueue);
 
+            detector.BlockDelayedUpdateWorkEnqueue.Set();
+
             await detector._deferredUpdates.Single().Value;
 
             var update = Assert.Single(workspaceStateGenerator.UpdateQueue);
@@ -184,7 +188,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
             var detector = new WorkspaceProjectStateChangeDetector(workspaceStateGenerator)
             {
-                EnqueueDelay = 50,
+                EnqueueDelay = 1,
+                BlockDelayedUpdateWorkEnqueue = new ManualResetEventSlim(initialState: false),
             };
 
             Workspace.TryApplyChanges(SolutionWithTwoProjects);
@@ -203,6 +208,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             // The change hasn't come through yet.
             Assert.Empty(workspaceStateGenerator.UpdateQueue);
 
+            detector.BlockDelayedUpdateWorkEnqueue.Set();
+
             await detector._deferredUpdates.Single().Value;
 
             var update = Assert.Single(workspaceStateGenerator.UpdateQueue);
@@ -217,7 +224,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
             var detector = new WorkspaceProjectStateChangeDetector(workspaceStateGenerator)
             {
-                EnqueueDelay = 50,
+                EnqueueDelay = 1,
+                BlockDelayedUpdateWorkEnqueue = new ManualResetEventSlim(initialState: false),
             };
 
             Workspace.TryApplyChanges(SolutionWithTwoProjects);
@@ -235,6 +243,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             //
             // The change hasn't come through yet.
             Assert.Empty(workspaceStateGenerator.UpdateQueue);
+
+            detector.BlockDelayedUpdateWorkEnqueue.Set();
 
             await detector._deferredUpdates.Single().Value;
 


### PR DESCRIPTION
- Prior to this we had a 50ms window in which tests can potentially fail. Basically, calling `Workspace_WorkspaceChanged` immediately enqueues an update after 50ms, if the CI is slow and it takes longer than 50ms to continue to the execution then all of these would fail.
- Added a manual reset event to ensure we can block delayed work yet still ensure that delayed work happens.

aspnet/AspNetCore-Internal#2787