### PR TITLE
Fix serialization of SourceSpan

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/RazorDiagnosticJsonConverter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/RazorDiagnosticJsonConverter.cs
@@ -27,15 +27,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Serialization
             }
 
             var diagnostic = JObject.Load(reader);
+            var id = diagnostic[nameof(RazorDiagnostic.Id)].Value<string>();
+            var severity = diagnostic[nameof(RazorDiagnostic.Severity)].Value<int>();
+            var message = diagnostic[RazorDiagnosticMessageKey].Value<string>();
+
             var span = diagnostic[nameof(RazorDiagnostic.Span)].Value<JObject>();
+            var filePath = span[nameof(SourceSpan.FilePath)].Value<string>();
             var absoluteIndex = span[nameof(SourceSpan.AbsoluteIndex)].Value<int>();
             var lineIndex = span[nameof(SourceSpan.LineIndex)].Value<int>();
             var characterIndex = span[nameof(SourceSpan.CharacterIndex)].Value<int>();
             var length = span[nameof(SourceSpan.Length)].Value<int>();
-            var filePath = span[nameof(SourceSpan.FilePath)].Value<string>();
-            var message = diagnostic[RazorDiagnosticMessageKey].Value<string>();
-            var id = diagnostic[nameof(RazorDiagnostic.Id)].Value<string>();
-            var severity = diagnostic[nameof(RazorDiagnostic.Severity)].Value<int>();
 
             var descriptor = new RazorDiagnosticDescriptor(id, () => message, (RazorDiagnosticSeverity)severity);
             var sourceSpan = new SourceSpan(filePath, absoluteIndex, lineIndex, characterIndex, length);
@@ -53,7 +54,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Serialization
             WriteProperty(writer, RazorDiagnosticMessageKey, diagnostic.GetMessage(CultureInfo.CurrentCulture));
 
             writer.WritePropertyName(nameof(RazorDiagnostic.Span));
-            serializer.Serialize(writer, diagnostic.Span);
+            writer.WriteStartObject();
+            WriteProperty(writer, nameof(SourceSpan.FilePath), diagnostic.Span.FilePath);
+            WriteProperty(writer, nameof(SourceSpan.AbsoluteIndex), diagnostic.Span.AbsoluteIndex);
+            WriteProperty(writer, nameof(SourceSpan.LineIndex), diagnostic.Span.LineIndex);
+            WriteProperty(writer, nameof(SourceSpan.CharacterIndex), diagnostic.Span.CharacterIndex);
+            WriteProperty(writer, nameof(SourceSpan.Length), diagnostic.Span.Length);
+            writer.WriteEndObject();
 
             writer.WriteEndObject();
         }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Serialization/TagHelperDescriptorSerializationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Serialization/TagHelperDescriptorSerializationTest.cs
@@ -48,6 +48,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
                 {
                     builder.AllowChildTag("allowed-child-one");
                     builder.AddMetadata("foo", "bar");
+                    builder.AddDiagnostic(RazorDiagnostic.Create(
+                        RazorDiagnosticFactory.TagHelper_InvalidTargetedTagNameNullOrWhitespace,
+                        new SourceSpan("Test.razor", 5, 17, 18, 22)));
                 });
             var serializerSettings = new JsonSerializerSettings()
             {
@@ -56,7 +59,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
                 {
                     TagHelperDescriptorJsonConverter.Instance,
                     RazorDiagnosticJsonConverter.Instance,
-                }
+                },
+                //NullValueHandling = NullValueHandling.Ignore,
             };
             var serializedDescriptor = JsonConvert.SerializeObject(expectedDescriptor, serializerSettings);
 


### PR DESCRIPTION
I noticed this while debugging something else in VS. It looks like the
service hub is using camelCase, which wasn't covered with a diagnostic
in our tests. As a result we would fail to read the data from the OOP
host, and fall back to in-process tag helper discovery.
