### PR TITLE
Increase timeout in attempt to fix test flakiness

### DIFF
--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerTestFixtureBase.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerTestFixtureBase.cs
@@ -14,8 +14,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 {
     public abstract class BuildServerTestFixtureBase : IDisposable
     {
-        private static readonly TimeSpan _defaultShutdownTimeout = TimeSpan.FromSeconds(60);
-
+        private static readonly TimeSpan _defaultShutdownTimeout = TimeSpan.FromSeconds(120);
 
         protected BuildServerTestFixtureBase(string pipeName)
         {


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2706

This has suddenly started being flaky again. I don't see any obvious issues with it and I can't reproduce this locally. Increasing the timeout to see if that fixes it.