### PR TITLE
Move to new vside feeds and make Roslyn package coherent with Extensions version

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,8 +7,7 @@
     <add key="aspnet-extensions" value="https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json" />
     <add key="myget-roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="myget-roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
-    <add key="myget-vssdk" value="https://vside.myget.org/F/vssdk/api/v3/index.json" />
-    <add key="myget-vsmac" value="https://vside.myget.org/F/vsmac/api/v3/index.json" />
-    <add key="myget-devcore" value="https://vside.myget.org/F/devcore/api/v3/index.json" />
+    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -64,7 +64,7 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>a190d4865fe3c86a168ec49c4fc61c90c96ae051</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.3.0-beta2-19374-02">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.3.0-beta2-19374-02" CoherentParentDependency="Microsoft.Extensions.Logging">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>e4e7c09bc4d22648b1a6193b3bf645b0aa8a23ea</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,13 +37,8 @@
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://dotnet.myget.org/F/roslyn/api/v3/index.json;
       https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
-      https://vside.myget.org/F/vssdk/api/v3/index.json;
-      https://vside.myget.org/F/vsmac/api/v3/index.json;
-      https://vside.myget.org/F/devcore/api/v3/index.json;
-    </RestoreSources>
-    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true' AND $(MicrosoftNetCompilersToolsetPackageVersion.Contains('-')) ">
-      $(RestoreSources);
-      https://dotnet.myget.org/F/roslyn/api/v3/index.json;
+      https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json;
+      https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
   <!--


### PR DESCRIPTION
nit: last conditional `$(RestoreSources)` update was redundant