### PR TITLE
Enable Razor integration tests to use repos Roslyn version.

### DIFF
--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/BuildVariables.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/BuildVariables.cs
@@ -7,6 +7,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
     {
         private static string _msBuildPath = string.Empty;
         private static string _microsoftNETCoreApp30PackageVersion = string.Empty;
+        private static string _microsoftNetCompilersToolsetPackageVersion = string.Empty;
 
         static partial void InitializeVariables();
 
@@ -25,6 +26,15 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             {
                 InitializeVariables();
                 return _microsoftNETCoreApp30PackageVersion;
+            }
+        }
+
+        public static string MicrosoftNetCompilersToolsetPackageVersion
+        {
+            get
+            {
+                InitializeVariables();
+                return _microsoftNetCompilersToolsetPackageVersion;
             }
         }
     }

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerIntegrationTest.cs
@@ -77,6 +77,12 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         [InitializeTestProject(originalProjectName: "SimpleMvc", targetProjectName: "Whitespace in name", baseDirectory: "")]
         public async Task Build_AppWithWhitespaceInName_CanBuildSuccessfully()
         {
+            // We need to separately restore the project in order to ensure this project uses the latest Roslyn. Without this
+            // the Csc task from Roslyn would have already been loaded and any update to it from nuget packages would not have
+            // an effect. This allows us to create our obj/Whitespace in name.csproj.nuget.g.props file (we renamed the project)
+            // and then properly build the project with an appropriate Csc.
+            await DotnetMSBuild("Restore");
+
             var result = await DotnetMSBuild(
                 "Build",
                 "/p:_RazorForceBuildServer=true");

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
@@ -95,6 +95,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 "/p:RunningAsTest=true",
 
                 $"/p:MicrosoftNETCoreApp30PackageVersion={BuildVariables.MicrosoftNETCoreApp30PackageVersion}",
+                $"/p:MicrosoftNetCompilersToolsetPackageVersion={BuildVariables.MicrosoftNetCompilersToolsetPackageVersion}",
 
                 // Additional restore sources for projects that require built packages
                 $"/p:RuntimeAdditionalRestoreSources={additionalRestoreSources}",

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/PackIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/PackIntegrationTest.cs
@@ -230,10 +230,10 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         [InitializeTestProject("PackageLibraryDirectDependency", additionalProjects: new[] { "PackageLibraryTransitiveDependency" })]
         public async Task Pack_NoBuild_IncludesStaticWebAssets()
         {
-            var result = await DotnetMSBuild("Build");
+            var result = await DotnetMSBuild("Build", runRestoreBeforeBuildOrPublish: false);
             Assert.BuildPassed(result, allowWarnings: true);
 
-            var pack = await DotnetMSBuild("Pack", "/p:NoBuild=true");
+            var pack = await DotnetMSBuild("Pack", "/p:NoBuild=true", runRestoreBeforeBuildOrPublish: false);
             Assert.BuildPassed(pack, allowWarnings: true);
 
             Assert.FileExists(pack, OutputPath, "PackageLibraryDirectDependency.dll");

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/Microsoft.NET.Sdk.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/Microsoft.NET.Sdk.Razor.Test.csproj
@@ -87,6 +87,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         {
             _msBuildPath = @"$(_DesktopMSBuildPath)";
             _microsoftNETCoreApp30PackageVersion = "$(MicrosoftNETCoreApp30PackageVersion)";
+            _microsoftNetCompilersToolsetPackageVersion = "$(MicrosoftNetCompilersToolsetPackageVersion)";
         }
     }
 }
@@ -108,7 +109,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
   </Target>
 
   <Target Name="RestoreTestProjects" BeforeTargets="Restore;Build" Condition="'$(DotNetBuildFromSource)' != 'true'">
-    <MSBuild Projects="..\testapps\RestoreTestProjects\RestoreTestProjects.csproj" Targets="Restore" />
+    <MSBuild Projects="..\testapps\RestoreTestProjects\RestoreTestProjects.csproj" Targets="Restore" Properties="MicrosoftNetCompilersToolsetPackageVersion=$(MicrosoftNetCompilersToolsetPackageVersion)" />
   </Target>
 
 </Project>

--- a/src/Razor/test/testapps/Directory.Build.props
+++ b/src/Razor/test/testapps/Directory.Build.props
@@ -6,6 +6,13 @@
     <SolutionRoot>$([MSBuild]::EnsureTrailingSlash('$(SolutionRoot)'))</SolutionRoot>
     <RepositoryRoot>$(SolutionRoot)..\..\</RepositoryRoot>
 
+    <!--
+      In the case that a user is building a sample directly the MicrosoftNetCompilersToolsetPackagerVersion will not be provided.
+      We'll fall back to whatever the current SDK provides in regards to Roslyn's Microsoft.Net.Compilers.Toolset.
+    -->
+    <BuildingTestAppsIndependently>false</BuildingTestAppsIndependently>
+    <BuildingTestAppsIndependently Condition="'$(MicrosoftNetCompilersToolsetPackageVersion)' == ''">true</BuildingTestAppsIndependently>
+
     <!-- Retarget tests to use the copy of the Sdk from source -->
     <RazorSdkArtifactsDirectory>$(SolutionRoot)..\..\artifacts\bin\Microsoft.NET.Sdk.Razor\</RazorSdkArtifactsDirectory>
 
@@ -18,6 +25,11 @@
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json;
       https://api.nuget.org/v3/index.json;
+    </RestoreSources>
+
+    <RestoreSources Condition="$(BuildingTestAppsIndependently) == false">
+      $(RestoreSources);
+      https://dotnet.myget.org/F/roslyn/api/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 
@@ -34,6 +46,13 @@
   <ItemGroup>
     <!-- Have the SDK treat the MvcShim as an MVC assembly -->
     <_MvcAssemblyName Include="Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(BuildingTestAppsIndependently) == false">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset"
+        Version="$(MicrosoftNetCompilersToolsetPackageVersion)"
+        PrivateAssets="all"
+        IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <Import Project="After.Directory.Build.props" Condition="Exists('After.Directory.Build.props')" />


### PR DESCRIPTION
- Updated `BuildVariables` to lift the `Microsoft.Net.Compilers.Toolset` package version into C# so we can pass it as a parameter to our testapps when building them.
- Flowed the `MicrosoftNetCompilersToolsetPackageVersion` to transitive testapp projects on restore. This enables `build.cmd` to properly pre-build our `testapp` projects with the latest version of Roslyn.
- Added several conditions to detect if a user is attempting to independently build a `testapp` at which point we fallback to using the SDKs Roslyn compiler toolset version.

aspnet/AspNetCore#12268