### PR TITLE
Remove ability to auto-restore before build in integration tests

### DIFF
--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIncrementalismTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIncrementalismTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             var thumbprintLookup = new Dictionary<string, FileThumbPrint>();
 
             // Act 1
-            var result = await DotnetMSBuild("Build", runRestoreBeforeBuildOrPublish: false);
+            var result = await DotnetMSBuild("Build");
 
             var directoryPath = Path.Combine(result.Project.DirectoryPath, IntermediateOutputPath);
             var filesToIgnore = new[]
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 // We want to make sure nothing changed between multiple incremental builds.
                 using (var razorGenDirectoryLock = LockDirectory(RazorIntermediateOutputPath))
                 {
-                    result = await DotnetMSBuild("Build", runRestoreBeforeBuildOrPublish: false);
+                    result = await DotnetMSBuild("Build");
                 }
 
                 Assert.BuildPassed(result);

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
@@ -69,8 +69,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             bool suppressTimeout = false,
             bool suppressBuildServer = false,
             string buildServerPipeName = null,
-            MSBuildProcessKind msBuildProcessKind = MSBuildProcessKind.Dotnet,
-            bool runRestoreBeforeBuildOrPublish = true)
+            MSBuildProcessKind msBuildProcessKind = MSBuildProcessKind.Dotnet)
         {
             var timeout = suppressTimeout ? (TimeSpan?)Timeout.InfiniteTimeSpan : null;
 
@@ -117,23 +116,10 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
             if (!string.IsNullOrEmpty(target))
             {
-                // Restore before build or publish
-                if (runRestoreBeforeBuildOrPublish &&
-                    (string.Equals("Build", target, StringComparison.OrdinalIgnoreCase)
-                        || string.Equals("Publish", target, StringComparison.OrdinalIgnoreCase)))
-                {
-                    buildArgumentList.Add($"/t:Restore");
-                }
-
                 buildArgumentList.Add($"/t:{target}");
             }
             else
             {
-                // By default, restore then build
-                if (runRestoreBeforeBuildOrPublish)
-                {
-                    buildArgumentList.Add($"/t:Restore");
-                }
                 buildArgumentList.Add($"/t:Build");
             }
 

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/PackIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/PackIntegrationTest.cs
@@ -230,10 +230,10 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         [InitializeTestProject("PackageLibraryDirectDependency", additionalProjects: new[] { "PackageLibraryTransitiveDependency" })]
         public async Task Pack_NoBuild_IncludesStaticWebAssets()
         {
-            var result = await DotnetMSBuild("Build", runRestoreBeforeBuildOrPublish: false);
+            var result = await DotnetMSBuild("Build");
             Assert.BuildPassed(result, allowWarnings: true);
 
-            var pack = await DotnetMSBuild("Pack", "/p:NoBuild=true", runRestoreBeforeBuildOrPublish: false);
+            var pack = await DotnetMSBuild("Pack", "/p:NoBuild=true");
             Assert.BuildPassed(pack, allowWarnings: true);
 
             Assert.FileExists(pack, OutputPath, "PackageLibraryDirectDependency.dll");


### PR DESCRIPTION
- We already restore at build-time and very few tests need to restore by themselves anyhwo (I've already changed them in previous PRs to restore manually).
- This mechanism of restoring didn't technically work because any NuGet resolved MSBuild pieces would not be included during Build.