### PR TITLE
Forgive nullability violation in directive syntax helpers.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectiveTargetExtension.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectiveTargetExtension.cs
@@ -79,9 +79,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
                                 .Write(node.Content)
                                 .Write(" ")
                                 .WriteStartAssignment(TypeHelper)
-                                .Write("default(")
-                                .Write(node.Content)
-                                .WriteLine(");");
+                                .Write("default");
+
+                            if (!context.Options.SuppressNullabilityEnforcement)
+                            {
+                                context.CodeWriter.Write("!");
+                            }
+
+                            context.CodeWriter.WriteLine(";");
                         }
                         break;
 
@@ -105,7 +110,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
                             context.AddSourceMappingFor(node);
                             context.CodeWriter
                                 .Write(node.Content)
-                                .WriteLine(" = null;");
+                                .Write(" = null");
+
+                            if (!context.Options.SuppressNullabilityEnforcement)
+                            {
+                                context.CodeWriter.Write("!");
+                            }
+
+                            context.CodeWriter.WriteLine(";");
                         }
                         break;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.codegen.cs
@@ -15,7 +15,7 @@ namespace __GeneratedComponent
         ((System.Action)(() => {
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent.cshtml"
-IDisposable __typeHelper = default(IDisposable);
+IDisposable __typeHelper = default!;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.mappings.txt
@@ -5,19 +5,19 @@ Generated Location: (641:17,0 [11] )
 
 Source Location: (38:1,13 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent.cshtml)
 |this.ToString()|
-Generated Location: (1251:35,13 [15] )
+Generated Location: (1239:35,13 [15] )
 |this.ToString()|
 
 Source Location: (79:3,5 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent.cshtml)
 |string.Format("{0}", "Hello")|
-Generated Location: (1448:43,6 [29] )
+Generated Location: (1436:43,6 [29] )
 |string.Format("{0}", "Hello")|
 
 Source Location: (132:6,12 [37] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent.cshtml)
 |
     void IDisposable.Dispose(){ }
 |
-Generated Location: (1700:52,12 [37] )
+Generated Location: (1688:52,12 [37] )
 |
     void IDisposable.Dispose(){ }
 |

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -58,7 +58,7 @@ namespace AspNetCore
         ((System.Action)(() => {
 #nullable restore
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
-MyService<TModel> __typeHelper = default(MyService<TModel>);
+MyService<TModel> __typeHelper = default!;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -25,16 +25,16 @@ Generated Location: (1701:60,0 [17] )
 
 Source Location: (176:11,25 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1989:70,0 [0] )
+Generated Location: (1971:70,0 [0] )
 ||
 
 Source Location: (190:13,10 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (2218:80,0 [0] )
+Generated Location: (2200:80,0 [0] )
 ||
 
 Source Location: (203:14,11 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (2447:90,0 [0] )
+Generated Location: (2429:90,0 [0] )
 ||
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.codegen.cs
@@ -18,7 +18,7 @@ namespace AspNetCore
         ((System.Action)(() => {
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml"
-MyBasePageForViews<TModel> __typeHelper = default(MyBasePageForViews<TModel>);
+MyBasePageForViews<TModel> __typeHelper = default!;
 
 #line default
 #line hidden
@@ -28,7 +28,7 @@ MyBasePageForViews<TModel> __typeHelper = default(MyBasePageForViews<TModel>);
         ((System.Action)(() => {
 #nullable restore
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml"
-MyModel __typeHelper = default(MyModel);
+MyModel __typeHelper = default!;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (759:20,0 [26] )
 
 Source Location: (45:1,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml)
 |MyModel|
-Generated Location: (1061:30,0 [7] )
+Generated Location: (1034:30,0 [7] )
 |MyModel|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.codegen.cs
@@ -18,7 +18,7 @@ namespace AspNetCore
         ((System.Action)(() => {
 #nullable restore
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports.cshtml"
-MyModel __typeHelper = default(MyModel);
+MyModel __typeHelper = default!;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
@@ -18,7 +18,7 @@ namespace AspNetCore
         ((System.Action)(() => {
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
-MyModel __typeHelper = default(MyModel);
+MyModel __typeHelper = default!;
 
 #line default
 #line hidden
@@ -28,7 +28,7 @@ MyModel __typeHelper = default(MyModel);
         ((System.Action)(() => {
 #nullable restore
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
-MyApp __typeHelper = default(MyApp);
+MyApp __typeHelper = default!;
 
 #line default
 #line hidden
@@ -38,7 +38,7 @@ MyApp __typeHelper = default(MyApp);
         ((System.Action)(() => {
 #nullable restore
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
-global::System.Object MyPropertyName = null;
+global::System.Object MyPropertyName = null!;
 
 #line default
 #line hidden
@@ -48,7 +48,7 @@ global::System.Object MyPropertyName = null;
         ((System.Action)(() => {
 #nullable restore
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
-MyService<TModel> __typeHelper = default(MyService<TModel>);
+MyService<TModel> __typeHelper = default!;
 
 #line default
 #line hidden
@@ -58,7 +58,7 @@ MyService<TModel> __typeHelper = default(MyService<TModel>);
         ((System.Action)(() => {
 #nullable restore
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
-global::System.Object Html = null;
+global::System.Object Html = null!;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.mappings.txt
@@ -5,21 +5,21 @@ Generated Location: (785:20,0 [7] )
 
 Source Location: (24:1,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyApp|
-Generated Location: (1047:30,0 [5] )
+Generated Location: (1039:30,0 [5] )
 |MyApp|
 
 Source Location: (30:1,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyPropertyName|
-Generated Location: (1327:40,22 [14] )
+Generated Location: (1313:40,22 [14] )
 |MyPropertyName|
 
 Source Location: (54:2,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyService<TModel>|
-Generated Location: (1571:50,0 [17] )
+Generated Location: (1558:50,0 [17] )
 |MyService<TModel>|
 
 Source Location: (72:2,26 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |Html|
-Generated Location: (1875:60,22 [4] )
+Generated Location: (1844:60,22 [4] )
 |Html|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
@@ -18,7 +18,7 @@ namespace AspNetCore
         ((System.Action)(() => {
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-MyModel __typeHelper = default(MyModel);
+MyModel __typeHelper = default!;
 
 #line default
 #line hidden
@@ -28,7 +28,7 @@ MyModel __typeHelper = default(MyModel);
         ((System.Action)(() => {
 #nullable restore
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-MyApp __typeHelper = default(MyApp);
+MyApp __typeHelper = default!;
 
 #line default
 #line hidden
@@ -38,7 +38,7 @@ MyApp __typeHelper = default(MyApp);
         ((System.Action)(() => {
 #nullable restore
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-global::System.Object MyPropertyName = null;
+global::System.Object MyPropertyName = null!;
 
 #line default
 #line hidden
@@ -48,7 +48,7 @@ global::System.Object MyPropertyName = null;
         ((System.Action)(() => {
 #nullable restore
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-MyService<TModel> __typeHelper = default(MyService<TModel>);
+MyService<TModel> __typeHelper = default!;
 
 #line default
 #line hidden
@@ -58,7 +58,7 @@ MyService<TModel> __typeHelper = default(MyService<TModel>);
         ((System.Action)(() => {
 #nullable restore
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-global::System.Object Html = null;
+global::System.Object Html = null!;
 
 #line default
 #line hidden
@@ -68,7 +68,7 @@ global::System.Object Html = null;
         ((System.Action)(() => {
 #nullable restore
 #line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-MyApp __typeHelper = default(MyApp);
+MyApp __typeHelper = default!;
 
 #line default
 #line hidden
@@ -78,7 +78,7 @@ MyApp __typeHelper = default(MyApp);
         ((System.Action)(() => {
 #nullable restore
 #line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-global::System.Object MyPropertyName2 = null;
+global::System.Object MyPropertyName2 = null!;
 
 #line default
 #line hidden
@@ -88,7 +88,7 @@ global::System.Object MyPropertyName2 = null;
         ((System.Action)(() => {
 #nullable restore
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-MyService<TModel> __typeHelper = default(MyService<TModel>);
+MyService<TModel> __typeHelper = default!;
 
 #line default
 #line hidden
@@ -98,7 +98,7 @@ MyService<TModel> __typeHelper = default(MyService<TModel>);
         ((System.Action)(() => {
 #nullable restore
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-global::System.Object Html2 = null;
+global::System.Object Html2 = null!;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.mappings.txt
@@ -5,41 +5,41 @@ Generated Location: (793:20,0 [7] )
 
 Source Location: (24:1,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (1059:30,0 [5] )
+Generated Location: (1051:30,0 [5] )
 |MyApp|
 
 Source Location: (30:1,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyPropertyName|
-Generated Location: (1343:40,22 [14] )
+Generated Location: (1329:40,22 [14] )
 |MyPropertyName|
 
 Source Location: (58:2,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (1591:50,0 [17] )
+Generated Location: (1578:50,0 [17] )
 |MyService<TModel>|
 
 Source Location: (76:2,26 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |Html|
-Generated Location: (1899:60,22 [4] )
+Generated Location: (1868:60,22 [4] )
 |Html|
 
 Source Location: (93:3,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (2137:70,0 [5] )
+Generated Location: (2107:70,0 [5] )
 |MyApp|
 
 Source Location: (99:3,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyPropertyName2|
-Generated Location: (2421:80,22 [15] )
+Generated Location: (2385:80,22 [15] )
 |MyPropertyName2|
 
 Source Location: (129:4,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (2670:90,0 [17] )
+Generated Location: (2635:90,0 [17] )
 |MyService<TModel>|
 
 Source Location: (147:4,26 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |Html2|
-Generated Location: (2978:100,22 [5] )
+Generated Location: (2925:100,22 [5] )
 |Html2|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
@@ -18,7 +18,7 @@ namespace AspNetCore
         ((System.Action)(() => {
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml"
-MyApp __typeHelper = default(MyApp);
+MyApp __typeHelper = default!;
 
 #line default
 #line hidden
@@ -28,7 +28,7 @@ MyApp __typeHelper = default(MyApp);
         ((System.Action)(() => {
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml"
-global::System.Object MyPropertyName = null;
+global::System.Object MyPropertyName = null!;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (767:20,0 [5] )
 
 Source Location: (14:0,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml)
 |MyPropertyName|
-Generated Location: (1038:30,22 [14] )
+Generated Location: (1032:30,22 [14] )
 |MyPropertyName|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
@@ -24,7 +24,7 @@ namespace AspNetCore
         ((System.Action)(() => {
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml"
-DateTime __typeHelper = default(DateTime);
+DateTime __typeHelper = default!;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
@@ -5,16 +5,16 @@ Generated Location: (1278:26,0 [8] )
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (1588:36,37 [29] )
+Generated Location: (1579:36,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (83:4,17 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Date|
-Generated Location: (2305:54,102 [4] )
+Generated Location: (2296:54,102 [4] )
 |Date|
 
 Source Location: (111:5,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Model|
-Generated Location: (2735:63,94 [5] )
+Generated Location: (2726:63,94 [5] )
 |Model|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
@@ -18,7 +18,7 @@ namespace AspNetCore
         ((System.Action)(() => {
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model.cshtml"
-System.Collections.IEnumerable __typeHelper = default(System.Collections.IEnumerable);
+System.Collections.IEnumerable __typeHelper = default!;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
@@ -18,7 +18,7 @@ namespace AspNetCore
         ((System.Action)(() => {
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml"
-ThisShouldBeGenerated __typeHelper = default(ThisShouldBeGenerated);
+ThisShouldBeGenerated __typeHelper = default!;
 
 #line default
 #line hidden
@@ -28,7 +28,7 @@ ThisShouldBeGenerated __typeHelper = default(ThisShouldBeGenerated);
         ((System.Action)(() => {
 #nullable restore
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml"
-System.Collections.IEnumerable __typeHelper = default(System.Collections.IEnumerable);
+System.Collections.IEnumerable __typeHelper = default!;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (797:20,0 [21] )
 
 Source Location: (37:1,7 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml)
 |System.Collections.IEnumerable|
-Generated Location: (1086:30,0 [30] )
+Generated Location: (1064:30,0 [30] )
 |System.Collections.IEnumerable|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.codegen.cs
@@ -36,7 +36,7 @@ global::System.Object __typeHelper = "/About";
         ((System.Action)(() => {
 #nullable restore
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml"
-NewModel __typeHelper = default(NewModel);
+NewModel __typeHelper = default!;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.mappings.txt
@@ -15,7 +15,7 @@ Generated Location: (1408:38,0 [8] )
 
 Source Location: (213:12,18 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
 |Model.Name|
-Generated Location: (1974:55,18 [10] )
+Generated Location: (1965:55,18 [10] )
 |Model.Name|
 
 Source Location: (93:5,12 [97] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
@@ -25,7 +25,7 @@ Source Location: (93:5,12 [97] TestFiles/IntegrationTests/CodeGenerationIntegrat
         public string Name { get; set; }
     }
 |
-Generated Location: (2220:64,12 [97] )
+Generated Location: (2211:64,12 [97] )
 |
     public class NewModel : PageModel
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
@@ -31,7 +31,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         ((System.Action)(() => {
 #nullable restore
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml"
-NewModel __typeHelper = default(NewModel);
+NewModel __typeHelper = default!;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
@@ -10,12 +10,12 @@ Generated Location: (1427:33,0 [8] )
 
 Source Location: (40:3,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |"*, AppCode"|
-Generated Location: (1723:43,37 [12] )
+Generated Location: (1714:43,37 [12] )
 |"*, AppCode"|
 
 Source Location: (661:28,47 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |Model.Name|
-Generated Location: (2419:62,47 [10] )
+Generated Location: (2410:62,47 [10] )
 |Model.Name|
 
 Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
@@ -36,7 +36,7 @@ Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegr
         public string Name { get; set; }
     }
 |
-Generated Location: (3236:79,12 [360] )
+Generated Location: (3227:79,12 [360] )
 |
     public class NewModel : PageModel
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
@@ -24,7 +24,7 @@ namespace AspNetCore
         ((System.Action)(() => {
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
-DateTime __typeHelper = default(DateTime);
+DateTime __typeHelper = default!;
 
 #line default
 #line hidden
@@ -44,7 +44,7 @@ global::System.Object __typeHelper = "InputTestTagHelper, AppCode";
         ((System.Action)(() => {
 #nullable restore
 #line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
-global::System.Object Section1 = null;
+global::System.Object Section1 = null!;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
@@ -5,25 +5,25 @@ Generated Location: (1246:26,0 [8] )
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (1540:36,37 [29] )
+Generated Location: (1531:36,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (152:10,9 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Section1|
-Generated Location: (1808:46,22 [8] )
+Generated Location: (1799:46,22 [8] )
 |Section1|
 
 Source Location: (68:4,2 [46] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
-Generated Location: (2312:63,2 [46] )
+Generated Location: (2304:63,2 [46] )
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
 
 Source Location: (222:12,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Date|
-Generated Location: (2775:73,102 [4] )
+Generated Location: (2767:73,102 [4] )
 |Date|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
@@ -18,7 +18,7 @@ namespace AspNetCore
         ((System.Action)(() => {
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml"
-IHtmlHelper<TModel> __typeHelper = default(IHtmlHelper<TModel>);
+IHtmlHelper<TModel> __typeHelper = default!;
 
 #line default
 #line hidden
@@ -28,7 +28,7 @@ IHtmlHelper<TModel> __typeHelper = default(IHtmlHelper<TModel>);
         ((System.Action)(() => {
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml"
-global::System.Object Helper = null;
+global::System.Object Helper = null!;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (779:20,0 [19] )
 
 Source Location: (28:0,28 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml)
 |Helper|
-Generated Location: (1084:30,22 [6] )
+Generated Location: (1064:30,22 [6] )
 |Helper|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -49,7 +49,7 @@ namespace AspNetCore
         ))();
         ((System.Action)(() => {
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
-MyService<TModel> __typeHelper = default(MyService<TModel>);
+MyService<TModel> __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -25,6 +25,6 @@ Generated Location: (1536:51,0 [17] )
 
 Source Location: (150:7,25 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1785:59,0 [0] )
+Generated Location: (1766:59,0 [0] )
 ||
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml"
-MyBasePageForViews<TModel> __typeHelper = default(MyBasePageForViews<TModel>);
+MyBasePageForViews<TModel> __typeHelper = default;
 
 #line default
 #line hidden
@@ -25,7 +25,7 @@ MyBasePageForViews<TModel> __typeHelper = default(MyBasePageForViews<TModel>);
         ))();
         ((System.Action)(() => {
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml"
-MyModel __typeHelper = default(MyModel);
+MyModel __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (740:19,0 [26] )
 
 Source Location: (45:1,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml)
 |MyModel|
-Generated Location: (1004:27,0 [7] )
+Generated Location: (976:27,0 [7] )
 |MyModel|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports.cshtml"
-MyModel __typeHelper = default(MyModel);
+MyModel __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
-MyModel __typeHelper = default(MyModel);
+MyModel __typeHelper = default;
 
 #line default
 #line hidden
@@ -25,7 +25,7 @@ MyModel __typeHelper = default(MyModel);
         ))();
         ((System.Action)(() => {
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
-MyApp __typeHelper = default(MyApp);
+MyApp __typeHelper = default;
 
 #line default
 #line hidden
@@ -41,7 +41,7 @@ global::System.Object MyPropertyName = null;
         ))();
         ((System.Action)(() => {
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
-MyService<TModel> __typeHelper = default(MyService<TModel>);
+MyService<TModel> __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.mappings.txt
@@ -5,21 +5,21 @@ Generated Location: (766:19,0 [7] )
 
 Source Location: (24:1,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyApp|
-Generated Location: (990:27,0 [5] )
+Generated Location: (981:27,0 [5] )
 |MyApp|
 
 Source Location: (30:1,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyPropertyName|
-Generated Location: (1232:35,22 [14] )
+Generated Location: (1216:35,22 [14] )
 |MyPropertyName|
 
 Source Location: (54:2,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyService<TModel>|
-Generated Location: (1438:43,0 [17] )
+Generated Location: (1422:43,0 [17] )
 |MyService<TModel>|
 
 Source Location: (72:2,26 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |Html|
-Generated Location: (1704:51,22 [4] )
+Generated Location: (1669:51,22 [4] )
 |Html|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-MyModel __typeHelper = default(MyModel);
+MyModel __typeHelper = default;
 
 #line default
 #line hidden
@@ -25,7 +25,7 @@ MyModel __typeHelper = default(MyModel);
         ))();
         ((System.Action)(() => {
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-MyApp __typeHelper = default(MyApp);
+MyApp __typeHelper = default;
 
 #line default
 #line hidden
@@ -41,7 +41,7 @@ global::System.Object MyPropertyName = null;
         ))();
         ((System.Action)(() => {
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-MyService<TModel> __typeHelper = default(MyService<TModel>);
+MyService<TModel> __typeHelper = default;
 
 #line default
 #line hidden
@@ -57,7 +57,7 @@ global::System.Object Html = null;
         ))();
         ((System.Action)(() => {
 #line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-MyApp __typeHelper = default(MyApp);
+MyApp __typeHelper = default;
 
 #line default
 #line hidden
@@ -73,7 +73,7 @@ global::System.Object MyPropertyName2 = null;
         ))();
         ((System.Action)(() => {
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-MyService<TModel> __typeHelper = default(MyService<TModel>);
+MyService<TModel> __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.mappings.txt
@@ -5,41 +5,41 @@ Generated Location: (774:19,0 [7] )
 
 Source Location: (24:1,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (1002:27,0 [5] )
+Generated Location: (993:27,0 [5] )
 |MyApp|
 
 Source Location: (30:1,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyPropertyName|
-Generated Location: (1248:35,22 [14] )
+Generated Location: (1232:35,22 [14] )
 |MyPropertyName|
 
 Source Location: (58:2,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (1458:43,0 [17] )
+Generated Location: (1442:43,0 [17] )
 |MyService<TModel>|
 
 Source Location: (76:2,26 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |Html|
-Generated Location: (1728:51,22 [4] )
+Generated Location: (1693:51,22 [4] )
 |Html|
 
 Source Location: (93:3,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (1928:59,0 [5] )
+Generated Location: (1893:59,0 [5] )
 |MyApp|
 
 Source Location: (99:3,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyPropertyName2|
-Generated Location: (2174:67,22 [15] )
+Generated Location: (2132:67,22 [15] )
 |MyPropertyName2|
 
 Source Location: (129:4,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (2385:75,0 [17] )
+Generated Location: (2343:75,0 [17] )
 |MyService<TModel>|
 
 Source Location: (147:4,26 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |Html2|
-Generated Location: (2655:83,22 [5] )
+Generated Location: (2594:83,22 [5] )
 |Html2|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml"
-MyApp __typeHelper = default(MyApp);
+MyApp __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (748:19,0 [5] )
 
 Source Location: (14:0,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml)
 |MyPropertyName|
-Generated Location: (981:27,22 [14] )
+Generated Location: (974:27,22 [14] )
 |MyPropertyName|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
@@ -23,7 +23,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml"
-DateTime __typeHelper = default(DateTime);
+DateTime __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
@@ -5,16 +5,16 @@ Generated Location: (1259:25,0 [8] )
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (1531:33,37 [29] )
+Generated Location: (1521:33,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (83:4,17 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Date|
-Generated Location: (2210:49,102 [4] )
+Generated Location: (2200:49,102 [4] )
 |Date|
 
 Source Location: (111:5,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Model|
-Generated Location: (2602:56,94 [5] )
+Generated Location: (2592:56,94 [5] )
 |Model|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model.cshtml"
-System.Collections.IEnumerable __typeHelper = default(System.Collections.IEnumerable);
+System.Collections.IEnumerable __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml"
-ThisShouldBeGenerated __typeHelper = default(ThisShouldBeGenerated);
+ThisShouldBeGenerated __typeHelper = default;
 
 #line default
 #line hidden
@@ -25,7 +25,7 @@ ThisShouldBeGenerated __typeHelper = default(ThisShouldBeGenerated);
         ))();
         ((System.Action)(() => {
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml"
-System.Collections.IEnumerable __typeHelper = default(System.Collections.IEnumerable);
+System.Collections.IEnumerable __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (778:19,0 [21] )
 
 Source Location: (37:1,7 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml)
 |System.Collections.IEnumerable|
-Generated Location: (1029:27,0 [30] )
+Generated Location: (1006:27,0 [30] )
 |System.Collections.IEnumerable|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
@@ -23,7 +23,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
-DateTime __typeHelper = default(DateTime);
+DateTime __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
@@ -5,25 +5,25 @@ Generated Location: (1227:25,0 [8] )
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (1483:33,37 [29] )
+Generated Location: (1473:33,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (152:10,9 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Section1|
-Generated Location: (1713:41,22 [8] )
+Generated Location: (1703:41,22 [8] )
 |Section1|
 
 Source Location: (68:4,2 [46] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
-Generated Location: (2179:56,2 [46] )
+Generated Location: (2169:56,2 [46] )
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
 
 Source Location: (222:12,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Date|
-Generated Location: (2604:64,102 [4] )
+Generated Location: (2594:64,102 [4] )
 |Date|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml"
-IHtmlHelper<TModel> __typeHelper = default(IHtmlHelper<TModel>);
+IHtmlHelper<TModel> __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (760:19,0 [19] )
 
 Source Location: (28:0,28 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml)
 |Helper|
-Generated Location: (1027:27,22 [6] )
+Generated Location: (1006:27,22 [6] )
 |Helper|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -49,7 +49,7 @@ namespace AspNetCore
         ))();
         ((System.Action)(() => {
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
-MyService<TModel> __typeHelper = default(MyService<TModel>);
+MyService<TModel> __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -25,16 +25,16 @@ Generated Location: (1530:51,0 [17] )
 
 Source Location: (176:11,25 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1780:59,0 [0] )
+Generated Location: (1761:59,0 [0] )
 ||
 
 Source Location: (190:13,10 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1971:67,0 [0] )
+Generated Location: (1952:67,0 [0] )
 ||
 
 Source Location: (203:14,11 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (2162:75,0 [0] )
+Generated Location: (2143:75,0 [0] )
 ||
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml"
-MyBasePageForViews<TModel> __typeHelper = default(MyBasePageForViews<TModel>);
+MyBasePageForViews<TModel> __typeHelper = default;
 
 #line default
 #line hidden
@@ -25,7 +25,7 @@ MyBasePageForViews<TModel> __typeHelper = default(MyBasePageForViews<TModel>);
         ))();
         ((System.Action)(() => {
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml"
-MyModel __typeHelper = default(MyModel);
+MyModel __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (740:19,0 [26] )
 
 Source Location: (45:1,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml)
 |MyModel|
-Generated Location: (1004:27,0 [7] )
+Generated Location: (976:27,0 [7] )
 |MyModel|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports.cshtml"
-MyModel __typeHelper = default(MyModel);
+MyModel __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
-MyModel __typeHelper = default(MyModel);
+MyModel __typeHelper = default;
 
 #line default
 #line hidden
@@ -25,7 +25,7 @@ MyModel __typeHelper = default(MyModel);
         ))();
         ((System.Action)(() => {
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
-MyApp __typeHelper = default(MyApp);
+MyApp __typeHelper = default;
 
 #line default
 #line hidden
@@ -41,7 +41,7 @@ global::System.Object MyPropertyName = null;
         ))();
         ((System.Action)(() => {
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
-MyService<TModel> __typeHelper = default(MyService<TModel>);
+MyService<TModel> __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.mappings.txt
@@ -5,21 +5,21 @@ Generated Location: (766:19,0 [7] )
 
 Source Location: (24:1,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyApp|
-Generated Location: (990:27,0 [5] )
+Generated Location: (981:27,0 [5] )
 |MyApp|
 
 Source Location: (30:1,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyPropertyName|
-Generated Location: (1232:35,22 [14] )
+Generated Location: (1216:35,22 [14] )
 |MyPropertyName|
 
 Source Location: (54:2,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyService<TModel>|
-Generated Location: (1438:43,0 [17] )
+Generated Location: (1422:43,0 [17] )
 |MyService<TModel>|
 
 Source Location: (72:2,26 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |Html|
-Generated Location: (1704:51,22 [4] )
+Generated Location: (1669:51,22 [4] )
 |Html|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-MyModel __typeHelper = default(MyModel);
+MyModel __typeHelper = default;
 
 #line default
 #line hidden
@@ -25,7 +25,7 @@ MyModel __typeHelper = default(MyModel);
         ))();
         ((System.Action)(() => {
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-MyApp __typeHelper = default(MyApp);
+MyApp __typeHelper = default;
 
 #line default
 #line hidden
@@ -41,7 +41,7 @@ global::System.Object MyPropertyName = null;
         ))();
         ((System.Action)(() => {
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-MyService<TModel> __typeHelper = default(MyService<TModel>);
+MyService<TModel> __typeHelper = default;
 
 #line default
 #line hidden
@@ -57,7 +57,7 @@ global::System.Object Html = null;
         ))();
         ((System.Action)(() => {
 #line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-MyApp __typeHelper = default(MyApp);
+MyApp __typeHelper = default;
 
 #line default
 #line hidden
@@ -73,7 +73,7 @@ global::System.Object MyPropertyName2 = null;
         ))();
         ((System.Action)(() => {
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
-MyService<TModel> __typeHelper = default(MyService<TModel>);
+MyService<TModel> __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.mappings.txt
@@ -5,41 +5,41 @@ Generated Location: (774:19,0 [7] )
 
 Source Location: (24:1,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (1002:27,0 [5] )
+Generated Location: (993:27,0 [5] )
 |MyApp|
 
 Source Location: (30:1,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyPropertyName|
-Generated Location: (1248:35,22 [14] )
+Generated Location: (1232:35,22 [14] )
 |MyPropertyName|
 
 Source Location: (58:2,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (1458:43,0 [17] )
+Generated Location: (1442:43,0 [17] )
 |MyService<TModel>|
 
 Source Location: (76:2,26 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |Html|
-Generated Location: (1728:51,22 [4] )
+Generated Location: (1693:51,22 [4] )
 |Html|
 
 Source Location: (93:3,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (1928:59,0 [5] )
+Generated Location: (1893:59,0 [5] )
 |MyApp|
 
 Source Location: (99:3,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyPropertyName2|
-Generated Location: (2174:67,22 [15] )
+Generated Location: (2132:67,22 [15] )
 |MyPropertyName2|
 
 Source Location: (129:4,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (2385:75,0 [17] )
+Generated Location: (2343:75,0 [17] )
 |MyService<TModel>|
 
 Source Location: (147:4,26 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |Html2|
-Generated Location: (2655:83,22 [5] )
+Generated Location: (2594:83,22 [5] )
 |Html2|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml"
-MyApp __typeHelper = default(MyApp);
+MyApp __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (748:19,0 [5] )
 
 Source Location: (14:0,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml)
 |MyPropertyName|
-Generated Location: (981:27,22 [14] )
+Generated Location: (974:27,22 [14] )
 |MyPropertyName|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
@@ -23,7 +23,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml"
-DateTime __typeHelper = default(DateTime);
+DateTime __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
@@ -5,16 +5,16 @@ Generated Location: (1259:25,0 [8] )
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (1531:33,37 [29] )
+Generated Location: (1521:33,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (83:4,17 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Date|
-Generated Location: (2210:49,102 [4] )
+Generated Location: (2200:49,102 [4] )
 |Date|
 
 Source Location: (111:5,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Model|
-Generated Location: (2602:56,94 [5] )
+Generated Location: (2592:56,94 [5] )
 |Model|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model.cshtml"
-System.Collections.IEnumerable __typeHelper = default(System.Collections.IEnumerable);
+System.Collections.IEnumerable __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml"
-ThisShouldBeGenerated __typeHelper = default(ThisShouldBeGenerated);
+ThisShouldBeGenerated __typeHelper = default;
 
 #line default
 #line hidden
@@ -25,7 +25,7 @@ ThisShouldBeGenerated __typeHelper = default(ThisShouldBeGenerated);
         ))();
         ((System.Action)(() => {
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml"
-System.Collections.IEnumerable __typeHelper = default(System.Collections.IEnumerable);
+System.Collections.IEnumerable __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (778:19,0 [21] )
 
 Source Location: (37:1,7 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml)
 |System.Collections.IEnumerable|
-Generated Location: (1029:27,0 [30] )
+Generated Location: (1006:27,0 [30] )
 |System.Collections.IEnumerable|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.codegen.cs
@@ -31,7 +31,7 @@ global::System.Object __typeHelper = "/About";
         ))();
         ((System.Action)(() => {
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml"
-NewModel __typeHelper = default(NewModel);
+NewModel __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.mappings.txt
@@ -15,7 +15,7 @@ Generated Location: (1313:33,0 [8] )
 
 Source Location: (213:12,18 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
 |Model.Name|
-Generated Location: (1841:48,18 [10] )
+Generated Location: (1831:48,18 [10] )
 |Model.Name|
 
 Source Location: (93:5,12 [97] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
@@ -25,7 +25,7 @@ Source Location: (93:5,12 [97] TestFiles/IntegrationTests/CodeGenerationIntegrat
         public string Name { get; set; }
     }
 |
-Generated Location: (2049:55,12 [97] )
+Generated Location: (2039:55,12 [97] )
 |
     public class NewModel : PageModel
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
@@ -28,7 +28,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml"
-NewModel __typeHelper = default(NewModel);
+NewModel __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
@@ -10,12 +10,12 @@ Generated Location: (1370:30,0 [8] )
 
 Source Location: (40:3,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |"*, AppCode"|
-Generated Location: (1628:38,37 [12] )
+Generated Location: (1618:38,37 [12] )
 |"*, AppCode"|
 
 Source Location: (661:28,47 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |Model.Name|
-Generated Location: (2286:55,47 [10] )
+Generated Location: (2276:55,47 [10] )
 |Model.Name|
 
 Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
@@ -36,7 +36,7 @@ Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegr
         public string Name { get; set; }
     }
 |
-Generated Location: (3065:70,12 [360] )
+Generated Location: (3055:70,12 [360] )
 |
     public class NewModel : PageModel
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
@@ -23,7 +23,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
-DateTime __typeHelper = default(DateTime);
+DateTime __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
@@ -5,25 +5,25 @@ Generated Location: (1227:25,0 [8] )
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (1483:33,37 [29] )
+Generated Location: (1473:33,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (152:10,9 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Section1|
-Generated Location: (1713:41,22 [8] )
+Generated Location: (1703:41,22 [8] )
 |Section1|
 
 Source Location: (68:4,2 [46] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
-Generated Location: (2179:56,2 [46] )
+Generated Location: (2169:56,2 [46] )
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
 
 Source Location: (222:12,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Date|
-Generated Location: (2604:64,102 [4] )
+Generated Location: (2594:64,102 [4] )
 |Date|
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml"
-IHtmlHelper<TModel> __typeHelper = default(IHtmlHelper<TModel>);
+IHtmlHelper<TModel> __typeHelper = default;
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (760:19,0 [19] )
 
 Source Location: (28:0,28 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml)
 |Helper|
-Generated Location: (1027:27,22 [6] )
+Generated Location: (1006:27,22 [6] )
 |Helper|
 

--- a/src/Razor/test/RazorLanguage.Test/Extensions/DesignTimeDirectiveTargetExtensionTest.cs
+++ b/src/Razor/test/RazorLanguage.Test/Extensions/DesignTimeDirectiveTargetExtensionTest.cs
@@ -60,7 +60,7 @@ private void __RazorDirectiveTokenHelpers__() {
 ((System.Action)(() => {
 #nullable restore
 #line 1 ""test.cshtml""
-System.String __typeHelper = default(System.String);
+System.String __typeHelper = default!;
 
 #line default
 #line hidden
@@ -142,7 +142,7 @@ private void __RazorDirectiveTokenHelpers__() {
 ((System.Action)(() => {
 #nullable restore
 #line 1 ""test.cshtml""
-global::System.Object Foo = null;
+global::System.Object Foo = null!;
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.codegen.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         ((System.Action)(() => {
 #nullable restore
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml"
-global::System.Object Footer = null;
+global::System.Object Footer = null!;
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.mappings.txt
@@ -6,44 +6,44 @@ Generated Location: (507:12,22 [6] )
 Source Location: (20:1,13 [36] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |for(int i = 1; i <= 10; i++) {
     |
-Generated Location: (1005:29,13 [36] )
+Generated Location: (1006:29,13 [36] )
 |for(int i = 1; i <= 10; i++) {
     |
 
 Source Location: (74:2,22 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |i|
-Generated Location: (1220:37,22 [1] )
+Generated Location: (1221:37,22 [1] )
 |i|
 
 Source Location: (79:2,27 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |
             }|
-Generated Location: (1406:44,27 [15] )
+Generated Location: (1407:44,27 [15] )
 |
             }|
 
 Source Location: (113:7,2 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |Foo(Bar.Baz)|
-Generated Location: (1584:52,6 [12] )
+Generated Location: (1585:52,6 [12] )
 |Foo(Bar.Baz)|
 
 Source Location: (129:8,1 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |Foo(|
-Generated Location: (1760:59,6 [4] )
+Generated Location: (1761:59,6 [4] )
 |Foo(|
 
 Source Location: (142:8,14 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |baz|
-Generated Location: (1941:62,14 [3] )
+Generated Location: (1942:62,14 [3] )
 |baz|
 
 Source Location: (153:8,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |)|
-Generated Location: (2001:68,1 [1] )
+Generated Location: (2002:68,1 [1] )
 |)|
 
 Source Location: (204:13,5 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |bar|
-Generated Location: (2239:76,6 [3] )
+Generated Location: (2240:76,6 [3] )
 |bar|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Implements_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Implements_DesignTime.codegen.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         ((System.Action)(() => {
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Implements.cshtml"
-IDisposable __typeHelper = default(IDisposable);
+IDisposable __typeHelper = default!;
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Implements_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Implements_DesignTime.mappings.txt
@@ -7,7 +7,7 @@ Source Location: (39:2,12 [38] TestFiles/IntegrationTests/CodeGenerationIntegrat
 |
     void IDisposable.Dispose() { }
 |
-Generated Location: (1078:31,12 [38] )
+Generated Location: (1066:31,12 [38] )
 |
     void IDisposable.Dispose() { }
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.codegen.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         ((System.Action)(() => {
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml"
-foo.bar<baz<biz>>.boz __typeHelper = default(foo.bar<baz<biz>>.boz);
+foo.bar<baz<biz>>.boz __typeHelper = default!;
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (504:12,0 [21] )
 
 Source Location: (36:2,1 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml)
 |foo()|
-Generated Location: (1047:29,6 [5] )
+Generated Location: (1025:29,6 [5] )
 |foo()|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.codegen.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         ((System.Action)(() => {
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml"
-global::System.Object Link = null;
+global::System.Object Link = null!;
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.mappings.txt
@@ -5,21 +5,21 @@ Generated Location: (510:12,22 [4] )
 
 Source Location: (44:1,14 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 |if(link != null) { |
-Generated Location: (1009:29,14 [19] )
+Generated Location: (1010:29,14 [19] )
 |if(link != null) { |
 
 Source Location: (64:1,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 |link|
-Generated Location: (1221:36,34 [4] )
+Generated Location: (1222:36,34 [4] )
 |link|
 
 Source Location: (68:1,38 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 | } else { |
-Generated Location: (1423:43,38 [10] )
+Generated Location: (1424:43,38 [10] )
 | } else { |
 
 Source Location: (92:1,62 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 | }|
-Generated Location: (1654:50,62 [2] )
+Generated Location: (1655:50,62 [2] )
 | }|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         ((System.Action)(() => {
 #nullable restore
 #line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
-global::System.Object Section2 = null;
+global::System.Object Section2 = null!;
 
 #line default
 #line hidden
@@ -20,7 +20,7 @@ global::System.Object Section2 = null;
         ((System.Action)(() => {
 #nullable restore
 #line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
-global::System.Object Section1 = null;
+global::System.Object Section1 = null!;
 
 #line default
 #line hidden
@@ -30,7 +30,7 @@ global::System.Object Section1 = null;
         ((System.Action)(() => {
 #nullable restore
 #line 15 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
-global::System.Object NestedDelegates = null;
+global::System.Object NestedDelegates = null!;
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
@@ -5,40 +5,40 @@ Generated Location: (502:12,22 [8] )
 
 Source Location: (172:10,9 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Section1|
-Generated Location: (756:22,22 [8] )
+Generated Location: (757:22,22 [8] )
 |Section1|
 
 Source Location: (235:14,9 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |NestedDelegates|
-Generated Location: (1010:32,22 [15] )
+Generated Location: (1012:32,22 [15] )
 |NestedDelegates|
 
 Source Location: (2:0,2 [44] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |
     Layout = "_SectionTestLayout.cshtml"
 |
-Generated Location: (1504:49,2 [44] )
+Generated Location: (1507:49,2 [44] )
 |
     Layout = "_SectionTestLayout.cshtml"
 |
 
 Source Location: (123:7,22 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |thing|
-Generated Location: (1797:58,22 [5] )
+Generated Location: (1800:58,22 [5] )
 |thing|
 
 Source Location: (260:15,6 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 | Func<dynamic, object> f = |
-Generated Location: (2182:71,6 [27] )
+Generated Location: (2185:71,6 [27] )
 | Func<dynamic, object> f = |
 
 Source Location: (295:15,41 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |item|
-Generated Location: (2480:79,41 [4] )
+Generated Location: (2483:79,41 [4] )
 |item|
 
 Source Location: (306:15,52 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |; |
-Generated Location: (2731:88,52 [2] )
+Generated Location: (2734:88,52 [2] )
 |; |
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.codegen.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         ((System.Action)(() => {
 #nullable restore
 #line 86 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals.cshtml"
-global::System.Object WriteLiteralsToInHere = null;
+global::System.Object WriteLiteralsToInHere = null!;
 
 #line default
 #line hidden
@@ -20,7 +20,7 @@ global::System.Object WriteLiteralsToInHere = null;
         ((System.Action)(() => {
 #nullable restore
 #line 206 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals.cshtml"
-global::System.Object WriteLiteralsToInHereAlso = null;
+global::System.Object WriteLiteralsToInHereAlso = null!;
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (515:12,22 [21] )
 
 Source Location: (5701:205,9 [25] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals.cshtml)
 |WriteLiteralsToInHereAlso|
-Generated Location: (789:22,22 [25] )
+Generated Location: (790:22,22 [25] )
 |WriteLiteralsToInHereAlso|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_DesignTime.codegen.cs
@@ -27,7 +27,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ((System.Action)(() => {
 #nullable restore
 #line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml"
-global::System.Object MySection = null;
+global::System.Object MySection = null!;
 
 #line default
 #line hidden
@@ -37,7 +37,7 @@ global::System.Object MySection = null;
         ((System.Action)(() => {
 #nullable restore
 #line 15 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml"
-global::System.Object nestedsection = null;
+global::System.Object nestedsection = null!;
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_DesignTime.mappings.txt
@@ -10,30 +10,30 @@ Generated Location: (1381:29,22 [9] )
 
 Source Location: (388:14,13 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml)
 |nestedsection|
-Generated Location: (1647:39,22 [13] )
+Generated Location: (1648:39,22 [13] )
 |nestedsection|
 
 Source Location: (37:2,2 [31] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml)
 |
     var code = "some code";
 |
-Generated Location: (2150:56,2 [31] )
+Generated Location: (2152:56,2 [31] )
 |
     var code = "some code";
 |
 
 Source Location: (313:10,56 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml)
 |code|
-Generated Location: (2477:65,56 [4] )
+Generated Location: (2479:65,56 [4] )
 |code|
 
 Source Location: (157:8,51 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml)
 |DateTime.Now|
-Generated Location: (2989:75,51 [12] )
+Generated Location: (2991:75,51 [12] )
 |DateTime.Now|
 
 Source Location: (203:8,97 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml)
 |DateTime.Now|
-Generated Location: (3340:83,97 [12] )
+Generated Location: (3342:83,97 [12] )
 |DateTime.Now|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentImports/_Imports.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentImports/_Imports.codegen.cs
@@ -30,7 +30,7 @@ using System.Reflection;
         ((System.Action)(() => {
 #nullable restore
 #line 4 "x:\dir\subdir\Test\_Imports.razor"
-MainLayout __typeHelper = default(MainLayout);
+MainLayout __typeHelper = default!;
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentImports/_Imports.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentImports/_Imports.mappings.txt
@@ -15,6 +15,6 @@ Generated Location: (841:32,0 [10] )
 
 Source Location: (69:4,1 [3] x:\dir\subdir\Test\_Imports.razor)
 |Foo|
-Generated Location: (1292:49,6 [3] )
+Generated Location: (1281:49,6 [3] )
 |Foo|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.codegen.cs
@@ -21,7 +21,7 @@ using Microsoft.AspNetCore.Components;
         ((System.Action)(() => {
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
-global::System.Object TItem1 = null;
+global::System.Object TItem1 = null!;
 
 #line default
 #line hidden
@@ -31,7 +31,7 @@ global::System.Object TItem1 = null;
         ((System.Action)(() => {
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
-global::System.Object TItem2 = null;
+global::System.Object TItem2 = null!;
 
 #line default
 #line hidden

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
@@ -10,27 +10,27 @@ Generated Location: (689:23,22 [6] )
 
 Source Location: (71:2,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TItem2|
-Generated Location: (907:33,22 [6] )
+Generated Location: (908:33,22 [6] )
 |TItem2|
 
 Source Location: (98:5,1 [38] x:\dir\subdir\Test\TestComponent.cshtml)
 |foreach (var item2 in Items2)
 {
     |
-Generated Location: (1412:50,1 [38] )
+Generated Location: (1414:50,1 [38] )
 |foreach (var item2 in Items2)
 {
     |
 
 Source Location: (146:8,5 [19] x:\dir\subdir\Test\TestComponent.cshtml)
 |ChildContent(item2)|
-Generated Location: (1578:59,6 [19] )
+Generated Location: (1580:59,6 [19] )
 |ChildContent(item2)|
 
 Source Location: (176:9,8 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |
 }|
-Generated Location: (1729:66,8 [3] )
+Generated Location: (1731:66,8 [3] )
 |
 }|
 
@@ -40,7 +40,7 @@ Source Location: (188:11,7 [185] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter] public List<TItem2> Items2 { get; set; }
     [Parameter] public RenderFragment<TItem2> ChildContent { get; set; }
 |
-Generated Location: (1911:76,7 [185] )
+Generated Location: (1913:76,7 [185] )
 |
     [Parameter] public TItem1 Item1 { get; set; }
     [Parameter] public List<TItem2> Items2 { get; set; }


### PR DESCRIPTION
- Directives utilize helpers to add to colorization errors, etc. in Razor files. These helpers typically look like `MyType __something = default(MyType)`. The issue with this approach is that `default(MyType)` can be `null` yet `MyType` is a non-nullable type. To workaround this restriction I added nulllability forgiveness operators to the type and member directive tokens (the only two that could possibly generate `null` based output).
- Updated baselines to reflect new forgiveness operator.

aspnet/AspNetCore#10919
aspnet/AspNetCore#11478