### PR TITLE
Prevent StackOverflows when assemblies have recursive references

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/AssemblyItem.cs
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/AssemblyItem.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
     {
         public string Path { get; set; }
 
-        public bool IsSystemReference { get; set; }
+        public bool IsFrameworkReference { get; set; }
 
         public string AssemblyName { get; set; }
     }

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/FindAssembliesWithReferencesTo.cs
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/FindAssembliesWithReferencesTo.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                 referenceItems.Add(new AssemblyItem
                 {
                     AssemblyName = assemblyName,
-                    IsSystemReference = item.GetMetadata("IsSystemReference") == "true",
+                    IsFrameworkReference = item.GetMetadata("IsFrameworkReference") == "true",
                     Path = item.ItemSpec,
                 });
             }

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/ReferenceResolver.cs
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/ReferenceResolver.cs
@@ -18,19 +18,22 @@ namespace Microsoft.AspNetCore.Razor.Tasks
     {
         private readonly HashSet<string> _mvcAssemblies;
         private readonly IReadOnlyList<AssemblyItem> _assemblyItems;
-        private readonly Dictionary<AssemblyItem, Classification> _classifications = new Dictionary<AssemblyItem, Classification>();
+        private readonly Dictionary<AssemblyItem, Classification> _classifications;
 
         public ReferenceResolver(IReadOnlyList<string> targetAssemblies, IReadOnlyList<AssemblyItem> assemblyItems)
         {
             _mvcAssemblies = new HashSet<string>(targetAssemblies, StringComparer.Ordinal);
             _assemblyItems = assemblyItems;
+            _classifications = new Dictionary<AssemblyItem, Classification>();
+
+            Lookup = new Dictionary<string, AssemblyItem>(StringComparer.Ordinal);
             foreach (var item in assemblyItems)
             {
                 Lookup[item.AssemblyName] = item;
             }
         }
 
-        protected Dictionary<string, AssemblyItem> Lookup { get; } = new Dictionary<string, AssemblyItem>(StringComparer.Ordinal);
+        protected Dictionary<string, AssemblyItem> Lookup { get; }
 
         public IReadOnlyList<string> ResolveAssemblies()
         {
@@ -67,7 +70,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                     Classification.IsMvc :
                     Classification.DoesNotReferenceMvc;
             }
-            else if (assemblyItem.IsSystemReference)
+            else if (assemblyItem.IsFrameworkReference)
             {
                 // We do not allow transitive references to MVC via a framework reference to count.
                 // e.g. depending on Microsoft.AspNetCore.SomeThingNewThatDependsOnMvc would not result in an assembly being treated as

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/ReferenceResolverTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/ReferenceResolverTest.cs
@@ -206,7 +206,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
         private class TestReferencesToMvcResolver : ReferenceResolver
         {
-            private readonly Dictionary<string, List<ClassifiedAssemblyItem>> _references = new Dictionary<string, List<ClassifiedAssemblyItem>>();
+            private readonly Dictionary<string, string[]> _references = new Dictionary<string, string[]>();
 
             public TestReferencesToMvcResolver(AssemblyItem[] referenceItems)
                 : base(MvcAssemblies, referenceItems)
@@ -215,18 +215,17 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
             public void Add(string assembly, params string[] references)
             {
-                var assemblyItems = references.Select(r => Lookup[r]).ToList();
-                _references[assembly] = assemblyItems;
+                _references.Add(assembly, references);
             }
 
-            protected override IReadOnlyList<ClassifiedAssemblyItem> GetReferences(string file)
+            protected override IReadOnlyList<AssemblyItem> GetReferences(string file)
             {
                 if (_references.TryGetValue(file, out var result))
                 {
-                    return result;
+                    return result.Select(r => Lookup[r]).ToArray();
                 }
 
-                return Array.Empty<ClassifiedAssemblyItem>();
+                return Array.Empty<AssemblyItem>();
             }
         }
     }

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/ReferenceResolverTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/ReferenceResolverTest.cs
@@ -59,13 +59,13 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             var resolver = new TestReferencesToMvcResolver(new[]
             {
                 CreateAssemblyItem("MyApp.Models"),
-                CreateAssemblyItem("Microsoft.AspNetCore.Mvc", isSystemReference: true),
-                CreateAssemblyItem("Microsoft.AspNetCore.Hosting", isSystemReference: true),
-                CreateAssemblyItem("Microsoft.AspNetCore.HttpAbstractions", isSystemReference: true),
-                CreateAssemblyItem("Microsoft.AspNetCore.KestrelHttpServer", isSystemReference: true),
-                CreateAssemblyItem("Microsoft.AspNetCore.StaticFiles", isSystemReference: true),
-                CreateAssemblyItem("Microsoft.Extensions.Primitives", isSystemReference: true),
-                CreateAssemblyItem("System.Net.Http", isSystemReference: true),
+                CreateAssemblyItem("Microsoft.AspNetCore.Mvc", isFrameworkReference: true),
+                CreateAssemblyItem("Microsoft.AspNetCore.Hosting", isFrameworkReference: true),
+                CreateAssemblyItem("Microsoft.AspNetCore.HttpAbstractions", isFrameworkReference: true),
+                CreateAssemblyItem("Microsoft.AspNetCore.KestrelHttpServer", isFrameworkReference: true),
+                CreateAssemblyItem("Microsoft.AspNetCore.StaticFiles", isFrameworkReference: true),
+                CreateAssemblyItem("Microsoft.Extensions.Primitives", isFrameworkReference: true),
+                CreateAssemblyItem("System.Net.Http", isFrameworkReference: true),
                 CreateAssemblyItem("Microsoft.EntityFrameworkCore"),
             });
 
@@ -89,16 +89,16 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             // Arrange
             var resolver = new TestReferencesToMvcResolver(new[]
             {
-                CreateAssemblyItem("Microsoft.AspNetCore.Mvc", isSystemReference: true),
-                CreateAssemblyItem("Microsoft.AspNetCore.Mvc.TagHelpers", isSystemReference: true),
+                CreateAssemblyItem("Microsoft.AspNetCore.Mvc", isFrameworkReference: true),
+                CreateAssemblyItem("Microsoft.AspNetCore.Mvc.TagHelpers", isFrameworkReference: true),
                 CreateAssemblyItem("MyTagHelpers"),
                 CreateAssemblyItem("MyControllers"),
                 CreateAssemblyItem("MyApp.Models"),
-                CreateAssemblyItem("Microsoft.AspNetCore.Hosting", isSystemReference: true),
-                CreateAssemblyItem("Microsoft.AspNetCore.HttpAbstractions", isSystemReference: true),
-                CreateAssemblyItem("Microsoft.AspNetCore.KestrelHttpServer", isSystemReference: true),
-                CreateAssemblyItem("Microsoft.AspNetCore.StaticFiles", isSystemReference: true),
-                CreateAssemblyItem("Microsoft.Extensions.Primitives", isSystemReference: true),
+                CreateAssemblyItem("Microsoft.AspNetCore.Hosting", isFrameworkReference: true),
+                CreateAssemblyItem("Microsoft.AspNetCore.HttpAbstractions", isFrameworkReference: true),
+                CreateAssemblyItem("Microsoft.AspNetCore.KestrelHttpServer", isFrameworkReference: true),
+                CreateAssemblyItem("Microsoft.AspNetCore.StaticFiles", isFrameworkReference: true),
+                CreateAssemblyItem("Microsoft.Extensions.Primitives", isFrameworkReference: true),
                 CreateAssemblyItem("Microsoft.EntityFrameworkCore"),
             });
 
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             {
                 CreateAssemblyItem("MyCMS"),
                 CreateAssemblyItem("MyCMS.Core"),
-                CreateAssemblyItem("Microsoft.AspNetCore.Mvc.ViewFeatures", isSystemReference: true),
+                CreateAssemblyItem("Microsoft.AspNetCore.Mvc.ViewFeatures", isFrameworkReference: true),
             });
 
             resolver.Add("MyCMS", "MyCMS.Core");
@@ -150,7 +150,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                 CreateAssemblyItem("ReachFramework"),
                 CreateAssemblyItem("MyCMS"),
                 CreateAssemblyItem("MyCMS.Core"),
-                CreateAssemblyItem("Microsoft.AspNetCore.Mvc.ViewFeatures", isSystemReference: true),
+                CreateAssemblyItem("Microsoft.AspNetCore.Mvc.ViewFeatures", isFrameworkReference: true),
             });
 
             resolver.Add("PresentationFramework", "ReachFramework");
@@ -177,7 +177,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                 CreateAssemblyItem("ReachFramework"),
                 CreateAssemblyItem("MyCMS"),
                 CreateAssemblyItem("MyCMS.Core"),
-                CreateAssemblyItem("Microsoft.AspNetCore.Mvc.ViewFeatures", isSystemReference: true),
+                CreateAssemblyItem("Microsoft.AspNetCore.Mvc.ViewFeatures", isFrameworkReference: true),
             });
 
             resolver.Add("MyCoolLibrary", "PresentationFramework");
@@ -194,12 +194,12 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             Assert.Equal(new[] { "MyCMS", "MyCMS.Core", "MyCoolLibrary", "PresentationFramework", "ReachFramework" }, assemblies.OrderBy(a => a));
         }
 
-        public AssemblyItem CreateAssemblyItem(string name, bool isSystemReference = false)
+        public AssemblyItem CreateAssemblyItem(string name, bool isFrameworkReference = false)
         {
             return new AssemblyItem
             {
                 AssemblyName = name,
-                IsSystemReference = isSystemReference,
+                IsFrameworkReference = isFrameworkReference,
                 Path = name,
             };
         }


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore/issues/12693

#### Description

Building a project that references the WebSDK results in StackOverflow if any of it's dependencies have cyclical references. This was observed with a transitive dependency that referenced WPF

#### Customer Impact

Project cannot be built

#### Regression?

Regression compared to 2.x

#### Risk

Low. This code was written assuming references are not cyclical and now adds a guard to prevent this.


