### PR TITLE
Add support for non-numeric CSharpLanguageVersions.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/RazorProjectEngineBuilderExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/RazorProjectEngineBuilderExtensions.cs
@@ -32,12 +32,15 @@ namespace Microsoft.CodeAnalysis.Razor
                 builder.Features.Remove(existingFeature);
             }
 
-            builder.Features.Add(new ConfigureParserForCSharpVersionFeature(csharpLanguageVersion));
+            // This will convert any "latest", "default" or "LatestMajor" LanguageVersions into their numerical equivalent.
+            var effectiveCSharpLanguageVersion = LanguageVersionFacts.MapSpecifiedToEffectiveVersion(csharpLanguageVersion);
+            builder.Features.Add(new ConfigureParserForCSharpVersionFeature(effectiveCSharpLanguageVersion));
 
             return builder;
         }
 
-        private class ConfigureParserForCSharpVersionFeature : IConfigureRazorCodeGenerationOptionsFeature
+        // Internal for testing
+        internal class ConfigureParserForCSharpVersionFeature : IConfigureRazorCodeGenerationOptionsFeature
         {
             public ConfigureParserForCSharpVersionFeature(LanguageVersion csharpLanguageVersion)
             {

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/RazorProjectEngineBuilderExtensionsTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Test/RazorProjectEngineBuilderExtensionsTest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Xunit;
+using static Microsoft.CodeAnalysis.Razor.RazorProjectEngineBuilderExtensions;
+
+namespace Microsoft.CodeAnalysis.Razor
+{
+    public class RazorProjectEngineBuilderExtensionsTest
+    {
+        [Fact]
+        public void SetCSharpLanguageVersion_ResolvesNonNumericCSharpLangVersions()
+        {
+            // Arrange
+            var csharpLanguageVersion = CSharp.LanguageVersion.Latest;
+
+            // Act
+            var projectEngine = RazorProjectEngine.Create(builder =>
+            {
+                builder.SetCSharpLanguageVersion(csharpLanguageVersion);
+            });
+
+            // Assert
+            var feature = projectEngine.EngineFeatures.OfType<ConfigureParserForCSharpVersionFeature>().FirstOrDefault();
+            Assert.NotNull(feature);
+            Assert.NotEqual(csharpLanguageVersion, feature.CSharpLanguageVersion);
+        }
+    }
+}


### PR DESCRIPTION
- We would default to improper C# language versions when given non-numeric `LangVersion`s. For instance when given `CSharpLanguageVersion.Latest` we'd default to 7.3 which was inconsistent with how the rest of the C# world functioned in VS
- Added a test.

aspnet/AspNetCore#11139