### PR TITLE
Update Roslyn dependencies to align with SDK and VS.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -89,12 +89,12 @@
     <MicrosoftBuildFrameworkPackageVersion>15.8.166</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildPackageVersion>15.8.166</MicrosoftBuildPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.8.166</MicrosoftBuildUtilitiesCorePackageVersion>
-    <MicrosoftCodeAnalysisCommonPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCommonPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.0.0-beta4-final</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <MicrosoftCodeAnalysisCommonPackageVersion>3.3.0-beta1-final</MicrosoftCodeAnalysisCommonPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>3.3.0-beta1-final</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.3.0-beta1-final</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <MicrosoftNETCoreApp30PackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreApp30PackageVersion>
     <MicrosoftNETFrameworkReferenceAssemblies>1.0.0-alpha-5</MicrosoftNETFrameworkReferenceAssemblies>
-    <MicrosoftNetRoslynDiagnosticsPackageVersion>2.6.2</MicrosoftNetRoslynDiagnosticsPackageVersion>
+    <MicrosoftNetRoslynDiagnosticsPackageVersion>2.6.3</MicrosoftNetRoslynDiagnosticsPackageVersion>
     <MicrosoftVisualStudioComponentModelHostPackageVersion>16.0.467</MicrosoftVisualStudioComponentModelHostPackageVersion>
     <MicrosoftVisualStudioImageCatalogPackageVersion>16.0.28727</MicrosoftVisualStudioImageCatalogPackageVersion>
     <MicrosoftVisualStudioEditorPackageVersion>16.0.467</MicrosoftVisualStudioEditorPackageVersion>
@@ -125,17 +125,18 @@
     <TEST_NewtonsoftJsonPackageVersion>11.0.1</TEST_NewtonsoftJsonPackageVersion>
     <StreamJsonRpcPackageVersion>2.0.167</StreamJsonRpcPackageVersion>
     <VSIX_MicrosoftVisualStudioTelemetryPackageVersion>16.0.4-master</VSIX_MicrosoftVisualStudioTelemetryPackageVersion>
-    <VSIX_MicrosoftCodeAnalysisPackageVersion>3.2.0-beta2-19277-03</VSIX_MicrosoftCodeAnalysisPackageVersion>
-    <VSIX_MicrosoftCodeAnalysisCommonPackageVersion>3.2.0-beta2-19277-03</VSIX_MicrosoftCodeAnalysisCommonPackageVersion>
-    <VSIX_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>3.2.0-beta2-19277-03</VSIX_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <VSIX_MicrosoftCodeAnalysisCSharpPackageVersion>3.2.0-beta2-19277-03</VSIX_MicrosoftCodeAnalysisCSharpPackageVersion>
-    <VSIX_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.2.0-beta2-19277-03</VSIX_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <VSIX_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>3.2.0-beta2-19277-03</VSIX_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
-    <VSIX_MicrosoftCodeAnalysisRemoteRazorServiceHubPackageVersion>3.2.0-beta2-19277-03</VSIX_MicrosoftCodeAnalysisRemoteRazorServiceHubPackageVersion>
-    <VSIX_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>3.2.0-beta2-19277-03</VSIX_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
-    <VSIX_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.2.0-beta2-19277-03</VSIX_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
-    <VSIX_MicrosoftVisualStudioLanguageServicesPackageVersion>3.2.0-beta2-19277-03</VSIX_MicrosoftVisualStudioLanguageServicesPackageVersion>
-    <VSIX_MicrosoftVisualStudioLanguageServicesRazorRemoteClientPackageVersion>3.2.0-beta2-19277-03</VSIX_MicrosoftVisualStudioLanguageServicesRazorRemoteClientPackageVersion>
+    <VSIX_MicrosoftCodeAnalysisAnalyzersPackageVersion>2.9.4</VSIX_MicrosoftCodeAnalysisAnalyzersPackageVersion>
+    <VSIX_MicrosoftCodeAnalysisPackageVersion>3.3.0-beta2-19328-07</VSIX_MicrosoftCodeAnalysisPackageVersion>
+    <VSIX_MicrosoftCodeAnalysisCommonPackageVersion>3.3.0-beta2-19328-07</VSIX_MicrosoftCodeAnalysisCommonPackageVersion>
+    <VSIX_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>3.3.0-beta2-19328-07</VSIX_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <VSIX_MicrosoftCodeAnalysisCSharpPackageVersion>3.3.0-beta2-19328-07</VSIX_MicrosoftCodeAnalysisCSharpPackageVersion>
+    <VSIX_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.3.0-beta2-19328-07</VSIX_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <VSIX_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>3.3.0-beta2-19328-07</VSIX_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
+    <VSIX_MicrosoftCodeAnalysisRemoteRazorServiceHubPackageVersion>3.3.0-beta2-19328-07</VSIX_MicrosoftCodeAnalysisRemoteRazorServiceHubPackageVersion>
+    <VSIX_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>3.3.0-beta2-19328-07</VSIX_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
+    <VSIX_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.3.0-beta2-19328-07</VSIX_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <VSIX_MicrosoftVisualStudioLanguageServicesPackageVersion>3.3.0-beta2-19328-07</VSIX_MicrosoftVisualStudioLanguageServicesPackageVersion>
+    <VSIX_MicrosoftVisualStudioLanguageServicesRazorRemoteClientPackageVersion>3.3.0-beta2-19328-07</VSIX_MicrosoftVisualStudioLanguageServicesRazorRemoteClientPackageVersion>
     <XunitAnalyzersPackageVersion>0.10.0</XunitAnalyzersPackageVersion>
     <XunitVersion>2.4.1</XunitVersion>
   </PropertyGroup>

--- a/src/Razor/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/ViewComponentTagHelperDescriptorFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/ViewComponentTagHelperDescriptorFactory.cs
@@ -110,11 +110,11 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
             if (string.Equals(selectedMethod.Name, ViewComponentTypes.AsyncMethodName, StringComparison.Ordinal))
             {
                 // Will invoke asynchronously. Method must not return Task or Task<T>.
-                if (returnType == _taskSymbol)
+                if (Equals(returnType, _taskSymbol))
                 {
                     // This is ok.
                 }
-                else if (returnType.IsGenericType && returnType.ConstructedFrom == _genericTaskSymbol)
+                else if (returnType.IsGenericType && Equals(returnType.ConstructedFrom, _genericTaskSymbol))
                 {
                     // This is ok.
                 }
@@ -134,13 +134,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
                     method = null;
                     return false;
                 }
-                else if (returnType == _taskSymbol)
+                else if (Equals(returnType, _taskSymbol))
                 {
                     diagnostic = RazorExtensionsDiagnosticFactory.CreateViewComponent_SyncMethod_CannotReturnTask(type.ToDisplayString(FullNameTypeDisplayFormat));
                     method = null;
                     return false;
                 }
-                else if (returnType.IsGenericType && returnType.ConstructedFrom == _genericTaskSymbol)
+                else if (returnType.IsGenericType && Equals(returnType.ConstructedFrom, _genericTaskSymbol))
                 {
                     diagnostic = RazorExtensionsDiagnosticFactory.CreateViewComponent_SyncMethod_CannotReturnTask(type.ToDisplayString(FullNameTypeDisplayFormat));
                     method = null;
@@ -208,13 +208,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
         private string GetIndexerValueTypeName(IParameterSymbol parameter)
         {
             INamedTypeSymbol dictionaryType;
-            if ((parameter.Type as INamedTypeSymbol)?.ConstructedFrom == _iDictionarySymbol)
+            if (Equals((parameter.Type as INamedTypeSymbol)?.ConstructedFrom, _iDictionarySymbol))
             {
                 dictionaryType = (INamedTypeSymbol)parameter.Type;
             }
-            else if (parameter.Type.AllInterfaces.Any(s => s.ConstructedFrom == _iDictionarySymbol))
+            else if (parameter.Type.AllInterfaces.Any(s => Equals(s.ConstructedFrom, _iDictionarySymbol)))
             {
-                dictionaryType = parameter.Type.AllInterfaces.First(s => s.ConstructedFrom == _iDictionarySymbol);
+                dictionaryType = parameter.Type.AllInterfaces.First(s => Equals(s.ConstructedFrom, _iDictionarySymbol));
             }
             else
             {
@@ -234,7 +234,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
 
         private string GetShortName(INamedTypeSymbol componentType)
         {
-            var viewComponentAttribute = componentType.GetAttributes().Where(a => a.AttributeClass == _viewComponentAttributeSymbol).FirstOrDefault();
+            var viewComponentAttribute = componentType.GetAttributes().Where(a => Equals(a.AttributeClass, _viewComponentAttributeSymbol)).FirstOrDefault();
             var name = viewComponentAttribute
                 ?.NamedArguments
                 .Where(namedArgument => string.Equals(namedArgument.Key, ViewComponentTypes.ViewComponent.Name, StringComparison.Ordinal))

--- a/src/Razor/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/ViewComponentTypeVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/ViewComponentTypeVisitor.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
                 return false;
             }
 
-            var attribute = type.GetAttributes().Where(a => a.AttributeClass == queryAttribute).FirstOrDefault();
+            var attribute = type.GetAttributes().Where(a => Equals(a.AttributeClass, queryAttribute)).FirstOrDefault();
 
             if (attribute != null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/ViewComponentTagHelperDescriptorFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/ViewComponentTagHelperDescriptorFactory.cs
@@ -104,11 +104,11 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X
             if (string.Equals(selectedMethod.Name, ViewComponentTypes.AsyncMethodName, StringComparison.Ordinal))
             {
                 // Will invoke asynchronously. Method must not return Task or Task<T>.
-                if (returnType == _taskSymbol)
+                if (Equals(returnType, _taskSymbol))
                 {
                     // This is ok.
                 }
-                else if (returnType.IsGenericType && returnType.ConstructedFrom == _genericTaskSymbol)
+                else if (returnType.IsGenericType && Equals(returnType.ConstructedFrom, _genericTaskSymbol))
                 {
                     // This is ok.
                 }
@@ -128,13 +128,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X
                     method = null;
                     return false;
                 }
-                else if (returnType == _taskSymbol)
+                else if (Equals(returnType, _taskSymbol))
                 {
                     diagnostic = RazorExtensionsDiagnosticFactory.CreateViewComponent_SyncMethod_CannotReturnTask(type.ToDisplayString(FullNameTypeDisplayFormat));
                     method = null;
                     return false;
                 }
-                else if (returnType.IsGenericType && returnType.ConstructedFrom == _genericTaskSymbol)
+                else if (returnType.IsGenericType && Equals(returnType.ConstructedFrom, _genericTaskSymbol))
                 {
                     diagnostic = RazorExtensionsDiagnosticFactory.CreateViewComponent_SyncMethod_CannotReturnTask(type.ToDisplayString(FullNameTypeDisplayFormat));
                     method = null;
@@ -223,13 +223,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X
         private string GetIndexerValueTypeName(IParameterSymbol parameter)
         {
             INamedTypeSymbol dictionaryType;
-            if ((parameter.Type as INamedTypeSymbol)?.ConstructedFrom == _iDictionarySymbol)
+            if (Equals((parameter.Type as INamedTypeSymbol)?.ConstructedFrom, _iDictionarySymbol))
             {
                 dictionaryType = (INamedTypeSymbol)parameter.Type;
             }
-            else if (parameter.Type.AllInterfaces.Any(s => s.ConstructedFrom == _iDictionarySymbol))
+            else if (parameter.Type.AllInterfaces.Any(s => Equals(s.ConstructedFrom, _iDictionarySymbol)))
             {
-                dictionaryType = parameter.Type.AllInterfaces.First(s => s.ConstructedFrom == _iDictionarySymbol);
+                dictionaryType = parameter.Type.AllInterfaces.First(s => Equals(s.ConstructedFrom, _iDictionarySymbol));
             }
             else
             {
@@ -249,7 +249,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X
 
         private string GetShortName(INamedTypeSymbol componentType)
         {
-            var viewComponentAttribute = componentType.GetAttributes().Where(a => a.AttributeClass == _viewComponentAttributeSymbol).FirstOrDefault();
+            var viewComponentAttribute = componentType.GetAttributes().Where(a => Equals(a.AttributeClass, _viewComponentAttributeSymbol)).FirstOrDefault();
             var name = viewComponentAttribute
                 ?.NamedArguments
                 .Where(namedArgument => string.Equals(namedArgument.Key, ViewComponentTypes.ViewComponent.Name, StringComparison.Ordinal))

--- a/src/Razor/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/ViewComponentTypeVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/ViewComponentTypeVisitor.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X
                 return false;
             }
 
-            var attribute = type.GetAttributes().Where(a => a.AttributeClass == queryAttribute).FirstOrDefault();
+            var attribute = type.GetAttributes().Where(a => Equals(a.AttributeClass, queryAttribute)).FirstOrDefault();
 
             if (attribute != null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ViewComponentTagHelperDescriptorFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ViewComponentTagHelperDescriptorFactory.cs
@@ -104,11 +104,11 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             if (string.Equals(selectedMethod.Name, ViewComponentTypes.AsyncMethodName, StringComparison.Ordinal))
             {
                 // Will invoke asynchronously. Method must not return Task or Task<T>.
-                if (returnType == _taskSymbol)
+                if (Equals(returnType, _taskSymbol))
                 {
                     // This is ok.
                 }
-                else if (returnType.IsGenericType && returnType.ConstructedFrom == _genericTaskSymbol)
+                else if (returnType.IsGenericType && Equals(returnType.ConstructedFrom, _genericTaskSymbol))
                 {
                     // This is ok.
                 }
@@ -128,13 +128,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                     method = null;
                     return false;
                 }
-                else if (returnType == _taskSymbol)
+                else if (Equals(returnType, _taskSymbol))
                 {
                     diagnostic = RazorExtensionsDiagnosticFactory.CreateViewComponent_SyncMethod_CannotReturnTask(type.ToDisplayString(FullNameTypeDisplayFormat));
                     method = null;
                     return false;
                 }
-                else if (returnType.IsGenericType && returnType.ConstructedFrom == _genericTaskSymbol)
+                else if (returnType.IsGenericType && Equals(returnType.ConstructedFrom, _genericTaskSymbol))
                 {
                     diagnostic = RazorExtensionsDiagnosticFactory.CreateViewComponent_SyncMethod_CannotReturnTask(type.ToDisplayString(FullNameTypeDisplayFormat));
                     method = null;
@@ -223,13 +223,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
         private string GetIndexerValueTypeName(IParameterSymbol parameter)
         {
             INamedTypeSymbol dictionaryType;
-            if ((parameter.Type as INamedTypeSymbol)?.ConstructedFrom == _iDictionarySymbol)
+            if (Equals((parameter.Type as INamedTypeSymbol)?.ConstructedFrom, _iDictionarySymbol))
             {
                 dictionaryType = (INamedTypeSymbol)parameter.Type;
             }
-            else if (parameter.Type.AllInterfaces.Any(s => s.ConstructedFrom == _iDictionarySymbol))
+            else if (parameter.Type.AllInterfaces.Any(s => Equals(s.ConstructedFrom, _iDictionarySymbol)))
             {
-                dictionaryType = parameter.Type.AllInterfaces.First(s => s.ConstructedFrom == _iDictionarySymbol);
+                dictionaryType = parameter.Type.AllInterfaces.First(s => Equals(s.ConstructedFrom, _iDictionarySymbol));
             }
             else
             {
@@ -249,7 +249,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 
         private string GetShortName(INamedTypeSymbol componentType)
         {
-            var viewComponentAttribute = componentType.GetAttributes().Where(a => a.AttributeClass == _viewComponentAttributeSymbol).FirstOrDefault();
+            var viewComponentAttribute = componentType.GetAttributes().Where(a => Equals(a.AttributeClass, _viewComponentAttributeSymbol)).FirstOrDefault();
             var name = viewComponentAttribute
                 ?.NamedArguments
                 .Where(namedArgument => string.Equals(namedArgument.Key, ViewComponentTypes.ViewComponent.Name, StringComparison.Ordinal))

--- a/src/Razor/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ViewComponentTypeVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ViewComponentTypeVisitor.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                 return false;
             }
 
-            var attribute = type.GetAttributes().Where(a => a.AttributeClass == queryAttribute).FirstOrDefault();
+            var attribute = type.GetAttributes().Where(a => Equals(a.AttributeClass, queryAttribute)).FirstOrDefault();
 
             if (attribute != null)
             {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/BindTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/BindTagHelperDescriptorProvider.cs
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.Razor
 
                     // We need to check the constructor argument length here, because this can show up as 0
                     // if the language service fails to initialize. This is an invalid case, so skip it.
-                    if (attribute.AttributeClass == bindElement && attribute.ConstructorArguments.Length == 4)
+                    if (Equals(attribute.AttributeClass, bindElement) && attribute.ConstructorArguments.Length == 4)
                     {
                         results.Add(new ElementBindData(
                             type.ContainingAssembly.Name,
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.Razor
                             (string)attribute.ConstructorArguments[2].Value,
                             (string)attribute.ConstructorArguments[3].Value));
                     }
-                    else if (attribute.AttributeClass == bindInputElement && attribute.ConstructorArguments.Length == 4)
+                    else if (Equals(attribute.AttributeClass, bindInputElement) && attribute.ConstructorArguments.Length == 4)
                     {
                         results.Add(new ElementBindData(
                             type.ContainingAssembly.Name,
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.Razor
                             (string)attribute.ConstructorArguments[2].Value,
                             (string)attribute.ConstructorArguments[3].Value));
                     }
-                    else if (attribute.AttributeClass == bindInputElement && attribute.ConstructorArguments.Length == 6)
+                    else if (Equals(attribute.AttributeClass, bindInputElement) && attribute.ConstructorArguments.Length == 6)
                     {
                         results.Add(new ElementBindData(
                             type.ContainingAssembly.Name,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/ComponentTagHelperDescriptorProvider.cs
@@ -342,7 +342,7 @@ namespace Microsoft.CodeAnalysis.Razor
             var properties = new Dictionary<string, (IPropertySymbol, PropertyKind)>(StringComparer.Ordinal);
             do
             {
-                if (type == symbols.ComponentBase)
+                if (Equals(type, symbols.ComponentBase))
                 {
                     // The ComponentBase base class doesn't have any [Parameter].
                     // Bail out now to avoid walking through its many members, plus the members
@@ -384,7 +384,7 @@ namespace Microsoft.CodeAnalysis.Razor
                         kind = PropertyKind.Ignored;
                     }
 
-                    if (!property.GetAttributes().Any(a => a.AttributeClass == symbols.ParameterAttribute))
+                    if (!property.GetAttributes().Any(a => Equals(a.AttributeClass, symbols.ParameterAttribute)))
                     {
                         if (property.IsOverride)
                         {
@@ -402,7 +402,7 @@ namespace Microsoft.CodeAnalysis.Razor
                         kind = PropertyKind.Enum;
                     }
 
-                    if (kind == PropertyKind.Default && property.Type == symbols.RenderFragment)
+                    if (kind == PropertyKind.Default && Equals(property.Type, symbols.RenderFragment))
                     {
                         kind = PropertyKind.ChildContent;
                     }
@@ -410,12 +410,12 @@ namespace Microsoft.CodeAnalysis.Razor
                     if (kind == PropertyKind.Default &&
                         property.Type is INamedTypeSymbol namedType &&
                         namedType.IsGenericType &&
-                        namedType.ConstructedFrom == symbols.RenderFragmentOfT)
+                        Equals(namedType.ConstructedFrom, symbols.RenderFragmentOfT))
                     {
                         kind = PropertyKind.ChildContent;
                     }
 
-                    if (kind == PropertyKind.Default && property.Type == symbols.EventCallback)
+                    if (kind == PropertyKind.Default && Equals(property.Type, symbols.EventCallback))
                     {
                         kind = PropertyKind.EventCallback;
                     }
@@ -423,7 +423,7 @@ namespace Microsoft.CodeAnalysis.Razor
                     if (kind == PropertyKind.Default &&
                         property.Type is INamedTypeSymbol namedType2 &&
                         namedType2.IsGenericType &&
-                        namedType2.ConstructedFrom == symbols.EventCallbackOfT)
+                        Equals(namedType2.ConstructedFrom, symbols.EventCallbackOfT))
                     {
                         kind = PropertyKind.EventCallback;
                     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/DefaultTagHelperDescriptorFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/DefaultTagHelperDescriptorFactory.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Razor
         {
             var targetElementAttributes = type
                 .GetAttributes()
-                .Where(attribute => attribute.AttributeClass == _htmlTargetElementAttributeSymbol);
+                .Where(attribute => Equals(attribute.AttributeClass, _htmlTargetElementAttributeSymbol));
 
             // If there isn't an attribute specifying the tag name derive it from the name
             if (!targetElementAttributes.Any())
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Razor
 
         private void AddAllowedChildren(INamedTypeSymbol type, TagHelperDescriptorBuilder builder)
         {
-            var restrictChildrenAttribute = type.GetAttributes().Where(a => a.AttributeClass == _restrictChildrenAttributeSymbol).FirstOrDefault();
+            var restrictChildrenAttribute = type.GetAttributes().Where(a => Equals(a.AttributeClass, _restrictChildrenAttributeSymbol)).FirstOrDefault();
             if (restrictChildrenAttribute == null)
             {
                 return;
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Razor
         private void AddTagOutputHint(INamedTypeSymbol type, TagHelperDescriptorBuilder builder)
         {
             string outputElementHint = null;
-            var outputElementHintAttribute = type.GetAttributes().Where(a => a.AttributeClass == _outputElementHintAttributeSymbol).FirstOrDefault();
+            var outputElementHintAttribute = type.GetAttributes().Where(a => Equals(a.AttributeClass, _outputElementHintAttributeSymbol)).FirstOrDefault();
             if (outputElementHintAttribute != null)
             {
                 outputElementHint = (string)(outputElementHintAttribute.ConstructorArguments[0]).Value;
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.Razor
         {
             var attributeNameAttribute = property
                 .GetAttributes()
-                .Where(a => a.AttributeClass == _htmlAttributeNameAttributeSymbol)
+                .Where(a => Equals(a.AttributeClass, _htmlAttributeNameAttributeSymbol))
                 .FirstOrDefault();
 
             bool hasExplicitName;
@@ -310,13 +310,13 @@ namespace Microsoft.CodeAnalysis.Razor
         private IReadOnlyList<ITypeSymbol> GetDictionaryArgumentTypes(IPropertySymbol property)
         {
             INamedTypeSymbol dictionaryType;
-            if ((property.Type as INamedTypeSymbol)?.ConstructedFrom == _iDictionarySymbol)
+            if (Equals((property.Type as INamedTypeSymbol)?.ConstructedFrom, _iDictionarySymbol))
             {
                 dictionaryType = (INamedTypeSymbol)property.Type;
             }
-            else if (property.Type.AllInterfaces.Any(s => s.ConstructedFrom == _iDictionarySymbol))
+            else if (property.Type.AllInterfaces.Any(s => Equals(s.ConstructedFrom, _iDictionarySymbol)))
             {
-                dictionaryType = property.Type.AllInterfaces.First(s => s.ConstructedFrom == _iDictionarySymbol);
+                dictionaryType = property.Type.AllInterfaces.First(s => Equals(s.ConstructedFrom, _iDictionarySymbol));
             }
             else
             {
@@ -380,7 +380,7 @@ namespace Microsoft.CodeAnalysis.Razor
         private bool IsPotentialDictionaryProperty(IPropertySymbol property)
         {
             return
-                ((property.Type as INamedTypeSymbol)?.ConstructedFrom == _iDictionarySymbol || property.Type.AllInterfaces.Any(s => s.ConstructedFrom == _iDictionarySymbol)) &&
+                (Equals((property.Type as INamedTypeSymbol)?.ConstructedFrom, _iDictionarySymbol) || property.Type.AllInterfaces.Any(s => Equals(s.ConstructedFrom, _iDictionarySymbol))) &&
                 GetDictionaryArgumentTypes(property)?[0].SpecialType == SpecialType.System_String;
         }
 
@@ -397,8 +397,8 @@ namespace Microsoft.CodeAnalysis.Razor
                         property.Parameters.Length == 0 &&
                         property.GetMethod != null &&
                         property.GetMethod.DeclaredAccessibility == Accessibility.Public &&
-                        property.GetAttributes().Where(a => a.AttributeClass == _htmlAttributeNotBoundAttributeSymbol).FirstOrDefault() == null &&
-                        (property.GetAttributes().Any(a => a.AttributeClass == _htmlAttributeNameAttributeSymbol) ||
+                        property.GetAttributes().Where(a => Equals(a.AttributeClass, _htmlAttributeNotBoundAttributeSymbol)).FirstOrDefault() == null &&
+                        (property.GetAttributes().Any(a => Equals(a.AttributeClass, _htmlAttributeNameAttributeSymbol)) ||
                         property.SetMethod != null && property.SetMethod.DeclaredAccessibility == Accessibility.Public ||
                         IsPotentialDictionaryProperty(property)) &&
                         !accessibleProperties.ContainsKey(property.Name))
@@ -418,7 +418,7 @@ namespace Microsoft.CodeAnalysis.Razor
         {
             if (ExcludeHidden)
             {
-                var editorBrowsableAttribute = symbol.GetAttributes().Where(a => a.AttributeClass == _editorBrowsableAttributeSymbol).FirstOrDefault();
+                var editorBrowsableAttribute = symbol.GetAttributes().Where(a => Equals(a.AttributeClass, _editorBrowsableAttributeSymbol)).FirstOrDefault();
 
                 if (editorBrowsableAttribute == null)
                 {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/EventHandlerTagHelperDescriptorProvider.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Razor
                 {
                     var attribute = attributes[j];
 
-                    if (attribute.AttributeClass == eventHandlerAttribute)
+                    if (Equals(attribute.AttributeClass, eventHandlerAttribute))
                     {
                         results.Add(new EventHandlerData(
                             type.ContainingAssembly.Name,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(VSIX_MicrosoftCodeAnalysisPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(VSIX_MicrosoftCodeAnalysisAnalyzersPackageVersion)" NoWarn="NU1608" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(VSIX_MicrosoftCodeAnalysisCommonPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(VSIX_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(VSIX_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -98,6 +98,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(VSIX_MicrosoftCodeAnalysisAnalyzersPackageVersion)" NoWarn="NU1608" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150PackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="$(MicrosoftVisualStudioSDKAnalyzersVersion)" PrivateAssets="all" />

--- a/src/Razor/src/RazorDeveloperTools/RazorDeveloperTools.csproj
+++ b/src/Razor/src/RazorDeveloperTools/RazorDeveloperTools.csproj
@@ -94,6 +94,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(VSIX_MicrosoftCodeAnalysisAnalyzersPackageVersion)" NoWarn="NU1608" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150PackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="$(MicrosoftVisualStudioSDKAnalyzersVersion)" PrivateAssets="all" />

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
@@ -36,6 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(VSIX_MicrosoftCodeAnalysisAnalyzersPackageVersion)" NoWarn="NU1608" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(VSIX_MicrosoftCodeAnalysisCommonPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(VSIX_MicrosoftCodeAnalysisCSharpPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(VSIX_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />


### PR DESCRIPTION
- Updated instances of our code to no longer use reference type checks on `ISymbol`s. This was a new restriction added by Roslyn [here](https://github.com/dotnet/roslyn-analyzers/issues/2084). We also have a follow up AspNetCore issue [here](https://github.com/aspnet/AspNetCore/issues/12747) to bring these level of changes to AspNetCore.
- Had to pin `Microsoft.CodeAnalysis.Analyzers` in our VSIX projects in order to workaround version conflicts of `Microsoft.CodeAnalysis.Analyzers`. The version conflict is introduced from our dependency on `Microsoft.VisualStudio.ProjectSystem.Managed.VS`. It transitively depends on `Microsoft.CodeAnalysis.Analyzers` `2.6.3` where as our latest Roslyn bits transitively depend on `Microsoft.CodeAnlalysis.Analyzers` `2.9.4`. Tried updating to the latest, private, `Microsoft.VisualStudio.ProjectSystem.Managed.VS` but it also had the version conflict.
- Pinned our runtime bits to the latest public Roslyn NuGet package and pinned our tooling bits to the latest private NuGet package (both are compatible flavors of 3.3.0).

Thought i'd do this sooner than later to get us running on more RTM equivalent bits. Would rather find catastrophic failures earlier rather than later.

@pranavkm I assume this will be "ok" for runtime compilation as well?
