### PR TITLE
Require public component parameters and remove private metadata workaround

### DIFF
--- a/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -4574,7 +4574,7 @@ namespace Test
 {
     public class MyComponent : ComponentBase
     {
-        [Parameter] public string Message { get; private set; }
+        [Parameter] public string Message { get; set; }
     }
 }
 "));
@@ -4603,7 +4603,7 @@ namespace Test
 {
     public class MyComponent : ComponentBase
     {
-        [Parameter] public string Message { get; private set; }
+        [Parameter] public string Message { get; set; }
     }
 }
 "));
@@ -4634,7 +4634,7 @@ namespace Test
 {
     public class MyComponent : ComponentBase
     {
-        [Parameter] public string Message { get; private set; }
+        [Parameter] public string Message { get; set; }
     }
 }
 "));
@@ -4664,9 +4664,9 @@ namespace Test
 {
     public class MyComponent : ComponentBase
     {
-        [Parameter] public string Message { get; private set; }
-        [Parameter] public EventCallback<string> MessageChanged { get; private set; }
-        [Parameter] public Expression<Action<string>> MessageExpression { get; private set; }
+        [Parameter] public string Message { get; set; }
+        [Parameter] public EventCallback<string> MessageChanged { get; set; }
+        [Parameter] public Expression<Action<string>> MessageExpression { get; set; }
     }
 }
 "));
@@ -4699,9 +4699,9 @@ namespace Test
 {
     public class MyComponent : ComponentBase
     {
-        [Parameter] public string Message { get; private set; }
-        [Parameter] public EventCallback<string> MessageChanged { get; private set; }
-        [Parameter] public Expression<Action<string>> MessageExpression { get; private set; }
+        [Parameter] public string Message { get; set; }
+        [Parameter] public EventCallback<string> MessageChanged { get; set; }
+        [Parameter] public Expression<Action<string>> MessageExpression { get; set; }
     }
 }
 "));
@@ -4734,9 +4734,9 @@ namespace Test
 {
     public class MyComponent : ComponentBase
     {
-        [Parameter] public string Message { get; private set; }
-        [Parameter] public EventCallback<string> MessageChanged { get; private set; }
-        [Parameter] public Expression<Action<string>> MessageExpression { get; private set; }
+        [Parameter] public string Message { get; set; }
+        [Parameter] public EventCallback<string> MessageChanged { get; set; }
+        [Parameter] public Expression<Action<string>> MessageExpression { get; set; }
     }
 }
 "));


### PR DESCRIPTION
- Prior to this a user could have private, protected or public parameters. We now require public and plan to update analyzers to enforce good usage of public component parameters.
- Removed private `ComponentTagHelperDescriptorProvider` workaround. meta data workaround since we no longer operate on private parameters.
- Updated existing tests to not have private parameter setters. I missed these in my last pass.
- Added two new tests to validate parameters which are private or have private setters are ignored.

aspnet/AspNetCore#12291