### PR TITLE
Make launchSettings.json a content item that does not get copied to b…

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/Sdk/Sdk.Razor.StaticAssets.ProjectSystem.props
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/Sdk/Sdk.Razor.StaticAssets.ProjectSystem.props
@@ -31,8 +31,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Content Include="**\*.config" ExcludeFromSingleFile="true" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
     <Content Include="**\*.json" ExcludeFromSingleFile="true" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
 
-    <!-- Set CopyToOutputDirectory & CopyToPublishDirectory to Never for items under AppDesignerFolder ("Properties", by default) to avoid copying launchSettings.json to the build or publish directory -->
-    <Content Update="$(AppDesignerFolder)\**" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" Condition="'$(AppDesignerFolder)' != ''"/>
+    <!-- Set CopyToPublishDirectory to Never for items under AppDesignerFolder ("Properties", by default) to avoid publishing launchSettings.json -->
+    <Content Update="$(AppDesignerFolder)\**" CopyToPublishDirectory="Never" Condition="'$(AppDesignerFolder)' != ''"/>
 
     <!-- Remove Content items from other item types (in a way that CPS understands) -->
     <None Remove="wwwroot\**;**\*.json;**\*.config" />

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/Sdk/Sdk.Razor.StaticAssets.ProjectSystem.props
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/Sdk/Sdk.Razor.StaticAssets.ProjectSystem.props
@@ -23,7 +23,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultItemExcludes>$(DefaultItemExcludes);**\jspm_packages\**;jspm_packages\**</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**\bower_components\**;bower_components\**</DefaultItemExcludes>
     <DefaultWebContentItemExcludes>$(DefaultWebContentItemExcludes);wwwroot\**</DefaultWebContentItemExcludes>
-    <DefaultWebContentItemExcludes>$(DefaultWebContentItemExcludes);**\launchSettings.json</DefaultWebContentItemExcludes>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true' ">
@@ -32,14 +31,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Content Include="**\*.config" ExcludeFromSingleFile="true" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
     <Content Include="**\*.json" ExcludeFromSingleFile="true" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
 
-    <!-- Set CopyToPublishDirectory to Never for items under AppDesignerFolder ("Properties", by default) to avoid publishing launchSettings.json -->
-    <Content Update="$(AppDesignerFolder)\**" CopyToPublishDirectory="Never" Condition="'$(AppDesignerFolder)' != ''"/>   
+    <!-- Set CopyToOutputDirectory & CopyToPublishDirectory to Never for items under AppDesignerFolder ("Properties", by default) to avoid copying launchSettings.json to the build or publish directory -->
+    <Content Update="$(AppDesignerFolder)\**" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" Condition="'$(AppDesignerFolder)' != ''"/>
 
     <!-- Remove Content items from other item types (in a way that CPS understands) -->
     <None Remove="wwwroot\**;**\*.json;**\*.config" />
     <Compile Remove="wwwroot\**" />
     <EmbeddedResource Remove="wwwroot\**" />
-    
+
     <!-- Keep track of the default content items for later to distinguish them from newly generated content items -->
     <!-- It's important to keep this here so that it works well with the Web SDK -->
     <_ContentIncludedByDefault Include="@(Content)" />

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntrospectionTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntrospectionTest.cs
@@ -202,7 +202,8 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             var result = await DotnetMSBuild("_IntrospectContentItems");
 
             Assert.BuildPassed(result);
-            Assert.BuildOutputContainsLine(result, "Content: Properties\\launchSettings.json CopyToOutputDirectory=Never CopyToPublishDirectory=Never ExcludeFromSingleFile=true");
+            var launchSettingsPath = Path.Combine("Properties", "launchSettings.json");
+            Assert.BuildOutputContainsLine(result, $"Content: {launchSettingsPath} CopyToOutputDirectory=PreserveNewest CopyToPublishDirectory=Never ExcludeFromSingleFile=true");
             Assert.BuildOutputContainsLine(result, "Content: appsettings.json CopyToOutputDirectory=PreserveNewest CopyToPublishDirectory=PreserveNewest ExcludeFromSingleFile=true");
             Assert.BuildOutputContainsLine(result, "Content: appsettings.Development.json CopyToOutputDirectory=PreserveNewest CopyToPublishDirectory=PreserveNewest ExcludeFromSingleFile=true");
         }

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntrospectionTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntrospectionTest.cs
@@ -194,5 +194,17 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.BuildPassed(result);
             Assert.BuildOutputContainsLine(result, "UpToDateReloadFileTypes: ;.cs;.razor;.resx;");
         }
+
+        [Fact]
+        [InitializeTestProject("SimpleMvc")]
+        public async Task IntrospectJsonContentFiles()
+        {
+            var result = await DotnetMSBuild("_IntrospectContentItems");
+
+            Assert.BuildPassed(result);
+            Assert.BuildOutputContainsLine(result, "Content: Properties\\launchSettings.json CopyToOutputDirectory=Never CopyToPublishDirectory=Never ExcludeFromSingleFile=true");
+            Assert.BuildOutputContainsLine(result, "Content: appsettings.json CopyToOutputDirectory=PreserveNewest CopyToPublishDirectory=PreserveNewest ExcludeFromSingleFile=true");
+            Assert.BuildOutputContainsLine(result, "Content: appsettings.Development.json CopyToOutputDirectory=PreserveNewest CopyToPublishDirectory=PreserveNewest ExcludeFromSingleFile=true");
+        }
     }
 }

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/PublishIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/PublishIntegrationTest.cs
@@ -51,7 +51,6 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileExists(result, OutputPath, "SimpleMvc.Views.pdb");
             Assert.FileExists(result, OutputPath, "appsettings.json");
             Assert.FileExists(result, OutputPath, "appsettings.Development.json");
-            Assert.FileDoesNotExist(result, OutputPath, Path.Combine("Properties", "launchSettings.json"));
 
             Assert.FileExists(result, PublishOutputPath, "SimpleMvc.dll");
             Assert.FileExists(result, PublishOutputPath, "SimpleMvc.pdb");

--- a/src/Razor/test/testapps/RazorTest.Introspection.targets
+++ b/src/Razor/test/testapps/RazorTest.Introspection.targets
@@ -42,4 +42,8 @@
   <Target Name="_IntrospectUpToDateReloadFileTypes">
     <Message Text="UpToDateReloadFileTypes: $(UpToDateReloadFileTypes)" Importance="High" />
   </Target>
+
+  <Target Name="_IntrospectContentItems">
+    <Message Text="Content: %(Content.Identity) CopyToOutputDirectory=%(Content.CopyToOutputDirectory) CopyToPublishDirectory=%(Content.CopyToPublishDirectory) ExcludeFromSingleFile=%(Content.ExcludeFromSingleFile)" Importance="High" />
+  </Target>
 </Project>


### PR DESCRIPTION
…uild or publish directory

Fixes https://github.com/aspnet/AspNetCore/issues/12841


-------------------------------------------------------

## Description
`launchSettings.json` a user-editable file was marked as not being a content item. This makes it hidden in VS by default.

## Impact
Unless *Show all files* is set in VS, the file isn't available to edit.

## Regression
This was a regression in 3.0-preview7.

## Risk
Low. This change reverts the behavior back to the state it was in 3.0-preview6 and earlier.

