### PR TITLE
[Static web assets] Enables extensibility to manifest path remapping

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -45,7 +45,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <GenerateStaticWebAssetsManifestDependsOn>
       ResolveStaticWebAssetsInputs;
-      _CreateStaticWebAssetsInputsCacheFile;
+      CreateStaticWebAssetsInputsCacheFile;
       $(GenerateStaticWebAssetsManifestDependsOn)
     </GenerateStaticWebAssetsManifestDependsOn>
 
@@ -78,6 +78,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       _RemoveWebRootContentFromPackaging;
       $(PackDependsOn)
     </PackDependsOn>
+
+    <CreateStaticWebAssetsInputsCacheFileDependsOn>
+      ResolveStaticWebAssetContentRoots;
+      _PrepareForStaticWebAssets;
+      $(CreateStaticWebAssetsInputsCacheFileDependsOn)
+    </CreateStaticWebAssetsInputsCacheFileDependsOn>
 
   </PropertyGroup>
 
@@ -122,24 +128,31 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
 
-  <Target
-    Name="_CreateStaticWebAssetsInputsCacheFile"
-    DependsOnTargets="ResolveStaticWebAssetsInputs;_PrepareForStaticWebAssets">
+  <!--
+  This is the list of inputs that will be used for generating the manifest used during development.
+  -->
 
+  <Target
+    Name="ResolveStaticWebAssetContentRoots"
+    DependsOnTargets="$(ResolveStaticWebAssetContentRootsDependsOn)">
     <ItemGroup>
-      <!--
-      This is the list of inputs that will be used for generating the manifest used during development.
-      -->
-      <_ExternalStaticWebAsset
-        Include="%(StaticWebAsset.Identity)"
+
+      <StaticWebAssetContentRoot
+        Include="%(StaticWebAsset.ContentRoot)"
         Condition="'%(SourceType)' != ''">
           <BasePath>%(StaticWebAsset.BasePath)</BasePath>
-          <ContentRoot>%(StaticWebAsset.ContentRoot)</ContentRoot>
-      </_ExternalStaticWebAsset>
+          <OriginalItemSpec>%(StaticWebAsset.Identity)</OriginalItemSpec>
+      </StaticWebAssetContentRoot>
+
     </ItemGroup>
+  </Target>
+
+  <Target
+    Name="CreateStaticWebAssetsInputsCacheFile"
+    DependsOnTargets="$(CreateStaticWebAssetsInputsCacheFileDependsOn)">
 
     <!-- We need a transform here to make sure we hash the metadata -->
-    <Hash ItemsToHash="@(_ExternalStaticWebAsset->'%(Identity)%(BasePath)%(ContentRoot)')">
+    <Hash ItemsToHash="@(StaticWebAssetContentRoot->'%(OriginalItemSpec)%(BasePath)%(Identity)')">
       <Output TaskParameter="HashResult" PropertyName="_StaticWebAssetsCacheHash" />
     </Hash>
 
@@ -171,15 +184,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     Outputs="$(_GeneratedStaticWebAssetsDevelopmentManifest)"
     DependsOnTargets="$(GenerateStaticWebAssetsManifestDependsOn)">
 
+    <ItemGroup>
+      <_ContentRootDefinitions Include="@(StaticWebAssetContentRoot)">
+        <ContentRoot>%(StaticWebAssetContentRoot.Identity)</ContentRoot>
+      </_ContentRootDefinitions>
+    </ItemGroup>
+
     <GenerateStaticWebAssetsManifest
-      ContentRootDefinitions="@(_ExternalStaticWebAsset)"
+      ContentRootDefinitions="@(_ContentRootDefinitions)"
       TargetManifestPath="$(_GeneratedStaticWebAssetsDevelopmentManifest)" />
 
       <!-- This is the list of inputs that will be used for generating the manifest used during development. -->
     <ItemGroup>
       <Content
         Include="$(_GeneratedStaticWebAssetsDevelopmentManifest)"
-        Condition="'@(_ExternalStaticWebAsset->Count())' != '0'"
+        Condition="'@(StaticWebAssetContentRoot->Count())' != '0'"
         Link="$(TargetName).StaticWebAssets.xml">
 
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Razor/test/testapps/AppWithPackageAndP2PReference/AppWithPackageAndP2PReference.csproj
+++ b/src/Razor/test/testapps/AppWithPackageAndP2PReference/AppWithPackageAndP2PReference.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-  
+
   <PropertyGroup>
     <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
   </PropertyGroup>
@@ -37,6 +37,43 @@
     <!-- In test scenarios $(BinariesRoot) is defined in a generated Directory.Build.props file -->
     <BinariesRoot>$(RepositoryRoot)artifacts\bin\Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib\$(Configuration)\netstandard2.0\</BinariesRoot>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <CreateStaticWebAssetsInputsCacheFileDependsOn>
+      $(CreateStaticWebAssetsInputsCacheFileDependsOn);
+      UpdateContainerPaths
+    </CreateStaticWebAssetsInputsCacheFileDependsOn>
+  </PropertyGroup>
+
+  <Target
+    Name="UpdateContainerPaths"
+    DependsOnTargets="ResolveStaticWebAssetContentRoots"
+    Condition="'$(UpdatePathsForDocker)' == 'true'">
+
+    <PropertyGroup>
+      <!-- This simulates re-mapping the path into a container folder -->
+      <ContainerNugetFolder>/app/packages/</ContainerNugetFolder>
+      <!-- This is normally $(SolutionDir) -->
+      <ContainerSolutionFolder>/app/</ContainerSolutionFolder>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <UpdatedPackageContentRoot
+        Condition="$([System.String]::new('%(StaticWebAssetContentRoot.Identity)').StartsWith('$(PackagesRoot)'))"
+        Include="@(StaticWebAssetContentRoot->'$([System.String]::new('%(Identity)').Replace('$(PackagesRoot)','$(ContainerNugetFolder)').Replace('\','/'))')">
+        <OriginalPath>%(Identity)</OriginalPath>
+      </UpdatedPackageContentRoot>
+
+      <UpdatedPackageContentRoot
+        Condition="$([System.String]::new('%(StaticWebAssetContentRoot.Identity)').StartsWith('$(SolutionFolder)'))"
+        Include="@(StaticWebAssetContentRoot->'$([System.String]::new('%(Identity)').Replace('$(SolutionFolder)','$(ContainerSolutionFolder)').Replace('\','/'))')">
+        <OriginalPath>%(Identity)</OriginalPath>
+      </UpdatedPackageContentRoot>
+
+      <StaticWebAssetContentRoot Remove="@(UpdatedPackageContentRoot->'%(OriginalPath)')" />
+      <StaticWebAssetContentRoot Include="@(UpdatedPackageContentRoot)" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup Condition="'$(BinariesRoot)'!=''">
     <Reference Include="$(BinariesRoot)\Microsoft.AspNetCore.Razor.Test.ComponentShim.dll" />


### PR DESCRIPTION
* Adds a target to resolve the paths.
* Adds a "public" itemgroup containing the paths to generate the manifest.
* Makes the target for generating the cache "public" so that other SDKs can have a chance to adapt the generated paths to the appropriate environment.