### PR TITLE
Fix @inject intellisense

### DIFF
--- a/clean.cmd
+++ b/clean.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+SETLOCAL
+PowerShell -NoProfile -NoLogo -ExecutionPolicy ByPass -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = ''; try { & '%~dp0clean.ps1' %*; exit $LASTEXITCODE } catch { write-host $_; exit 1 }"

--- a/clean.ps1
+++ b/clean.ps1
@@ -1,0 +1,42 @@
+#requires -version 5
+
+<#
+.SYNOPSIS
+Clean this repository.
+
+.DESCRIPTION
+This script cleans this repository interactively, leaving downloaded infrastructure untouched.
+Clean operation is interactive to avoid losing new but unstaged files. Press 'c' then [Enter]
+to perform the proposed deletions.
+
+.EXAMPLE
+Perform default clean operation.
+
+    clean.ps1
+
+.EXAMPLE
+Clean everything but downloaded infrastructure and VS / VS Code folders.
+
+    clean.ps1 -e .vs/ -e .vscode/
+#>
+
+[CmdletBinding(PositionalBinding = $false)]
+param(
+    # Other lifecycle targets
+    [switch]$Help, # Show help
+
+    # Capture the rest
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$GitArguments
+)
+
+Set-StrictMode -Version 2
+$ErrorActionPreference = 'Stop'
+
+if ($Help) {
+    Get-Help $PSCommandPath
+    exit 0
+}
+
+git clean -dix -e .dotnet/ -e .tools/ @GitArguments
+git checkout -- $(git ls-files -d)

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+#
+# Functions
+#
+__usage() {
+    echo "Usage: $(basename "${BASH_SOURCE[0]}") <Arguments>
+
+Arguments:
+    <Arguments>...         Arguments passed to the 'git' command. Any number of arguments allowed.
+
+Description:
+    This script cleans the repository interactively, leaving downloaded infrastructure untouched.
+    Clean operation is interactive to avoid losing new but unstaged files. Press 'c' then [Enter]
+    to perform the proposed deletions.
+"
+}
+
+git_args=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -\?|-h|--help)
+            __usage
+            exit 0
+            ;;
+        *)
+            git_args[${#git_args[*]}]="$1"
+            ;;
+    esac
+    shift
+done
+
+# This incantation avoids unbound variable issues if git_args is empty
+# https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u
+git clean -dix -e .dotnet/ -e .tools/ ${git_args[@]+"${git_args[@]}"}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
@@ -1315,31 +1315,36 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
                         var tokenDescriptor = descriptor.Tokens[i];
                         AcceptWhile(IsSpacingToken(includeNewLines: false, includeComments: true));
+                        var seenWhitespace = TokenBuilder.Count > 0;
 
-                        if (tokenDescriptor.Kind == DirectiveTokenKind.Member ||
-                            tokenDescriptor.Kind == DirectiveTokenKind.Namespace ||
-                            tokenDescriptor.Kind == DirectiveTokenKind.Type ||
-                            tokenDescriptor.Kind == DirectiveTokenKind.Attribute)
+                        if (seenWhitespace)
                         {
-                            SpanContext.ChunkGenerator = SpanChunkGenerator.Null;
-                            SpanContext.EditHandler.AcceptedCharacters = AcceptedCharactersInternal.Whitespace;
-                            directiveBuilder.Add(OutputTokensAsStatementLiteral());
-
-                            if (EndOfFile || At(SyntaxKind.NewLine))
+                            if (tokenDescriptor.Kind == DirectiveTokenKind.Member ||
+                                tokenDescriptor.Kind == DirectiveTokenKind.Namespace ||
+                                tokenDescriptor.Kind == DirectiveTokenKind.Type ||
+                                tokenDescriptor.Kind == DirectiveTokenKind.Attribute)
                             {
-                                // Add a marker token to provide CSharp intellisense when we start typing the directive token.
-                                AcceptMarkerTokenIfNecessary();
-                                SpanContext.ChunkGenerator = new DirectiveTokenChunkGenerator(tokenDescriptor);
-                                SpanContext.EditHandler = new DirectiveTokenEditHandler(Language.TokenizeString);
-                                SpanContext.EditHandler.AcceptedCharacters = AcceptedCharactersInternal.NonWhitespace;
+                                SpanContext.ChunkGenerator = SpanChunkGenerator.Null;
+                                SpanContext.EditHandler.AcceptedCharacters = AcceptedCharactersInternal.Whitespace;
                                 directiveBuilder.Add(OutputTokensAsStatementLiteral());
+
+                                if (EndOfFile || At(SyntaxKind.NewLine))
+                                {
+                                    // Add a marker token to provide CSharp intellisense when we start typing the directive token.
+                                    // We want CSharp intellisense only if there is whitespace after the directive keyword.
+                                    AcceptMarkerTokenIfNecessary();
+                                    SpanContext.ChunkGenerator = new DirectiveTokenChunkGenerator(tokenDescriptor);
+                                    SpanContext.EditHandler = new DirectiveTokenEditHandler(Language.TokenizeString);
+                                    SpanContext.EditHandler.AcceptedCharacters = AcceptedCharactersInternal.NonWhitespace;
+                                    directiveBuilder.Add(OutputTokensAsStatementLiteral());
+                                }
                             }
-                        }
-                        else
-                        {
-                            SpanContext.ChunkGenerator = SpanChunkGenerator.Null;
-                            SpanContext.EditHandler.AcceptedCharacters = AcceptedCharactersInternal.Whitespace;
-                            directiveBuilder.Add(OutputAsMarkupEphemeralLiteral());
+                            else
+                            {
+                                SpanContext.ChunkGenerator = SpanChunkGenerator.Null;
+                                SpanContext.EditHandler.AcceptedCharacters = AcceptedCharactersInternal.Whitespace;
+                                directiveBuilder.Add(OutputAsMarkupEphemeralLiteral());
+                            }
                         }
 
                         if (tokenDescriptor.Optional && (EndOfFile || At(SyntaxKind.NewLine)))

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
@@ -1314,11 +1314,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         }
 
                         var tokenDescriptor = descriptor.Tokens[i];
-                        AcceptWhile(IsSpacingToken(includeNewLines: false, includeComments: true));
-                        var seenWhitespace = TokenBuilder.Count > 0;
 
-                        if (seenWhitespace)
+                        if (At(SyntaxKind.Whitespace))
                         {
+                            AcceptWhile(IsSpacingToken(includeNewLines: false, includeComments: true));
+
                             if (tokenDescriptor.Kind == DirectiveTokenKind.Member ||
                                 tokenDescriptor.Kind == DirectiveTokenKind.Namespace ||
                                 tokenDescriptor.Kind == DirectiveTokenKind.Type ||

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -17,27 +17,7 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
 #nullable restore
-#line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
- 
-
-#line default
-#line hidden
-#nullable disable
-        }
-        ))();
-        ((System.Action)(() => {
-#nullable restore
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
- 
-
-#line default
-#line hidden
-#nullable disable
-        }
-        ))();
-        ((System.Action)(() => {
-#nullable restore
-#line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
  
 
 #line default
@@ -59,26 +39,6 @@ namespace AspNetCore
 #nullable restore
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
 MyService<TModel> __typeHelper = default!;
-
-#line default
-#line hidden
-#nullable disable
-        }
-        ))();
-        ((System.Action)(() => {
-#nullable restore
-#line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
- 
-
-#line default
-#line hidden
-#nullable disable
-        }
-        ))();
-        ((System.Action)(() => {
-#nullable restore
-#line 14 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
- 
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -23,13 +23,9 @@ Document -
                 DirectiveToken - (617:12,14 [96] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.UrlResolutionTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (729:13,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.HeadTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (832:14,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
-                DirectiveToken - (119:6,6 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (128:7,7 [0] IncompleteDirectives.cshtml) - 
-                DirectiveToken - (139:9,7 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (149:10,8 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (159:11,8 [17] IncompleteDirectives.cshtml) - MyService<TModel>
-                DirectiveToken - (176:11,25 [0] IncompleteDirectives.cshtml) - 
-                DirectiveToken - (190:13,10 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (203:14,11 [0] IncompleteDirectives.cshtml) - 
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning disable 0414
@@ -45,7 +41,6 @@ Document -
                 HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)
                     IntermediateToken - (108:4,6 [5] IncompleteDirectives.cshtml) - Html - "\n\n
                 MalformedDirective - (113:6,0 [6] IncompleteDirectives.cshtml) - model
-                    DirectiveToken - (119:6,6 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (119:6,6 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (119:6,6 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (121:7,0 [7] IncompleteDirectives.cshtml) - model
@@ -53,7 +48,6 @@ Document -
                 HtmlContent - (128:7,7 [4] IncompleteDirectives.cshtml)
                     IntermediateToken - (128:7,7 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (132:9,0 [7] IncompleteDirectives.cshtml) - inject
-                    DirectiveToken - (139:9,7 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (139:9,7 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (139:9,7 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (141:10,0 [8] IncompleteDirectives.cshtml) - inject
@@ -62,11 +56,9 @@ Document -
                     IntermediateToken - (149:10,8 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (151:11,0 [25] IncompleteDirectives.cshtml) - inject
                     DirectiveToken - (159:11,8 [17] IncompleteDirectives.cshtml) - MyService<TModel>
-                    DirectiveToken - (176:11,25 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (176:11,25 [4] IncompleteDirectives.cshtml)
                     IntermediateToken - (176:11,25 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (180:13,0 [10] IncompleteDirectives.cshtml) - namespace
-                    DirectiveToken - (190:13,10 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (190:13,10 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (190:13,10 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (192:14,0 [11] IncompleteDirectives.cshtml) - namespace

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -1,40 +1,20 @@
-Source Location: (119:6,6 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+Source Location: (128:7,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
 Generated Location: (786:20,0 [0] )
 ||
 
-Source Location: (128:7,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
-||
-Generated Location: (1014:30,0 [0] )
-||
-
-Source Location: (139:9,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
-||
-Generated Location: (1243:40,0 [0] )
-||
-
 Source Location: (149:10,8 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1472:50,0 [0] )
+Generated Location: (1015:30,0 [0] )
 ||
 
 Source Location: (159:11,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 |MyService<TModel>|
-Generated Location: (1701:60,0 [17] )
+Generated Location: (1244:40,0 [17] )
 |MyService<TModel>|
-
-Source Location: (176:11,25 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
-||
-Generated Location: (1971:70,0 [0] )
-||
-
-Source Location: (190:13,10 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
-||
-Generated Location: (2200:80,0 [0] )
-||
 
 Source Location: (203:14,11 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (2429:90,0 [0] )
+Generated Location: (1514:50,0 [0] )
 ||
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -18,7 +18,6 @@ Document -
                 HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)
                     IntermediateToken - (108:4,6 [5] IncompleteDirectives.cshtml) - Html - "\n\n
                 MalformedDirective - (113:6,0 [6] IncompleteDirectives.cshtml) - model
-                    DirectiveToken - (119:6,6 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (119:6,6 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (119:6,6 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (121:7,0 [7] IncompleteDirectives.cshtml) - model
@@ -26,7 +25,6 @@ Document -
                 HtmlContent - (128:7,7 [4] IncompleteDirectives.cshtml)
                     IntermediateToken - (128:7,7 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (132:9,0 [7] IncompleteDirectives.cshtml) - inject
-                    DirectiveToken - (139:9,7 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (139:9,7 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (139:9,7 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (141:10,0 [8] IncompleteDirectives.cshtml) - inject
@@ -35,11 +33,9 @@ Document -
                     IntermediateToken - (149:10,8 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (151:11,0 [25] IncompleteDirectives.cshtml) - inject
                     DirectiveToken - (159:11,8 [17] IncompleteDirectives.cshtml) - MyService<TModel>
-                    DirectiveToken - (176:11,25 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (176:11,25 [4] IncompleteDirectives.cshtml)
                     IntermediateToken - (176:11,25 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (180:13,0 [10] IncompleteDirectives.cshtml) - namespace
-                    DirectiveToken - (190:13,10 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (190:13,10 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (190:13,10 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (192:14,0 [11] IncompleteDirectives.cshtml) - namespace

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -16,23 +16,7 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
- 
-
-#line default
-#line hidden
-        }
-        ))();
-        ((System.Action)(() => {
 #line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
- 
-
-#line default
-#line hidden
-        }
-        ))();
-        ((System.Action)(() => {
-#line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
  
 
 #line default
@@ -50,14 +34,6 @@ namespace AspNetCore
         ((System.Action)(() => {
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
 MyService<TModel> __typeHelper = default;
-
-#line default
-#line hidden
-        }
-        ))();
-        ((System.Action)(() => {
-#line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
- 
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -21,12 +21,9 @@ Document -
                 DirectiveToken - (507:11,8 [70] ) - global::Microsoft.AspNetCore.Mvc.ViewFeatures.IModelExpressionProvider
                 DirectiveToken - (578:11,79 [23] ) - ModelExpressionProvider
                 DirectiveToken - (617:12,14 [96] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.UrlResolutionTagHelper, Microsoft.AspNetCore.Mvc.Razor
-                DirectiveToken - (93:2,6 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (102:3,7 [0] IncompleteDirectives.cshtml) - 
-                DirectiveToken - (113:5,7 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (123:6,8 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (133:7,8 [17] IncompleteDirectives.cshtml) - MyService<TModel>
-                DirectiveToken - (150:7,25 [0] IncompleteDirectives.cshtml) - 
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning disable 0414
             CSharpCode - 
@@ -37,7 +34,6 @@ Document -
                 HtmlContent - (85:1,0 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (85:1,0 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (87:2,0 [6] IncompleteDirectives.cshtml) - model
-                    DirectiveToken - (93:2,6 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (93:2,6 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (93:2,6 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (95:3,0 [7] IncompleteDirectives.cshtml) - model
@@ -45,7 +41,6 @@ Document -
                 HtmlContent - (102:3,7 [4] IncompleteDirectives.cshtml)
                     IntermediateToken - (102:3,7 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (106:5,0 [7] IncompleteDirectives.cshtml) - inject
-                    DirectiveToken - (113:5,7 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (113:5,7 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (113:5,7 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (115:6,0 [8] IncompleteDirectives.cshtml) - inject
@@ -54,7 +49,6 @@ Document -
                     IntermediateToken - (123:6,8 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (125:7,0 [25] IncompleteDirectives.cshtml) - inject
                     DirectiveToken - (133:7,8 [17] IncompleteDirectives.cshtml) - MyService<TModel>
-                    DirectiveToken - (150:7,25 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (150:7,25 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (150:7,25 [2] IncompleteDirectives.cshtml) - Html - \n
             Inject - 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -1,30 +1,15 @@
-Source Location: (93:2,6 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+Source Location: (102:3,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
 Generated Location: (776:19,0 [0] )
 ||
 
-Source Location: (102:3,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+Source Location: (123:6,8 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
 Generated Location: (966:27,0 [0] )
 ||
 
-Source Location: (113:5,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
-||
-Generated Location: (1156:35,0 [0] )
-||
-
-Source Location: (123:6,8 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
-||
-Generated Location: (1346:43,0 [0] )
-||
-
 Source Location: (133:7,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 |MyService<TModel>|
-Generated Location: (1536:51,0 [17] )
+Generated Location: (1156:35,0 [17] )
 |MyService<TModel>|
-
-Source Location: (150:7,25 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
-||
-Generated Location: (1766:59,0 [0] )
-||
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -16,23 +16,7 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-#line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
- 
-
-#line default
-#line hidden
-        }
-        ))();
-        ((System.Action)(() => {
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
- 
-
-#line default
-#line hidden
-        }
-        ))();
-        ((System.Action)(() => {
-#line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
  
 
 #line default
@@ -50,22 +34,6 @@ namespace AspNetCore
         ((System.Action)(() => {
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
 MyService<TModel> __typeHelper = default;
-
-#line default
-#line hidden
-        }
-        ))();
-        ((System.Action)(() => {
-#line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
- 
-
-#line default
-#line hidden
-        }
-        ))();
-        ((System.Action)(() => {
-#line 14 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
- 
 
 #line default
 #line hidden

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -23,13 +23,9 @@ Document -
                 DirectiveToken - (617:12,14 [96] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.UrlResolutionTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (729:13,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.HeadTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (832:14,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
-                DirectiveToken - (119:6,6 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (128:7,7 [0] IncompleteDirectives.cshtml) - 
-                DirectiveToken - (139:9,7 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (149:10,8 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (159:11,8 [17] IncompleteDirectives.cshtml) - MyService<TModel>
-                DirectiveToken - (176:11,25 [0] IncompleteDirectives.cshtml) - 
-                DirectiveToken - (190:13,10 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (203:14,11 [0] IncompleteDirectives.cshtml) - 
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning disable 0414
@@ -45,7 +41,6 @@ Document -
                 HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)
                     IntermediateToken - (108:4,6 [5] IncompleteDirectives.cshtml) - Html - "\n\n
                 MalformedDirective - (113:6,0 [6] IncompleteDirectives.cshtml) - model
-                    DirectiveToken - (119:6,6 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (119:6,6 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (119:6,6 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (121:7,0 [7] IncompleteDirectives.cshtml) - model
@@ -53,7 +48,6 @@ Document -
                 HtmlContent - (128:7,7 [4] IncompleteDirectives.cshtml)
                     IntermediateToken - (128:7,7 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (132:9,0 [7] IncompleteDirectives.cshtml) - inject
-                    DirectiveToken - (139:9,7 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (139:9,7 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (139:9,7 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (141:10,0 [8] IncompleteDirectives.cshtml) - inject
@@ -62,11 +56,9 @@ Document -
                     IntermediateToken - (149:10,8 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (151:11,0 [25] IncompleteDirectives.cshtml) - inject
                     DirectiveToken - (159:11,8 [17] IncompleteDirectives.cshtml) - MyService<TModel>
-                    DirectiveToken - (176:11,25 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (176:11,25 [4] IncompleteDirectives.cshtml)
                     IntermediateToken - (176:11,25 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (180:13,0 [10] IncompleteDirectives.cshtml) - namespace
-                    DirectiveToken - (190:13,10 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (190:13,10 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (190:13,10 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (192:14,0 [11] IncompleteDirectives.cshtml) - namespace

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -1,40 +1,20 @@
-Source Location: (119:6,6 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+Source Location: (128:7,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
 Generated Location: (767:19,0 [0] )
 ||
 
-Source Location: (128:7,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
-||
-Generated Location: (957:27,0 [0] )
-||
-
-Source Location: (139:9,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
-||
-Generated Location: (1148:35,0 [0] )
-||
-
 Source Location: (149:10,8 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1339:43,0 [0] )
+Generated Location: (958:27,0 [0] )
 ||
 
 Source Location: (159:11,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 |MyService<TModel>|
-Generated Location: (1530:51,0 [17] )
+Generated Location: (1149:35,0 [17] )
 |MyService<TModel>|
-
-Source Location: (176:11,25 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
-||
-Generated Location: (1761:59,0 [0] )
-||
-
-Source Location: (190:13,10 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
-||
-Generated Location: (1952:67,0 [0] )
-||
 
 Source Location: (203:14,11 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (2143:75,0 [0] )
+Generated Location: (1380:43,0 [0] )
 ||
 

--- a/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -28,7 +28,6 @@ Document -
                 CSharpCode - 
                     IntermediateToken -  - CSharp - EndContext();
                 MalformedDirective - (113:6,0 [6] IncompleteDirectives.cshtml) - model
-                    DirectiveToken - (119:6,6 [0] IncompleteDirectives.cshtml) - 
                 CSharpCode - 
                     IntermediateToken -  - CSharp - BeginContext(119, 2, true);
                 HtmlContent - (119:6,6 [2] IncompleteDirectives.cshtml)
@@ -44,7 +43,6 @@ Document -
                 CSharpCode - 
                     IntermediateToken -  - CSharp - EndContext();
                 MalformedDirective - (132:9,0 [7] IncompleteDirectives.cshtml) - inject
-                    DirectiveToken - (139:9,7 [0] IncompleteDirectives.cshtml) - 
                 CSharpCode - 
                     IntermediateToken -  - CSharp - BeginContext(139, 2, true);
                 HtmlContent - (139:9,7 [2] IncompleteDirectives.cshtml)
@@ -61,7 +59,6 @@ Document -
                     IntermediateToken -  - CSharp - EndContext();
                 MalformedDirective - (151:11,0 [25] IncompleteDirectives.cshtml) - inject
                     DirectiveToken - (159:11,8 [17] IncompleteDirectives.cshtml) - MyService<TModel>
-                    DirectiveToken - (176:11,25 [0] IncompleteDirectives.cshtml) - 
                 CSharpCode - 
                     IntermediateToken -  - CSharp - BeginContext(176, 4, true);
                 HtmlContent - (176:11,25 [4] IncompleteDirectives.cshtml)
@@ -69,7 +66,6 @@ Document -
                 CSharpCode - 
                     IntermediateToken -  - CSharp - EndContext();
                 MalformedDirective - (180:13,0 [10] IncompleteDirectives.cshtml) - namespace
-                    DirectiveToken - (190:13,10 [0] IncompleteDirectives.cshtml) - 
                 CSharpCode - 
                     IntermediateToken -  - CSharp - BeginContext(190, 2, true);
                 HtmlContent - (190:13,10 [2] IncompleteDirectives.cshtml)

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -99,27 +99,7 @@ global::System.Object __typeHelper = ";
         ))();
         ((System.Action)(() => {
 #nullable restore
-#line 15 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
- 
-
-#line default
-#line hidden
-#nullable disable
-        }
-        ))();
-        ((System.Action)(() => {
-#nullable restore
 #line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
- 
-
-#line default
-#line hidden
-#nullable disable
-        }
-        ))();
-        ((System.Action)(() => {
-#nullable restore
-#line 21 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
  
 
 #line default

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -11,9 +11,7 @@ Document -
                 DirectiveToken - (212:10,16 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (231:11,17 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (250:12,17 [1] IncompleteDirectives.cshtml) - "
-                DirectiveToken - (264:14,9 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (276:15,10 [0] IncompleteDirectives.cshtml) - 
-                DirectiveToken - (315:20,8 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (326:21,9 [0] IncompleteDirectives.cshtml) - 
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning disable 0414
@@ -61,7 +59,6 @@ Document -
                 HtmlContent - (251:12,18 [4] IncompleteDirectives.cshtml)
                     IntermediateToken - (251:12,18 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (255:14,0 [9] IncompleteDirectives.cshtml) - inherits
-                    DirectiveToken - (264:14,9 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (264:14,9 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (264:14,9 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (266:15,0 [10] IncompleteDirectives.cshtml) - inherits
@@ -71,7 +68,6 @@ Document -
                 MalformedDirective - (280:17,0 [12] IncompleteDirectives.cshtml) - functions
                 MalformedDirective - (292:18,0 [15] IncompleteDirectives.cshtml) - functions
                 MalformedDirective - (307:20,0 [8] IncompleteDirectives.cshtml) - section
-                    DirectiveToken - (315:20,8 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (315:20,8 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (315:20,8 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (317:21,0 [9] IncompleteDirectives.cshtml) - section

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -43,28 +43,18 @@ Source Location: (250:12,17 [1] TestFiles/IntegrationTests/CodeGenerationIntegra
 Generated Location: (2678:92,37 [1] )
 |"|
 
-Source Location: (264:14,9 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+Source Location: (276:15,10 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
 Generated Location: (2908:102,0 [0] )
 ||
 
-Source Location: (276:15,10 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+Source Location: (326:21,9 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
 Generated Location: (3137:112,0 [0] )
 ||
 
-Source Location: (315:20,8 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
-||
-Generated Location: (3366:122,0 [0] )
-||
-
-Source Location: (326:21,9 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
-||
-Generated Location: (3595:132,0 [0] )
-||
-
 Source Location: (354:24,12 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (4090:149,12 [0] )
+Generated Location: (3632:129,12 [0] )
 ||
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -31,7 +31,6 @@ Document -
                 HtmlContent - (253:13,0 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (253:13,0 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (255:14,0 [9] IncompleteDirectives.cshtml) - inherits
-                    DirectiveToken - (264:14,9 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (264:14,9 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (264:14,9 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (266:15,0 [10] IncompleteDirectives.cshtml) - inherits
@@ -41,7 +40,6 @@ Document -
                 MalformedDirective - (280:17,0 [12] IncompleteDirectives.cshtml) - functions
                 MalformedDirective - (292:18,0 [15] IncompleteDirectives.cshtml) - functions
                 MalformedDirective - (307:20,0 [8] IncompleteDirectives.cshtml) - section
-                    DirectiveToken - (315:20,8 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (315:20,8 [2] IncompleteDirectives.cshtml)
                     IntermediateToken - (315:20,8 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (317:21,0 [9] IncompleteDirectives.cshtml) - section

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/ParserTests/CSharpSectionTest/CapturesNewlineImmediatelyFollowing.cspans.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/ParserTests/CSharpSectionTest/CapturesNewlineImmediatelyFollowing.cspans.txt
@@ -1,5 +1,4 @@
 Markup span at (0:0,0 [0] ) (Accepts:Any) - Parent: Markup block at (0:0,0 [10] )
 Transition span at (0:0,0 [1] ) (Accepts:None) - Parent: Directive block at (0:0,0 [8] )
 MetaCode span at (1:0,1 [7] ) (Accepts:None) - Parent: Directive block at (0:0,0 [8] )
-Code span at (8:0,8 [0] ) (Accepts:NonWhitespace) - Parent: Directive block at (0:0,0 [8] )
 Markup span at (8:0,8 [2] ) (Accepts:Any) - Parent: Markup block at (0:0,0 [10] )

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/ParserTests/CSharpSectionTest/CapturesNewlineImmediatelyFollowing.stree.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/ParserTests/CSharpSectionTest/CapturesNewlineImmediatelyFollowing.stree.txt
@@ -10,7 +10,5 @@ RazorDocument - [0..10)::10 - [@sectionLF]
                     RazorMetaCode - [1..8)::7 - Gen<None> - SpanEditHandler;Accepts:None
                         Identifier;[section];
                     CSharpCodeBlock - [8..8)::0
-                        CSharpStatementLiteral - [8..8)::0 - [] - Gen<DirectiveToken {SectionName;Member;Opt:False}> - DirectiveTokenEditHandler;Accepts:NonWhitespace
-                            Marker;[];
         MarkupTextLiteral - [8..10)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
             NewLine;[LF];


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/11859

Looks like we add a marker token at the end of @inject| to provide CSharp intellisense for the upcoming token. We fix this by only adding the marker token if there is whitespace after @inject