### PR TITLE
Print warning when reference assembly is not found

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/FindAssembliesWithReferencesTo.cs
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/FindAssembliesWithReferencesTo.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             catch (ReferenceAssemblyNotFoundException ex)
             {
                 // Print a warning and return. We cannot produce a correct document at this point.
-                var warning = $"Reference assembly {0} could not be found. This is typically caused by build errors in referenced projects.";
+                var warning = "Reference assembly {0} could not be found. This is typically caused by build errors in referenced projects.";
                 Log.LogWarning(null, "RAZORSDK1007", null, null, 0, 0, 0, 0, warning, ex.FileName);
                 return true;
             }

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/FindAssembliesWithReferencesTo.cs
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/FindAssembliesWithReferencesTo.cs
@@ -51,6 +51,13 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                 var assemblyNames = provider.ResolveAssemblies();
                 ResolvedAssemblies = assemblyNames.ToArray();
             }
+            catch (ReferenceAssemblyNotFoundException ex)
+            {
+                // Print a warning and return. We cannot produce a correct document at this point.
+                var warning = $"Reference assembly {0} could not be found. This is typically caused by build errors in referenced projects.";
+                Log.LogWarning(null, "RAZORSDK1007", null, null, 0, 0, 0, 0, warning, ex.FileName);
+                return true;
+            }
             catch (Exception ex)
             {
                 Log.LogErrorFromException(ex);

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/ReferenceAssemblyNotFoundException.cs
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/ReferenceAssemblyNotFoundException.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.Tasks
+{
+    internal class ReferenceAssemblyNotFoundException : Exception
+    {
+        public ReferenceAssemblyNotFoundException(string fileName)
+        {
+            FileName = fileName;
+        }
+
+        public string FileName { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/ReferenceResolver.cs
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/ReferenceResolver.cs
@@ -107,6 +107,11 @@ namespace Microsoft.AspNetCore.Razor.Tasks
         {
             try
             {
+                if (!File.Exists(file))
+                {
+                    throw new ReferenceAssemblyNotFoundException(file);
+                }
+
                 using var peReader = new PEReader(File.OpenRead(file));
                 if (!peReader.HasMetadata)
                 {

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/ApplicationPartDiscoveryIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/ApplicationPartDiscoveryIntegrationTest.cs
@@ -177,5 +177,17 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 Assert.Equal(outputFilethumbPrint, GetThumbPrint(outputFile));
             }
         }
+
+        [Fact]
+        [InitializeTestProject("AppWithP2PReference", additionalProjects: "ClassLibrary")]
+        public async Task Build_ProjectWithMissingAssemblyReference_PrintsWarning()
+        {
+            var result = await DotnetMSBuild("Build /p:BuildProjectReferences=false");
+
+            Assert.BuildFailed(result);
+
+            Assert.BuildWarning(result, "RAZORSDK1007");
+            Assert.BuildError(result, "CS0006");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/11226

@pranavkm does this look like what you expect? I'll add a test once you confirm.