### PR TITLE
Use current AzDO and Arcade pools and syntax

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,10 +18,6 @@ variables:
 - name: _HelixRepo
   value: aspnet/AspNetCore-Tooling
 
-# increase timeout since BAR publishing (if enabled) might wait a long time
-- name: _TimeoutInMinutes
-  value: 120
-
 # Variables for public PR builds
 - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'github')) }}:
   # These are needed to suppress a warning in the cibuild invocation since AzDO leaves the `$(_SignArgs)` in place and it fails to resolve.
@@ -58,7 +54,7 @@ pr:
 jobs:
 - template: /eng/common/templates/jobs/jobs.yml
   parameters:
-    timeoutInMinutes: $(_TimeoutInMinutes)
+    timeoutInMinutes: 120
     enablePublishBuildArtifacts: true # publishes artifacts/log files
     enablePublishTestResults: true
     helixRepo: $(_HelixRepo)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,34 +1,50 @@
+#
+# See https://docs.microsoft.com/azure/devops/pipelines/yaml-schema for reference.
+#
+
 variables:
-  Build.Repository.Clean: true
-  _TeamName: AspNetCore
-  _DotNetPublishToBlobFeed : false
-  _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-  _PublishArgs: '/p:PublishToSymbolServer=false /p:PublishToAzure=false'
+- name: Build.Repository.Clean
+  value: true
+- name: _TeamName
+  value: AspNetCore
+- name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+  value: true
+- name: _DotNetPublishToBlobFeed
+  value: false
+- name: _PublishBlobFeedUrl
+  value: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+- name: _PublishArgs
+  value: '/p:PublishToSymbolServer=false /p:PublishToAzure=false'
+- name: _HelixRepo
+  value: aspnet/AspNetCore-Tooling
 
-  _TimeoutInMinutes: 120 #increase timeout since BAR publishing might wait a long time
-  
-  # Variables for public PR builds
-  ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'github')) }}:
-    _HelixType: build/product
-    _HelixSource: pr/aspnet/AspNetCore-Tooling/$(Build.SourceBranch)
-    # These are needed to suppress a warning in the cibuild invocation since AzDO leaves the `$(_SignArgs)` in place and it fails to resolve.
-    _SignArgs: ''
-    _OfficialBuildIdArgs: ''
+# increase timeout since BAR publishing (if enabled) might wait a long time
+- name: _TimeoutInMinutes
+  value: 120
 
-  # Variables for internal Official builds
-  ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'official')) }}:
-    _HelixType: build/product
-    _HelixSource: official/aspnet/AspNetCore-Tooling/$(Build.SourceBranch)
-    _SignType: real
-    _SignArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-    _OfficialBuildIdArgs: /p:OfficialBuildId=$(Build.BuildNumber) 
+# Variables for public PR builds
+- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'github')) }}:
+  # These are needed to suppress a warning in the cibuild invocation since AzDO leaves the `$(_SignArgs)` in place and it fails to resolve.
+  - name: _SignArgs
+    value: ''
+  - name: _OfficialBuildIdArgs
+    value: ''
+
+# Variables for internal Official builds
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'official')) }}:
+  - name: _SignType
+    value: real
+  - name: _SignArgs
+    value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
+  - name: _OfficialBuildIdArgs
+    value: /p:OfficialBuildId=$(Build.BuildNumber)
       /p:ManifestBuildBranch=$(Build.SourceBranchName)
       /p:ManifestBuildNumber=$(Build.BuildNumber)
- 
+
 resources:
   containers:
   - container: LinuxContainer
-    image: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
     options: --init # This ensures all the stray defunct processes are reaped.
 
 trigger:
@@ -39,164 +55,113 @@ pr:
 - "*"
 
 # Three phases for each of the three OSes we want to run on
-phases:
-- template: /eng/common/templates/phases/base.yml
+jobs:
+- template: /eng/common/templates/jobs/jobs.yml
   parameters:
-    name: Windows
     timeoutInMinutes: $(_TimeoutInMinutes)
+    enablePublishBuildArtifacts: true # publishes artifacts/log files
+    enablePublishTestResults: true
+    helixRepo: $(_HelixRepo)
     enableTelemetry: true
-    # enableMicrobuild can't be read from a user-defined variable (Azure DevOps limitation)
-    ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'official')) }}:
-      enableMicrobuild: true
-    queue:
-      # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
-      ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'github')) }}:
-        name: dotnet-external-temp
-      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'official')) }}:
-        name: dotnet-internal-temp
-      matrix:
-        debug:
-          _BuildConfig: Debug
-        release:
-          _BuildConfig: Release
-          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'official')) }}:
-            _DotNetPublishToBlobFeed: true
-            _PublishArgs: /p:PublishToSymbolServer=true
-              /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-              /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-              /p:PublishToAzure=true
-              /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-              /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
-              /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
-    steps:
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'official')) }}:
-      - task: AzureKeyVault@1
+    jobs:
+    - job: Windows
+      # enableMicrobuild can't be read from a user-defined variable (Azure DevOps limitation)
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        enableMicrobuild: true
+      pool:
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          name: NetCorePublic-Pool
+          queue: BuildPool.Windows.10.Amd64.VS2019.Open
+        ${{ if ne(variables['System.TeamProject'], 'public') }}:
+          name: NetCoreInternal-Pool
+          queue: BuildPool.Windows.10.Amd64.VS2019
+      strategy:
+        matrix:
+          debug:
+            _BuildConfig: Debug
+          release:
+            _BuildConfig: Release
+            ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+              _DotNetPublishToBlobFeed: true
+              _PublishArgs: /p:PublishToSymbolServer=true
+                /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                /p:PublishToAzure=true
+                /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+                /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
+                /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+      steps:
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.DefinitionName'], 'official')) }}:
+        - task: AzureKeyVault@1
+          inputs:
+            azureSubscription: 'DotNet-Engineering-Services_KeyVault'
+            KeyVaultName: EngKeyVault
+            SecretsFilter: 'dotnetfeed-storage-access-key-1,microsoft-symbol-server-pat,symweb-symbol-server-pat'
+      - script: eng\common\cibuild.cmd
+          -configuration $(_BuildConfig)
+          -prepareMachine
+          $(_SignArgs)
+          $(_OfficialBuildIdArgs)
+          $(_PublishArgs)
+        name: Build
+        displayName: Build
+        condition: succeeded()
+      - task: PublishBuildArtifacts@1
+        displayName: Publish VSIX Artifacts
         inputs:
-          azureSubscription: 'DotNet-Engineering-Services_KeyVault'
-          KeyVaultName: EngKeyVault
-          SecretsFilter: 'dotnetfeed-storage-access-key-1,microsoft-symbol-server-pat,symweb-symbol-server-pat'
-    - script: eng\common\cibuild.cmd 
-        -configuration $(_BuildConfig)
-        -prepareMachine
-        $(_SignArgs)
-        $(_OfficialBuildIdArgs)
-        $(_PublishArgs)
-      name: Build
-      displayName: Build
-      condition: succeeded()
-    - task: PublishTestResults@2
-      displayName: Publish xUnit Test Results
-      condition: always()
-      continueOnError: true
-      inputs:
-        testRunner: xunit
-        testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml' 
-    - task: PublishBuildArtifacts@1
-      displayName: Publish VSIX Artifacts
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/VSSetup/$(_BuildConfig)'
-        PublishLocation: Container
-        ArtifactName: VSIX_$(Agent.Os)_$(Agent.JobName)
-      continueOnError: true
-      condition: eq(variables['_BuildConfig'], 'Release')
-    - task: PublishBuildArtifacts@1
-      displayName: Publish VS for Mac Artifacts
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/MPack/$(_BuildConfig)'
-        PublishLocation: Container
-        ArtifactName: MPack_$(Agent.Os)_$(Agent.JobName)
-      continueOnError: true
-      condition: eq(variables['_BuildConfig'], 'Release')
-    - task: PublishBuildArtifacts@1
-      displayName: Publish package artifacts
-      inputs:
-        PathtoPublish: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)
-        PublishLocation: Container
-        ArtifactName: Packages_$(Agent.Os)_$(Agent.JobName)
-      continueOnError: true
-      condition: eq(variables['_BuildConfig'], 'Release')
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Logs
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
-        PublishLocation: Container
-        ArtifactName: Logs_$(Agent.Os)_$(Agent.JobName)
-      continueOnError: true
-      condition: always()
-    variables:
-      _HelixBuildConfig: $(_BuildConfig)
+          PathtoPublish: '$(Build.SourcesDirectory)/artifacts/VSSetup/$(_BuildConfig)'
+          PublishLocation: Container
+          ArtifactName: VSIX_$(Agent.Os)_$(_BuildConfig)
+        continueOnError: true
+        condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+      - task: PublishBuildArtifacts@1
+        displayName: Publish VS for Mac Artifacts
+        inputs:
+          PathtoPublish: '$(Build.SourcesDirectory)/artifacts/MPack/$(_BuildConfig)'
+          PublishLocation: Container
+          ArtifactName: MPack_$(Agent.Os)_$(_BuildConfig)
+        continueOnError: true
+        condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+      - task: PublishBuildArtifacts@1
+        displayName: Publish package artifacts
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)
+          PublishLocation: Container
+          ArtifactName: Packages_$(Agent.Os)_$(_BuildConfig)
+        continueOnError: true
+        condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
 
-- template: /eng/common/templates/phases/base.yml
-  parameters:
-    name: macOS
-    timeoutInMinutes: $(_TimeoutInMinutes)
-    enableTelemetry: true
-    queue:
-      name: Hosted macOS
-      matrix:
-        debug:
-          _BuildConfig: Debug
-        release:
-          _BuildConfig: Release
-    steps:
-    - script: eng/common/cibuild.sh
-        --configuration $(_BuildConfig)
-        --prepareMachine
-      name: Build
-      displayName: Build
-      condition: succeeded()
-    - task: PublishTestResults@2
-      displayName: Publish xUnit Test Results
-      condition: always()
-      continueOnError: true
-      inputs:
-        testRunner: xunit
-        testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Logs
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
-        PublishLocation: Container
-        ArtifactName: Logs_$(Agent.Os)_$(Agent.JobName)
-      continueOnError: true
-      condition: always()
-    variables:
-      _HelixBuildConfig: $(_BuildConfig)
+    - job: macOS
+      pool:
+        vmImage: macOS-10.13
+      strategy:
+        matrix:
+          debug:
+            _BuildConfig: Debug
+          release:
+            _BuildConfig: Release
+      steps:
+      - script: eng/common/cibuild.sh
+          --configuration $(_BuildConfig)
+          --prepareMachine
+        name: Build
+        displayName: Build
+        condition: succeeded()
 
-- template: /eng/common/templates/phases/base.yml
-  parameters:
-    name: Linux
-    timeoutInMinutes: $(_TimeoutInMinutes)
-    enableTelemetry: true
-    queue:
-      name: Hosted Ubuntu 1604
+    - job: Linux
       container: LinuxContainer
-      matrix:
-        debug:
-          _BuildConfig: Debug
-        release:
-          _BuildConfig: Release
-    steps:
-    - script: eng/common/cibuild.sh
-        --configuration $(_BuildConfig)
-        --prepareMachine
-      name: Build
-      displayName: Build
-      condition: succeeded()
-    - task: PublishTestResults@2
-      displayName: Publish xUnit Test Results
-      condition: always()
-      continueOnError: true
-      inputs:
-        testRunner: xunit
-        testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Logs
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
-        PublishLocation: Container
-        ArtifactName: Logs_$(Agent.Os)_$(Agent.JobName)
-      continueOnError: true
-      condition: always()
-    variables:
-      _HelixBuildConfig: $(_BuildConfig)
+      pool:
+        vmImage: ubuntu-16.04
+      strategy:
+        matrix:
+          debug:
+            _BuildConfig: Debug
+          release:
+            _BuildConfig: Release
+      steps:
+      - script: eng/common/cibuild.sh
+          --configuration $(_BuildConfig)
+          --prepareMachine
+        name: Build
+        displayName: Build
+        condition: succeeded()


### PR DESCRIPTION
- Windows: use BYOC pools
  - stop using removed `dotnet-external-temp` VM images
- non-Windows: `name` -> `vmImage`
  - stop using queue names for hosted images; all one queue now
- correct LinuxContainer location to match current URL
- move to jobs schema; phases are barely supported and no longer documented
  - phases do not support named pools and pools are needed on Windows
  - switch to array syntax for top-level variables; jobs.xml doesn't support object syntax
  - replace `queue` parameter with `container`, `pool`, `strategy` parameters
  - remove build steps available in jobs.xml: see `enablePublishBuildArtifacts`, `enablePublishTestResults`
  - remove variables that jobs.xml defaults correctly: `$(_HelixType)`, `$(_HelixBuildConfig)`
  - pass `helixRepo` parameter rather than provide `$(_HelixSource)` variable

nits:
- correct various conditions to ensure internal builds use internal queue and limit artifact upload
- define `$(DOTNET_SKIP_FIRST_TIME_EXPERIENCE)`
- check `$(Build.DefinitionName)` less often; was not necessary everywhere