### PR TITLE
Pass views assembly to linker

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -487,12 +487,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
     <!--
-    Called after ComputeRefAssembliesToPublish but before CopyFilesToPublishDirectory - this target is called when
+    Called after ComputeResolvedFilesToPublishList but before CopyFilesToPublishDirectory - this target is called when
     publishing the project to get a list of files to the output directory.
   -->
   <Target
     Name="_StaticWebAssetsComputeFilesToPublish"
-    AfterTargets="ComputeRefAssembliesToPublish"
+    AfterTargets="ComputeResolvedFilesToPublishList"
     DependsOnTargets="ResolveStaticWebAssetsInputs">
 
     <ItemGroup>

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -779,18 +779,20 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <!--
-    Called after ComputeFilesToPublish and ComputeRefAssembliesToPublish but before CopyFilesToPublishDirectory - this target is called when
+    Called after ComputeResolvedFilesToPublishList but before CopyFilesToPublishDirectory - this target is called when
     publishing the project to get a list of files to the output directory.
   -->
   <Target
     Name="_RazorComputeFilesToPublish"
-    AfterTargets="ComputeRefAssembliesToPublish"
+    AfterTargets="ComputeResolvedFilesToPublishList"
     Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnPublish)'=='true' and '@(RazorGenerate)'!=''">
 
     <!-- If we generated an assembly/pdb then include those -->
     <ItemGroup>
       <ResolvedFileToPublish Include="@(RazorIntermediateAssembly)" Condition="'$(CopyBuildOutputToPublishDirectory)'=='true'">
         <RelativePath>@(RazorIntermediateAssembly->'%(Filename)%(Extension)')</RelativePath>
+        <!-- Pass assembly to linker and crossgen -->
+        <PostprocessAssembly>true</PostprocessAssembly>
       </ResolvedFileToPublish>
       <ResolvedFileToPublish Include="@(_RazorDebugSymbolsIntermediatePath)" Condition="'$(CopyOutputSymbolsToPublishDirectory)'=='true'">
         <RelativePath>@(_RazorDebugSymbolsIntermediatePath->'%(Filename)%(Extension)')</RelativePath>


### PR DESCRIPTION
### Description
Publishing web app with trimming enabled, trims assemblies that are used only in Views, breaking the published application.

Also views aren't crossgened.

### Customer Impact
Trimming feature is broken out of the box in basic web scenarios.

Less severely, code in views does not get the benefit of crossgen.

### Regression
No.

### Risk
Low. 

---


Views assembly was not being passed to linker, causing anything in framework rooted only by it to be thrown out.

Views assembly was not be being crossgened.

Cause: Views assembly was added to ResolvedFileToPublish too late for linker and crossgen to see it.

Fix: Re-schedule target to run before linker and crossgen

There's a related change in https://github.com/dotnet/sdk/pull/3539, but this works with or without that and can be reviewed and approved independently. That sdk change has an end-to-end test for this scenario and I ran the test with and without my other changes, and this change applied to the razor sdk.

The sdk change will pass only what it determines is a managed runtime assembly, or what has been given PostprocessAssembly=true metadata in ResolvedFileToPublish. Without the change, both crossgen and linker scan all files to publish and check what is managed. This change applies the metadata so that it is future proofed against that sdk change. Without the sdk change, the metadata is harmless.

Addresses AspNet/AspNetCore#12064
