### PR TITLE
Retarget to netcoreapp5.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,6 @@
     <GenerateResxSource>true</GenerateResxSource>
     <GenerateResxSourceEmitFormatMethods>true</GenerateResxSourceEmitFormatMethods>
     <ExcludeFromSourceBuild Condition="'$(IsUnitTestProject)' == 'true'">true</ExcludeFromSourceBuild>
-    <DefaultNetCoreTargetFramework>netcoreapp5.0</DefaultNetCoreTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Label="Package and Assembly Metadata">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,6 +24,7 @@
     <GenerateResxSource>true</GenerateResxSource>
     <GenerateResxSourceEmitFormatMethods>true</GenerateResxSourceEmitFormatMethods>
     <ExcludeFromSourceBuild Condition="'$(IsUnitTestProject)' == 'true'">true</ExcludeFromSourceBuild>
+    <DefaultNetCoreTargetFramework>netcoreapp5.0</DefaultNetCoreTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Label="Package and Assembly Metadata">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -25,7 +25,7 @@
   <ItemGroup>
     <FrameworkReference 
       Update="Microsoft.NETCore.App"
-      Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' and '$(DotNetBuildFromSource)' == 'true'"
+      Condition="'$(TargetFramework)' == 'netcoreapp5.0' and '$(DotNetBuildFromSource)' == 'true'"
       RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimeVersion)"
       TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
     />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -21,6 +21,14 @@
     <NETCoreAppMaximumVersion>5.0</NETCoreAppMaximumVersion>
   </PropertyGroup>
 
+  <!-- Workaround while there is no publicly released 5.0 SDK available for source build -->
+  <FrameworkReference 
+    Update="Microsoft.NETCore.App"
+    Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' and '$(DotNetBuildFromSource)' == 'true'"
+    RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimeVersion)"
+    TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
+  />
+
   <ItemGroup>
     <!-- Track compiler separately from Arcade.-->
     <PackageReference Include="Microsoft.Net.Compilers.Toolset"

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -8,6 +8,19 @@
     <BundledNETCorePlatformsPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
   </PropertyGroup>
 
+  <!-- Source Build still uses a 3.0 SDK, which we need to retarget to 5.0 until the first 5.0 SDK is publicly released -->
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <KnownFrameworkReference
+      Include="@(KnownFrameworkReference->WithMetadataValue('TargetFramework', 'netcoreapp3.0'))"
+      TargetFramework="netcoreapp5.0"
+      />
+  </ItemGroup>
+
+  <!-- Workaround while there is no publicly released 5.0 SDK available for source build, suppress unsupported version error -->
+  <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <NETCoreAppMaximumVersion>5.0</NETCoreAppMaximumVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- Track compiler separately from Arcade.-->
     <PackageReference Include="Microsoft.Net.Compilers.Toolset"

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -22,12 +22,14 @@
   </PropertyGroup>
 
   <!-- Workaround while there is no publicly released 5.0 SDK available for source build -->
-  <FrameworkReference 
-    Update="Microsoft.NETCore.App"
-    Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' and '$(DotNetBuildFromSource)' == 'true'"
-    RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimeVersion)"
-    TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
-  />
+  <ItemGroup>
+    <FrameworkReference 
+      Update="Microsoft.NETCore.App"
+      Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' and '$(DotNetBuildFromSource)' == 'true'"
+      RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimeVersion)"
+      TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
+    />
+  </ItemGroup>
 
   <ItemGroup>
     <!-- Track compiler separately from Arcade.-->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -92,7 +92,7 @@
     <MicrosoftCodeAnalysisCommonPackageVersion>3.3.0</MicrosoftCodeAnalysisCommonPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>3.3.0</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.3.0</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
-    <MicrosoftNETCoreApp30PackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreApp30PackageVersion>
+    <MicrosoftNETCoreApp50PackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreApp50PackageVersion>
     <MicrosoftNETFrameworkReferenceAssemblies>1.0.0-alpha-5</MicrosoftNETFrameworkReferenceAssemblies>
     <MicrosoftNetRoslynDiagnosticsPackageVersion>2.6.3</MicrosoftNetRoslynDiagnosticsPackageVersion>
     <MicrosoftVisualStudioComponentModelHostPackageVersion>16.0.467</MicrosoftVisualStudioComponentModelHostPackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview7-012821",
+    "dotnet": "5.0.100-alpha1-013788",
     "runtimes": {
       "dotnet": [
         "2.1.11",
@@ -15,7 +15,7 @@
     }
   },
   "sdk": {
-    "version": "3.0.100-preview7-012821"
+    "version": "5.0.100-alpha1-013788"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19416.16"

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Tools/Microsoft.AspNetCore.Razor.Tools.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Tools/Microsoft.AspNetCore.Razor.Tools.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This assembly contains infrastructure supporting Razor MSBuild integration.</Description>
 
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>rzc</AssemblyName>
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Tools/Microsoft.AspNetCore.Razor.Tools.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Tools/Microsoft.AspNetCore.Razor.Tools.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This assembly contains infrastructure supporting Razor MSBuild integration.</Description>
 
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>rzc</AssemblyName>
 

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/Microsoft.NET.Sdk.Razor.csproj
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/Microsoft.NET.Sdk.Razor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains MSBuild support for Razor.</Description>
-    <TargetFrameworks>netcoreapp3.0;net46</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework);net46</TargetFrameworks>
 
     <TargetName>Microsoft.NET.Sdk.Razor.Tasks</TargetName>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataPackageVersion)" Condition="'$(TargetFramework)'=='net46'" />
 
-    <ProjectReference Include="..\Microsoft.AspNetCore.Mvc.Razor.Extensions\Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj" ReferenceOutputAssembly="false" Condition="'$(TargetFramework)'=='netcoreapp3.0'" />
-    <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Tools\Microsoft.AspNetCore.Razor.Tools.csproj" ReferenceOutputAssembly="false" Condition="'$(TargetFramework)'=='netcoreapp3.0'" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.Mvc.Razor.Extensions\Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj" ReferenceOutputAssembly="false" Condition="'$(TargetFramework)'=='$(DefaultNetCoreTargetFramework)'" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Tools\Microsoft.AspNetCore.Razor.Tools.csproj" ReferenceOutputAssembly="false" Condition="'$(TargetFramework)'=='$(DefaultNetCoreTargetFramework)'" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,7 +42,7 @@
     <!-- Layout tasks, compiler, and extensions in the sdk-output folder. The entire folder structure gets packaged as-is into the SDK -->
     <MSBuild
       Projects="..\Microsoft.AspNetCore.Razor.Tools\Microsoft.AspNetCore.Razor.Tools.csproj"
-      Properties="PublishDir=$(SdkOutputPath)tools\netcoreapp3.0;TargetFramework=netcoreapp3.0"
+      Properties="PublishDir=$(SdkOutputPath)tools\$(DefaultNetCoreTargetFramework);TargetFramework=$(DefaultNetCoreTargetFramework)"
       Targets="Publish" />
 
     <ItemGroup>
@@ -55,7 +55,7 @@
 
     <ItemGroup>
       <ProjectOutput Include="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor\$(Configuration)\net46*\Microsoft.NET.Sdk.Razor.Tasks.*" />
-      <ProjectOutput Include="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor\$(Configuration)\netcoreapp3.0*\Microsoft.NET.Sdk.Razor.Tasks.*" />
+      <ProjectOutput Include="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor\$(Configuration)\$(DefaultNetCoreTargetFramework)*\Microsoft.NET.Sdk.Razor.Tasks.*" />
 
       <ProjectOutput Include="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor\$(Configuration)\net46*\System.Collections.Immutable.dll" />
       <ProjectOutput Include="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor\$(Configuration)\net46*\System.Reflection.Metadata.dll" />

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/Microsoft.NET.Sdk.Razor.csproj
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/Microsoft.NET.Sdk.Razor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains MSBuild support for Razor.</Description>
-    <TargetFrameworks>$(DefaultNetCoreTargetFramework);net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp5.0;net46</TargetFrameworks>
 
     <TargetName>Microsoft.NET.Sdk.Razor.Tasks</TargetName>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataPackageVersion)" Condition="'$(TargetFramework)'=='net46'" />
 
-    <ProjectReference Include="..\Microsoft.AspNetCore.Mvc.Razor.Extensions\Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj" ReferenceOutputAssembly="false" Condition="'$(TargetFramework)'=='$(DefaultNetCoreTargetFramework)'" />
-    <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Tools\Microsoft.AspNetCore.Razor.Tools.csproj" ReferenceOutputAssembly="false" Condition="'$(TargetFramework)'=='$(DefaultNetCoreTargetFramework)'" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.Mvc.Razor.Extensions\Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj" ReferenceOutputAssembly="false" Condition="'$(TargetFramework)'=='netcoreapp5.0'" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Tools\Microsoft.AspNetCore.Razor.Tools.csproj" ReferenceOutputAssembly="false" Condition="'$(TargetFramework)'=='netcoreapp5.0'" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,7 +42,7 @@
     <!-- Layout tasks, compiler, and extensions in the sdk-output folder. The entire folder structure gets packaged as-is into the SDK -->
     <MSBuild
       Projects="..\Microsoft.AspNetCore.Razor.Tools\Microsoft.AspNetCore.Razor.Tools.csproj"
-      Properties="PublishDir=$(SdkOutputPath)tools\$(DefaultNetCoreTargetFramework);TargetFramework=$(DefaultNetCoreTargetFramework)"
+      Properties="PublishDir=$(SdkOutputPath)tools\netcoreapp5.0;TargetFramework=netcoreapp5.0"
       Targets="Publish" />
 
     <ItemGroup>
@@ -55,7 +55,7 @@
 
     <ItemGroup>
       <ProjectOutput Include="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor\$(Configuration)\net46*\Microsoft.NET.Sdk.Razor.Tasks.*" />
-      <ProjectOutput Include="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor\$(Configuration)\$(DefaultNetCoreTargetFramework)*\Microsoft.NET.Sdk.Razor.Tasks.*" />
+      <ProjectOutput Include="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor\$(Configuration)\netcoreapp5.0*\Microsoft.NET.Sdk.Razor.Tasks.*" />
 
       <ProjectOutput Include="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor\$(Configuration)\net46*\System.Collections.Immutable.dll" />
       <ProjectOutput Include="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor\$(Configuration)\net46*\System.Reflection.Metadata.dll" />

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.CodeGeneration.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.CodeGeneration.targets
@@ -39,7 +39,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_RazorGenerateInputsHash></_RazorGenerateInputsHash>
     <_RazorGenerateInputsHashFile>$(IntermediateOutputPath)$(MSBuildProjectName).RazorCoreGenerate.cache</_RazorGenerateInputsHashFile>
 
-    <_RazorToolAssembly Condition="'$(_RazorToolAssembly)'==''">$(RazorSdkDirectoryRoot)tools\netcoreapp3.0\rzc.dll</_RazorToolAssembly>
+    <_RazorToolAssembly Condition="'$(_RazorToolAssembly)'==''">$(RazorSdkDirectoryRoot)tools\$(DefaultNetCoreTargetFramework)\rzc.dll</_RazorToolAssembly>
   </PropertyGroup>
 
   <!--

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.CodeGeneration.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.CodeGeneration.targets
@@ -39,7 +39,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_RazorGenerateInputsHash></_RazorGenerateInputsHash>
     <_RazorGenerateInputsHashFile>$(IntermediateOutputPath)$(MSBuildProjectName).RazorCoreGenerate.cache</_RazorGenerateInputsHashFile>
 
-    <_RazorToolAssembly Condition="'$(_RazorToolAssembly)'==''">$(RazorSdkDirectoryRoot)tools\$(DefaultNetCoreTargetFramework)\rzc.dll</_RazorToolAssembly>
+    <_RazorToolAssembly Condition="'$(_RazorToolAssembly)'==''">$(RazorSdkDirectoryRoot)tools\netcoreapp5.0\rzc.dll</_RazorToolAssembly>
   </PropertyGroup>
 
   <!--

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Compilation.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Compilation.targets
@@ -111,6 +111,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <UseSharedCompilation>true</UseSharedCompilation>
     </PropertyGroup>
 
+    <!-- TODO: does this need to be updated for 5.0? -->
     <PropertyGroup Condition="('$(TargetFrameworkIdentifier)' != '.NETCoreApp' OR '$(TargetFrameworkVersion)' != 'v3.0') AND
                             ('$(TargetFrameworkIdentifier)' != '.NETStandard' OR '$(TargetFrameworkVersion)' != 'v2.1')">
       <MaxSupportedLangVersion Condition="'$(MaxSupportedLangVersion)' == ''">7.3</MaxSupportedLangVersion>

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Configuration.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Configuration.targets
@@ -19,7 +19,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       The properties and items here are designed to be read by CPS so they should be just simple evaluation-time values
       and should not require targets to initialize.
 
-      Also, these values are based on whether the library is targeting netcoreapp3.0 for now. A better heuristic
+      Also, these values are based on whether the library is targeting netcoreapp5.0 for now. A better heuristic
       would be to detect whether the ASP.NET Core shared framework is referenced.
   -->
   <PropertyGroup>

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -30,7 +30,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Paths to tools, tasks, and extensions are calculated relative to the RazorSdkDirectoryRoot. This can be modified to test a local build. -->
     <RazorSdkDirectoryRoot Condition="'$(RazorSdkDirectoryRoot)'==''">$(MSBuildThisFileDirectory)..\..\</RazorSdkDirectoryRoot>
     <RazorSdkBuildTasksDirectoryRoot Condition="'$(RazorSdkBuildTasksDirectoryRoot)'==''">$(RazorSdkDirectoryRoot)tasks\</RazorSdkBuildTasksDirectoryRoot>
-    <_RazorSdkTasksTFM Condition=" '$(MSBuildRuntimeType)' == 'Core'">$(DefaultNetCoreTargetFramework)</_RazorSdkTasksTFM>
+    <_RazorSdkTasksTFM Condition=" '$(MSBuildRuntimeType)' == 'Core'">netcoreapp5.0</_RazorSdkTasksTFM>
     <_RazorSdkTasksTFM Condition=" '$(_RazorSdkTasksTFM)' == ''">net46</_RazorSdkTasksTFM>
     <RazorSdkBuildTasksAssembly>$(RazorSdkBuildTasksDirectoryRoot)$(_RazorSdkTasksTFM)\Microsoft.NET.Sdk.Razor.Tasks.dll</RazorSdkBuildTasksAssembly>
   </PropertyGroup>

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -30,7 +30,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Paths to tools, tasks, and extensions are calculated relative to the RazorSdkDirectoryRoot. This can be modified to test a local build. -->
     <RazorSdkDirectoryRoot Condition="'$(RazorSdkDirectoryRoot)'==''">$(MSBuildThisFileDirectory)..\..\</RazorSdkDirectoryRoot>
     <RazorSdkBuildTasksDirectoryRoot Condition="'$(RazorSdkBuildTasksDirectoryRoot)'==''">$(RazorSdkDirectoryRoot)tasks\</RazorSdkBuildTasksDirectoryRoot>
-    <_RazorSdkTasksTFM Condition=" '$(MSBuildRuntimeType)' == 'Core'">netcoreapp3.0</_RazorSdkTasksTFM>
+    <_RazorSdkTasksTFM Condition=" '$(MSBuildRuntimeType)' == 'Core'">$(DefaultNetCoreTargetFramework)</_RazorSdkTasksTFM>
     <_RazorSdkTasksTFM Condition=" '$(_RazorSdkTasksTFM)' == ''">net46</_RazorSdkTasksTFM>
     <RazorSdkBuildTasksAssembly>$(RazorSdkBuildTasksDirectoryRoot)$(_RazorSdkTasksTFM)\Microsoft.NET.Sdk.Razor.Tasks.dll</RazorSdkBuildTasksAssembly>
   </PropertyGroup>
@@ -38,6 +38,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Resolve the RazorLangVersion based on values imported or TFM. -->
   <PropertyGroup>
     <_TargetFrameworkVersionWithoutV>$(TargetFrameworkVersion.TrimStart('vV'))</_TargetFrameworkVersionWithoutV>
+
+    <!-- TODO: Do we need to update _TargetingNETCoreApp30OrLater, _Targeting30OrNewerRazorLangVersion, and/or RazorLangVersion for 5.0? -->
     <_TargetingNETCoreApp30OrLater Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">true</_TargetingNETCoreApp30OrLater>
 
     <!--

--- a/src/Razor/src/RazorPageGenerator/RazorPageGenerator.csproj
+++ b/src/Razor/src/RazorPageGenerator/RazorPageGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Builds Razor pages for views in a project. For internal use only.</Description>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <AssemblyName>dotnet-razorpagegenerator</AssemblyName>
     <PackageId>RazorPageGenerator</PackageId>
     <OutputType>Exe</OutputType>

--- a/src/Razor/src/RazorPageGenerator/RazorPageGenerator.csproj
+++ b/src/Razor/src/RazorPageGenerator/RazorPageGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Builds Razor pages for views in a project. For internal use only.</Description>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <AssemblyName>dotnet-razorpagegenerator</AssemblyName>
     <PackageId>RazorPageGenerator</PackageId>
     <OutputType>Exe</OutputType>

--- a/src/Razor/test/Directory.Build.props
+++ b/src/Razor/test/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-    <DeveloperBuildTestTfms>netcoreapp3.0</DeveloperBuildTestTfms>
+    <DeveloperBuildTestTfms>$(DefaultNetCoreTargetFramework)</DeveloperBuildTestTfms>
     <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
     <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' ">$(StandardTestTfms)</StandardTestTfms>
     <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">net461;$(StandardTestTfms)</StandardTestTfms>

--- a/src/Razor/test/Directory.Build.props
+++ b/src/Razor/test/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-    <DeveloperBuildTestTfms>$(DefaultNetCoreTargetFramework)</DeveloperBuildTestTfms>
+    <DeveloperBuildTestTfms>netcoreapp5.0</DeveloperBuildTestTfms>
     <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
     <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' ">$(StandardTestTfms)</StandardTestTfms>
     <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">net461;$(StandardTestTfms)</StandardTestTfms>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework);net461</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(DefaultNetCoreTargetFramework);net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp5.0;net461</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework);net461</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(DefaultNetCoreTargetFramework);net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp5.0;net461</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.Test.MvcShim.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.Test.MvcShim.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework);net461</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.Test.MvcShim.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.Test.MvcShim.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(DefaultNetCoreTargetFramework);net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp5.0;net461</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Tools.Test/Microsoft.AspNetCore.Razor.Tools.Test.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Tools.Test/Microsoft.AspNetCore.Razor.Tools.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestFiles\**</DefaultItemExcludes>
   </PropertyGroup>
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Tools.Test/Microsoft.AspNetCore.Razor.Tools.Test.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Tools.Test/Microsoft.AspNetCore.Razor.Tools.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestFiles\**</DefaultItemExcludes>
   </PropertyGroup>
 

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/BuildVariables.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/BuildVariables.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
     internal static partial class BuildVariables
     {
         private static string _msBuildPath = string.Empty;
-        private static string _microsoftNETCoreApp30PackageVersion = string.Empty;
+        private static string _MicrosoftNETCoreApp50PackageVersion = string.Empty;
         private static string _microsoftNetCompilersToolsetPackageVersion = string.Empty;
 
         static partial void InitializeVariables();
@@ -20,12 +20,12 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             }
         }
 
-        public static string MicrosoftNETCoreApp30PackageVersion
+        public static string MicrosoftNETCoreApp50PackageVersion
         {
             get
             {
                 InitializeVariables();
-                return _microsoftNETCoreApp30PackageVersion;
+                return _MicrosoftNETCoreApp50PackageVersion;
             }
         }
 

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/InitializeTestProjectAttribute.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/InitializeTestProjectAttribute.cs
@@ -37,8 +37,8 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             }
 
             MSBuildIntegrationTestBase.Project = ProjectDirectory.Create(_originalProjectName, _testProjectName, _baseDirectory, _additionalProjects, _language);
-#if NETCOREAPP3_0
-            MSBuildIntegrationTestBase.TargetFramework = "netcoreapp3.0";
+#if NETCOREAPP
+            MSBuildIntegrationTestBase.TargetFramework = "netcoreapp5.0";
 #else
 #error Target frameworks need to be updated
 #endif

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 // Let the test app know it is running as part of a test.
                 "/p:RunningAsTest=true",
 
-                $"/p:MicrosoftNETCoreApp30PackageVersion={BuildVariables.MicrosoftNETCoreApp30PackageVersion}",
+                $"/p:MicrosoftNETCoreApp50PackageVersion={BuildVariables.MicrosoftNETCoreApp50PackageVersion}",
                 $"/p:MicrosoftNetCompilersToolsetPackageVersion={BuildVariables.MicrosoftNetCompilersToolsetPackageVersion}",
 
                 // Additional restore sources for projects that require built packages

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/PackIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/PackIntegrationTest.cs
@@ -29,12 +29,12 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.NuspecContains(
                 result,
                 Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
-                @"<files include=""any/netcoreapp3.0/Views/Shared/_Layout.cshtml"" buildAction=""Content"" />");
+                @"<files include=""any/netcoreapp5.0/Views/Shared/_Layout.cshtml"" buildAction=""Content"" />");
 
             Assert.NupkgContains(
                 result,
                 Path.Combine("bin", Configuration, "ClassLibrary.1.0.0.nupkg"),
-                Path.Combine("contentFiles", "any", "netcoreapp3.0", "Views", "Shared", "_Layout.cshtml"));
+                Path.Combine("contentFiles", "any", "netcoreapp5.0", "Views", "Shared", "_Layout.cshtml"));
         }
 
         [Fact]
@@ -56,25 +56,25 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 Assert.NuspecContains(
                     result,
                     Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
-                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp3.0", "ClassLibrary.Views.dll")}\" " +
-                    $"target=\"{Path.Combine("lib", "netcoreapp3.0", "ClassLibrary.Views.dll")}\" />");
+                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp5.0", "ClassLibrary.Views.dll")}\" " +
+                    $"target=\"{Path.Combine("lib", "netcoreapp5.0", "ClassLibrary.Views.dll")}\" />");
 
                 Assert.NuspecDoesNotContain(
                     result,
                     Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
-                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp3.0", "ClassLibrary.Views.pdb")}\" " +
-                    $"target=\"{Path.Combine("lib", "netcoreapp3.0", "ClassLibrary.Views.pdb")}\" />");
+                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp5.0", "ClassLibrary.Views.pdb")}\" " +
+                    $"target=\"{Path.Combine("lib", "netcoreapp5.0", "ClassLibrary.Views.pdb")}\" />");
             }
 
             Assert.NuspecDoesNotContain(
                 result,
                 Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
-                @"<files include=""any/netcoreapp3.0/Views/Shared/_Layout.cshtml"" buildAction=""Content"" />");
+                @"<files include=""any/netcoreapp5.0/Views/Shared/_Layout.cshtml"" buildAction=""Content"" />");
 
             Assert.NupkgContains(
                 result,
                 Path.Combine("bin", Configuration, "ClassLibrary.1.0.0.nupkg"),
-                Path.Combine("lib", "netcoreapp3.0", "ClassLibrary.Views.dll"));
+                Path.Combine("lib", "netcoreapp5.0", "ClassLibrary.Views.dll"));
         }
 
         [Fact]
@@ -94,25 +94,25 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 Assert.NuspecContains(
                     result,
                     Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
-                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp3.0", "ClassLibrary.Views.dll")}\" " +
-                    $"target=\"{Path.Combine("lib", "netcoreapp3.0", "ClassLibrary.Views.dll")}\" />");
+                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp5.0", "ClassLibrary.Views.dll")}\" " +
+                    $"target=\"{Path.Combine("lib", "netcoreapp5.0", "ClassLibrary.Views.dll")}\" />");
 
                 Assert.NuspecDoesNotContain(
                     result,
                     Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
-                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp3.0", "ClassLibrary.Views.pdb")}\" " +
-                    $"target=\"{Path.Combine("lib", "netcoreapp3.0", "ClassLibrary.Views.pdb")}\" />");
+                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp5.0", "ClassLibrary.Views.pdb")}\" " +
+                    $"target=\"{Path.Combine("lib", "netcoreapp5.0", "ClassLibrary.Views.pdb")}\" />");
             }
 
             Assert.NuspecDoesNotContain(
                 result,
                 Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
-                @"<files include=""any/netcoreapp3.0/Views/Shared/_Layout.cshtml"" buildAction=""Content"" />");
+                @"<files include=""any/netcoreapp5.0/Views/Shared/_Layout.cshtml"" buildAction=""Content"" />");
 
             Assert.NupkgContains(
                 result,
                 Path.Combine("bin", Configuration, "ClassLibrary.1.0.0.nupkg"),
-                Path.Combine("lib", "netcoreapp3.0", "ClassLibrary.Views.dll"));
+                Path.Combine("lib", "netcoreapp5.0", "ClassLibrary.Views.dll"));
         }
 
         [Fact]
@@ -129,21 +129,21 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 Assert.NuspecContains(
                     result,
                     Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.symbols.nuspec"),
-                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp3.0", "ClassLibrary.Views.dll")}\" " +
-                    $"target=\"{Path.Combine("lib", "netcoreapp3.0", "ClassLibrary.Views.dll")}\" />");
+                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp5.0", "ClassLibrary.Views.dll")}\" " +
+                    $"target=\"{Path.Combine("lib", "netcoreapp5.0", "ClassLibrary.Views.dll")}\" />");
 
                 Assert.NuspecContains(
                     result,
                     Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.symbols.nuspec"),
-                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp3.0", "ClassLibrary.Views.pdb")}\" " +
-                    $"target=\"{Path.Combine("lib", "netcoreapp3.0", "ClassLibrary.Views.pdb")}\" />");
+                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp5.0", "ClassLibrary.Views.pdb")}\" " +
+                    $"target=\"{Path.Combine("lib", "netcoreapp5.0", "ClassLibrary.Views.pdb")}\" />");
             }
 
             Assert.NupkgContains(
                 result,
                 Path.Combine("bin", Configuration, "ClassLibrary.1.0.0.symbols.nupkg"),
-                Path.Combine("lib", "netcoreapp3.0", "ClassLibrary.Views.dll"),
-                Path.Combine("lib", "netcoreapp3.0", "ClassLibrary.Views.pdb"));
+                Path.Combine("lib", "netcoreapp5.0", "ClassLibrary.Views.dll"),
+                Path.Combine("lib", "netcoreapp5.0", "ClassLibrary.Views.pdb"));
         }
 
         [Fact]
@@ -163,19 +163,19 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 Assert.NuspecContains(
                     result,
                     Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
-                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp3.0", "ClassLibrary.Views.dll")}\" " +
-                    $"target=\"{Path.Combine("lib", "netcoreapp3.0", "ClassLibrary.Views.dll")}\" />");
+                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp5.0", "ClassLibrary.Views.dll")}\" " +
+                    $"target=\"{Path.Combine("lib", "netcoreapp5.0", "ClassLibrary.Views.dll")}\" />");
 
                 Assert.NuspecContains(
                     result,
                     Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
-                    @"<files include=""any/netcoreapp3.0/Views/Shared/_Layout.cshtml"" buildAction=""Content"" />");
+                    @"<files include=""any/netcoreapp5.0/Views/Shared/_Layout.cshtml"" buildAction=""Content"" />");
             }
 
             Assert.NupkgContains(
                 result,
                 Path.Combine("bin", Configuration, "ClassLibrary.1.0.0.nupkg"),
-                Path.Combine("lib", "netcoreapp3.0", "ClassLibrary.Views.dll"));
+                Path.Combine("lib", "netcoreapp5.0", "ClassLibrary.Views.dll"));
         }
 
         [Fact]

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/PublishIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/PublishIntegrationTest.cs
@@ -434,7 +434,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             var result = await DotnetMSBuild("Publish", "/p:NoBuild=true");
 
             Assert.BuildFailed(result);
-            Assert.BuildError(result, "MSB3030"); // Could not copy the file "obj/Debug/netcoreapp3.0/SimpleMvc.dll because it couldn't be found.
+            Assert.BuildError(result, "MSB3030"); // Could not copy the file "obj/Debug/netcoreapp5.0/SimpleMvc.dll because it couldn't be found.
 
             Assert.FileDoesNotExist(result, PublishOutputPath, "SimpleMvc.dll");
             Assert.FileDoesNotExist(result, PublishOutputPath, "SimpleMvc.Views.dll");

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/Microsoft.NET.Sdk.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/Microsoft.NET.Sdk.Razor.Test.csproj
@@ -7,7 +7,7 @@
       This is also a partial workaround for https://github.com/Microsoft/msbuild/issues/2661 - this project
       has netcoreapp dependencies that need to be built first.
     -->
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <DefineConstants Condition="'$(PreserveWorkingDirectory)'=='true'">$(DefineConstants);PRESERVE_WORKING_DIRECTORY</DefineConstants>
     <!-- Copy references locally so that we can use them in the test. -->

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/Microsoft.NET.Sdk.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/Microsoft.NET.Sdk.Razor.Test.csproj
@@ -7,7 +7,7 @@
       This is also a partial workaround for https://github.com/Microsoft/msbuild/issues/2661 - this project
       has netcoreapp dependencies that need to be built first.
     -->
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <DefineConstants Condition="'$(PreserveWorkingDirectory)'=='true'">$(DefineConstants);PRESERVE_WORKING_DIRECTORY</DefineConstants>
     <!-- Copy references locally so that we can use them in the test. -->
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         static partial void InitializeVariables()
         {
             _msBuildPath = @"$(_DesktopMSBuildPath)";
-            _microsoftNETCoreApp30PackageVersion = "$(MicrosoftNETCoreApp30PackageVersion)";
+            _MicrosoftNETCoreApp50PackageVersion = "$(MicrosoftNETCoreApp50PackageVersion)";
             _microsoftNetCompilersToolsetPackageVersion = "$(MicrosoftNetCompilersToolsetPackageVersion)";
         }
     }

--- a/src/Razor/test/RazorPageGenerator.Test/RazorPageGenerator.Test.csproj
+++ b/src/Razor/test/RazorPageGenerator.Test/RazorPageGenerator.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <!-- To generate baselines, run tests with /p:GenerateBaselines=true -->
     <DefineConstants Condition="'$(GenerateBaselines)'=='true'">$(DefineConstants);GENERATE_BASELINES</DefineConstants>
     <DefineConstants>$(DefineConstants);__RemoveThisBitTo__GENERATE_BASELINES</DefineConstants>

--- a/src/Razor/test/RazorPageGenerator.Test/RazorPageGenerator.Test.csproj
+++ b/src/Razor/test/RazorPageGenerator.Test/RazorPageGenerator.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <!-- To generate baselines, run tests with /p:GenerateBaselines=true -->
     <DefineConstants Condition="'$(GenerateBaselines)'=='true'">$(DefineConstants);GENERATE_BASELINES</DefineConstants>
     <DefineConstants>$(DefineConstants);__RemoveThisBitTo__GENERATE_BASELINES</DefineConstants>

--- a/src/Razor/test/testapps/AppWithP2PReference/AppWithP2PReference.csproj
+++ b/src/Razor/test/testapps/AppWithP2PReference/AppWithP2PReference.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/testapps/AppWithP2PReference/AppWithP2PReference.csproj
+++ b/src/Razor/test/testapps/AppWithP2PReference/AppWithP2PReference.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/testapps/AppWithPackageAndP2PReference/AppWithPackageAndP2PReference.csproj
+++ b/src/Razor/test/testapps/AppWithPackageAndP2PReference/AppWithPackageAndP2PReference.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <RuntimeAdditionalRestoreSources Condition="'$(RuntimeAdditionalRestoreSources)' == ''">$(MSBuildThisFileDirectory)..\TestPackageRestoreSource\</RuntimeAdditionalRestoreSources>
     <RestoreSources>
       $(RestoreSources);

--- a/src/Razor/test/testapps/AppWithPackageAndP2PReference/AppWithPackageAndP2PReference.csproj
+++ b/src/Razor/test/testapps/AppWithPackageAndP2PReference/AppWithPackageAndP2PReference.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <RuntimeAdditionalRestoreSources Condition="'$(RuntimeAdditionalRestoreSources)' == ''">$(MSBuildThisFileDirectory)..\TestPackageRestoreSource\</RuntimeAdditionalRestoreSources>
     <RestoreSources>
       $(RestoreSources);

--- a/src/Razor/test/testapps/ClassLibrary/ClassLibrary.csproj
+++ b/src/Razor/test/testapps/ClassLibrary/ClassLibrary.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <Copyright>© Microsoft</Copyright>
     <Product>Razor Test</Product>
     <Company>Microsoft</Company>

--- a/src/Razor/test/testapps/ClassLibrary/ClassLibrary.csproj
+++ b/src/Razor/test/testapps/ClassLibrary/ClassLibrary.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Copyright>© Microsoft</Copyright>
     <Product>Razor Test</Product>
     <Company>Microsoft</Company>

--- a/src/Razor/test/testapps/ClassLibrary2/ClassLibrary2.csproj
+++ b/src/Razor/test/testapps/ClassLibrary2/ClassLibrary2.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 

--- a/src/Razor/test/testapps/ClassLibrary2/ClassLibrary2.csproj
+++ b/src/Razor/test/testapps/ClassLibrary2/ClassLibrary2.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 

--- a/src/Razor/test/testapps/ComponentApp/ComponentApp.csproj
+++ b/src/Razor/test/testapps/ComponentApp/ComponentApp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/testapps/ComponentApp/ComponentApp.csproj
+++ b/src/Razor/test/testapps/ComponentApp/ComponentApp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/testapps/Directory.Build.targets
+++ b/src/Razor/test/testapps/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="RazorTest.Introspection.targets" />
 
   <PropertyGroup>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">$(MicrosoftNETCoreApp30PackageVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp5.0' ">$(MicrosoftNETCoreApp50PackageVersion)</RuntimeFrameworkVersion>
     <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
     <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
   </PropertyGroup>

--- a/src/Razor/test/testapps/LargeProject/LargeProject.csproj
+++ b/src/Razor/test/testapps/LargeProject/LargeProject.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(RunningAsTest)' == ''">

--- a/src/Razor/test/testapps/LargeProject/LargeProject.csproj
+++ b/src/Razor/test/testapps/LargeProject/LargeProject.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(RunningAsTest)' == ''">

--- a/src/Razor/test/testapps/MvcWithComponents/MvcWithComponents.csproj
+++ b/src/Razor/test/testapps/MvcWithComponents/MvcWithComponents.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/testapps/MvcWithComponents/MvcWithComponents.csproj
+++ b/src/Razor/test/testapps/MvcWithComponents/MvcWithComponents.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/testapps/PackageLibraryDirectDependency/PackageLibraryDirectDependency.csproj
+++ b/src/Razor/test/testapps/PackageLibraryDirectDependency/PackageLibraryDirectDependency.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <Copyright>© Microsoft</Copyright>
     <Product>Razor Test</Product>
     <Company>Microsoft</Company>

--- a/src/Razor/test/testapps/PackageLibraryDirectDependency/PackageLibraryDirectDependency.csproj
+++ b/src/Razor/test/testapps/PackageLibraryDirectDependency/PackageLibraryDirectDependency.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Copyright>© Microsoft</Copyright>
     <Product>Razor Test</Product>
     <Company>Microsoft</Company>

--- a/src/Razor/test/testapps/RestoreTestProjects/RestoreTestProjects.csproj
+++ b/src/Razor/test/testapps/RestoreTestProjects/RestoreTestProjects.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/testapps/RestoreTestProjects/RestoreTestProjects.csproj
+++ b/src/Razor/test/testapps/RestoreTestProjects/RestoreTestProjects.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/testapps/SimpleMvc/SimpleMvc.csproj
+++ b/src/Razor/test/testapps/SimpleMvc/SimpleMvc.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/testapps/SimpleMvc/SimpleMvc.csproj
+++ b/src/Razor/test/testapps/SimpleMvc/SimpleMvc.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/testapps/SimpleMvcFSharp/SimpleMvcFSharp.fsproj
+++ b/src/Razor/test/testapps/SimpleMvcFSharp/SimpleMvcFSharp.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/testapps/SimpleMvcFSharp/SimpleMvcFSharp.fsproj
+++ b/src/Razor/test/testapps/SimpleMvcFSharp/SimpleMvcFSharp.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/testapps/SimplePages/SimplePages.csproj
+++ b/src/Razor/test/testapps/SimplePages/SimplePages.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/testapps/SimplePages/SimplePages.csproj
+++ b/src/Razor/test/testapps/SimplePages/SimplePages.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is a rough first-crack at retargeting AspNetCore-Tooling to `netcoreapp5.0`, as well as using a 5.0 SDK. This is partially a proof-of-concept for flowing into AspNetCore & removing the need for some Razor workarounds in https://github.com/aspnet/AspNetCore/pull/12977, and partially an honest attempt to get us to 5.0 in master.

@dougbu @JunTaoLuo @jkotalik @pranavkm PTAL, and please tag anyone else who should have eyes on this