### PR TITLE
Unskip VS4Mac tests.

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/FallbackRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/FallbackRazorProjectHostTest.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
 {
     public class FallbackRazorProjectHostTest
     {
-        [Theory(Skip = "MonoDevelop.Core.FilePath cannot be loaded due to strong name issues.")]
+        [Theory]
         [InlineData(null)]
         [InlineData("")]
         public void IsMvcAssembly_FailsIfNullOrEmptyFilePath(string filePath)
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             Assert.False(result);
         }
 
-        [Fact(Skip = "MonoDevelop.Core.FilePath cannot be loaded due to strong name issues.")]
+        [Fact]
         public void IsMvcAssembly_FailsIfNotMvc()
         {
             // Arrange
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             Assert.False(result);
         }
 
-        [Fact(Skip = "MonoDevelop.Core.FilePath cannot be loaded due to strong name issues.")]
+        [Fact]
         public void IsMvcAssembly_SucceedsIfMvc()
         {
             // Arrange


### PR DESCRIPTION
- We now depend on new and signed binaries from Monodevelop.

aspnet/AspNetCore#5051