### PR TITLE
Fix razor tool assembly path

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.CodeGeneration.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.CodeGeneration.targets
@@ -39,7 +39,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_RazorGenerateInputsHash></_RazorGenerateInputsHash>
     <_RazorGenerateInputsHashFile>$(IntermediateOutputPath)$(MSBuildProjectName).RazorCoreGenerate.cache</_RazorGenerateInputsHashFile>
 
-    <_RazorToolAssembly Condition="'$(_RazorToolAssembly)'==''">$(RazorSdkDirectoryRoot)tools\$(DefaultNetCoreTargetFramework)\rzc.dll</_RazorToolAssembly>
+    <_RazorToolAssembly Condition="'$(_RazorToolAssembly)'==''">$(RazorSdkDirectoryRoot)tools\netcoreapp3.1\rzc.dll</_RazorToolAssembly>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Search and replace was overzealous and rzc can no longer be resolved correctly. This fixes the template test breaks in https://github.com/aspnet/AspNetCore/pull/13571.