### PR TITLE
 Fix #10498 - void elements with directive attributes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,6 +31,9 @@
 
     <!-- Working around https://github.com/NuGet/Home/issues/8467 -->
     <NoWarn>$(NoWarn);NU5131</NoWarn>
+
+    <!-- Working around https://github.com/microsoft/msbuild/pull/4764 -->
+    <EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>
   </PropertyGroup>
 
   <PropertyGroup Label="Package and Assembly Metadata">

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 if (startTag != null)
                 {
                     var tagName = startTag.GetTagNameWithOptionalBang();
-                    if (TryRewriteTagHelperStart(startTag, out tagHelperStart, out tagHelperInfo))
+                    if (TryRewriteTagHelperStart(startTag, node.EndTag, out tagHelperStart, out tagHelperInfo))
                     {
                         // This is a tag helper.
                         if (tagHelperInfo.TagMode == TagMode.SelfClosing || tagHelperInfo.TagMode == TagMode.StartTagOnly)
@@ -215,7 +215,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 return base.VisitMarkupTextLiteral(node);
             }
 
-            private bool TryRewriteTagHelperStart(MarkupStartTagSyntax startTag, out MarkupTagHelperStartTagSyntax rewritten, out TagHelperInfo tagHelperInfo)
+            private bool TryRewriteTagHelperStart(
+                MarkupStartTagSyntax startTag,
+                MarkupEndTagSyntax endTag,
+                out MarkupTagHelperStartTagSyntax rewritten,
+                out TagHelperInfo tagHelperInfo)
             {
                 rewritten = null;
                 tagHelperInfo = null;
@@ -278,7 +282,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     _errorSink,
                     _source);
 
-                var tagMode = TagHelperBlockRewriter.GetTagMode(startTag, tagHelperBinding, _errorSink);
+                var tagMode = TagHelperBlockRewriter.GetTagMode(startTag, endTag, tagHelperBinding);
                 tagHelperInfo = new TagHelperInfo(tagName, tagMode, tagHelperBinding);
                 rewritten = rewrittenStartTag;
 

--- a/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Razor/test/RazorLanguage.Test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -184,7 +184,7 @@ namespace Test
 
             // Act
             var generated = CompileToCSharp(@"
-<MyComponent 
+<MyComponent
     IntProperty=""123""
     BoolProperty=""true""
     StringProperty=""My string""
@@ -317,7 +317,7 @@ namespace Test
 
             // Act
             var generated = CompileToCSharp(@"
-@{ 
+@{
   var myValue = ""Expression value"";
 }
 <elem data-abc=""Literal value"" data-def=""@myValue"" />");
@@ -335,7 +335,7 @@ namespace Test
 
             // Act
             var generated = CompileToCSharp(@"
-@{ 
+@{
   var myValue = ""Expression value"";
 }
 <elem data-abc=""Literal value"" data-def=""@(myValue)"" />");
@@ -353,7 +353,7 @@ namespace Test
 
             // Act
             var generated = CompileToCSharp(@"
-@{ 
+@{
   var myValue = ""Expression value"";
 }
 <div>@myValue <!-- @myValue --> </div>");
@@ -471,7 +471,7 @@ namespace Test
             var generated = CompileToCSharp(@"
 <InputText @bind-Value=""person.Name"" />
 
-@functions 
+@functions
 {
     Person person = new Person();
 }");
@@ -886,6 +886,37 @@ namespace Test
             // Act
             var generated = CompileToCSharp(@"
 <div @bind=""@ParentValue"" />
+@code {
+    public string ParentValue { get; set; } = ""hi"";
+}");
+
+            // Assert
+            AssertDocumentNodeMatchesBaseline(generated.CodeDocument);
+            AssertCSharpDocumentMatchesBaseline(generated.CodeDocument);
+            CompileToAssembly(generated);
+        }
+
+        [Fact]
+        public void BindToElement_WithoutCloseTag()
+        {
+            // Arrange
+            AdditionalSyntaxTrees.Add(Parse(@"
+using System;
+using Microsoft.AspNetCore.Components;
+
+namespace Test
+{
+    [BindElement(""div"", null, ""myvalue"", ""myevent"")]
+    public static class BindAttributes
+    {
+    }
+}"));
+
+            // Act
+            var generated = CompileToCSharp(@"
+<div>
+  <input @bind=""@ParentValue"">
+</div>
 @code {
     public string ParentValue { get; set; } = ""hi"";
 }");
@@ -2609,6 +2640,28 @@ namespace Test
         }
 
         [Fact]
+        public void EventHandler_OnElement_WithoutCloseTag()
+        {
+            // Arrange
+
+            // Act
+            var generated = CompileToCSharp(@"
+@using Microsoft.AspNetCore.Components.Web
+<div>
+  <input @onclick=""OnClick"">
+</div>
+@code {
+    void OnClick() {
+    }
+}");
+
+            // Assert
+            AssertDocumentNodeMatchesBaseline(generated.CodeDocument);
+            AssertCSharpDocumentMatchesBaseline(generated.CodeDocument);
+            CompileToAssembly(generated);
+        }
+
+        [Fact]
         public void EventHandler_OnElement_WithEventArgsMethodGroup()
         {
             // Arrange
@@ -2659,7 +2712,7 @@ namespace Test
 @using Microsoft.AspNetCore.Components.Web
 <input @onclick=""OnClick"" />
 @code {
-    Task OnClick() 
+    Task OnClick()
     {
         return Task.CompletedTask;
     }
@@ -2682,7 +2735,7 @@ namespace Test
 @using Microsoft.AspNetCore.Components.Web
 <input @onclick=""OnClick"" />
 @code {
-    Task OnClick(MouseEventArgs e) 
+    Task OnClick(MouseEventArgs e)
     {
         return Task.CompletedTask;
     }
@@ -4300,7 +4353,7 @@ namespace Test
         {
             // Arrange/Act
             var generated = CompileToCSharp(@"
-   
+
 @(""My value"")
 
 <h1>Hello</h1>");

--- a/src/Razor/test/RazorLanguage.Test/Legacy/TagHelperBlockRewriterTest.cs
+++ b/src/Razor/test/RazorLanguage.Test/Legacy/TagHelperBlockRewriterTest.cs
@@ -234,6 +234,57 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
+        public void AllowsCompatibleTagStructures_DirectiveAttribute_SelfClosing()
+        {
+            // Arrange
+            var descriptors = new TagHelperDescriptor[]
+            {
+                TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
+                    .TagMatchingRuleDescriptor(rule =>
+                    {
+                        rule
+                            .RequireTagName("*")
+                            .RequireAttributeDescriptor(b =>
+                            {
+                                b.Name = "@onclick";
+                                b.Metadata.Add(ComponentMetadata.Common.DirectiveAttribute, bool.TrueString);
+                            });
+                    })
+                    .AddMetadata(ComponentMetadata.SpecialKindKey, ComponentMetadata.EventHandler.TagHelperKind)
+                    .Build(),
+            };
+
+            // Act & Assert
+            EvaluateData(descriptors, "<input @onclick=\"@test\"/>");
+        }
+
+        [Fact]
+        public void AllowsCompatibleTagStructures_DirectiveAttribute_Void()
+        {
+            // Arrange
+            var descriptors = new TagHelperDescriptor[]
+            {
+                TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
+                    .TagMatchingRuleDescriptor(rule =>
+                    {
+                        rule
+                            .RequireTagName("*")
+                            .RequireAttributeDescriptor(b =>
+                            {
+                                b.Name = "@onclick";
+                                b.Metadata.Add(ComponentMetadata.Common.DirectiveAttribute, bool.TrueString);
+                            });
+ 
+                    })
+                    .AddMetadata(ComponentMetadata.SpecialKindKey, ComponentMetadata.EventHandler.TagHelperKind)
+                    .Build(),
+            };
+
+            // Act & Assert
+            EvaluateData(descriptors, "<input @onclick=\"@test\">");
+        }
+
+        [Fact]
         public void CreatesErrorForMalformedTagHelpersWithAttributes1()
         {
             RunParseTreeRewriterTest("<p class='", "strong", "p");

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
@@ -27,5 +27,5 @@ Document -
                             IntermediateToken -  - CSharp - )
                 HtmlContent - (103:2,28 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (103:2,28 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-            CSharpCode - (112:3,7 [89] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (112:3,7 [89] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick(MouseEventArgs e) \n    {\n        return Task.CompletedTask;\n    }\n
+            CSharpCode - (112:3,7 [88] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (112:3,7 [88] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick(MouseEventArgs e)\n    {\n        return Task.CompletedTask;\n    }\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
@@ -13,16 +13,16 @@ Source Location: (92:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1288:38,17 [7] )
 |OnClick|
 
-Source Location: (112:3,7 [89] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (112:3,7 [88] x:\dir\subdir\Test\TestComponent.cshtml)
 |
-    Task OnClick(MouseEventArgs e) 
+    Task OnClick(MouseEventArgs e)
     {
         return Task.CompletedTask;
     }
 |
-Generated Location: (1489:48,7 [89] )
+Generated Location: (1489:48,7 [88] )
 |
-    Task OnClick(MouseEventArgs e) 
+    Task OnClick(MouseEventArgs e)
     {
         return Task.CompletedTask;
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
@@ -47,7 +47,7 @@ using Microsoft.AspNetCore.Components.Web;
 #nullable restore
 #line 4 "x:\dir\subdir\Test\TestComponent.cshtml"
        
-    Task OnClick() 
+    Task OnClick()
     {
         return Task.CompletedTask;
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
@@ -27,5 +27,5 @@ Document -
                             IntermediateToken -  - CSharp - )
                 HtmlContent - (103:2,28 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (103:2,28 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-            CSharpCode - (112:3,7 [73] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (112:3,7 [73] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick() \n    {\n        return Task.CompletedTask;\n    }\n
+            CSharpCode - (112:3,7 [72] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (112:3,7 [72] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick()\n    {\n        return Task.CompletedTask;\n    }\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
@@ -13,16 +13,16 @@ Source Location: (92:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1288:38,17 [7] )
 |OnClick|
 
-Source Location: (112:3,7 [73] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (112:3,7 [72] x:\dir\subdir\Test\TestComponent.cshtml)
 |
-    Task OnClick() 
+    Task OnClick()
     {
         return Task.CompletedTask;
     }
 |
-Generated Location: (1489:48,7 [73] )
+Generated Location: (1489:48,7 [72] )
 |
-    Task OnClick() 
+    Task OnClick()
     {
         return Task.CompletedTask;
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.ir.txt
@@ -23,5 +23,5 @@ Document -
                             IntermediateToken -  - CSharp - __value => person.Name = __value
                 HtmlContent - (39:0,39 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (39:0,39 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
-            CSharpCode - (57:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (57:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Person person = new Person();\n
+            CSharpCode - (56:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (56:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Person person = new Person();\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
@@ -3,7 +3,7 @@ Source Location: (24:0,24 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (985:25,24 [11] )
 |person.Name|
 
-Source Location: (57:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (56:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     Person person = new Person();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithoutCloseTag/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithoutCloseTag/TestComponent.codegen.cs
@@ -20,18 +20,10 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
-#nullable restore
-#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-  
-  var myValue = "Expression value";
-
-#line default
-#line hidden
-#nullable disable
             __o = 
 #nullable restore
-#line 4 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                           myValue
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                 ParentValue
 
 #line default
 #line hidden
@@ -39,6 +31,14 @@ namespace Test
             ;
         }
         #pragma warning restore 1998
+#nullable restore
+#line 4 "x:\dir\subdir\Test\TestComponent.cshtml"
+       
+    public string ParentValue { get; set; } = "hi";
+
+#line default
+#line hidden
+#nullable disable
     }
 }
 #pragma warning restore 1591

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithoutCloseTag/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithoutCloseTag/TestComponent.ir.txt
@@ -1,0 +1,29 @@
+Document - 
+    NamespaceDeclaration -  - Test
+        UsingDirective - (3:1,1 [12] ) - System
+        UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
+        UsingDirective - (53:3,1 [17] ) - System.Linq
+        UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [37] ) - Microsoft.AspNetCore.Components
+        ClassDeclaration -  - public partial - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
+            DesignTimeDirective - 
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
+                IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
+            MethodDeclaration -  - protected override - void - BuildRenderTree
+                MarkupElement - (0:0,0 [45] x:\dir\subdir\Test\TestComponent.cshtml) - div
+                    HtmlContent - (5:0,5 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (5:0,5 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n  
+                    MarkupElement - (9:1,2 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                        HtmlAttribute - (15:1,8 [21] x:\dir\subdir\Test\TestComponent.cshtml) -  @bind=" - "
+                            CSharpExpressionAttributeValue - (23:1,16 [12] x:\dir\subdir\Test\TestComponent.cshtml) - 
+                                IntermediateToken - (24:1,17 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
+                    HtmlContent - (37:1,30 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (37:1,30 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+                HtmlContent - (45:2,6 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (45:2,6 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (54:3,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (54:3,7 [55] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public string ParentValue { get; set; } = "hi";\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithoutCloseTag/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithoutCloseTag/TestComponent.mappings.txt
@@ -1,0 +1,14 @@
+Source Location: (24:1,17 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (889:25,17 [11] )
+|ParentValue|
+
+Source Location: (54:3,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
+|
+    public string ParentValue { get; set; } = "hi";
+|
+Generated Location: (1093:35,7 [55] )
+|
+    public string ParentValue { get; set; } = "hi";
+|
+

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.ir.txt
@@ -14,13 +14,13 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                Component - (0:0,0 [132] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
-                    ComponentAttribute - (32:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml) - IntProperty - AttributeStructure.DoubleQuotes
-                        IntermediateToken - (32:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - 123
-                    ComponentAttribute - (56:2,18 [4] x:\dir\subdir\Test\TestComponent.cshtml) - BoolProperty - AttributeStructure.DoubleQuotes
-                        IntermediateToken - (56:2,18 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - true
-                    ComponentAttribute - (83:3,20 [9] x:\dir\subdir\Test\TestComponent.cshtml) - StringProperty - AttributeStructure.DoubleQuotes
-                        HtmlContent - (83:3,20 [9] x:\dir\subdir\Test\TestComponent.cshtml)
-                            IntermediateToken - (83:3,20 [9] x:\dir\subdir\Test\TestComponent.cshtml) - Html - My string
-                    ComponentAttribute - (115:4,20 [14] x:\dir\subdir\Test\TestComponent.cshtml) - ObjectProperty - AttributeStructure.DoubleQuotes
-                        IntermediateToken - (115:4,20 [14] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - new SomeType()
+                Component - (0:0,0 [131] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
+                    ComponentAttribute - (31:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml) - IntProperty - AttributeStructure.DoubleQuotes
+                        IntermediateToken - (31:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - 123
+                    ComponentAttribute - (55:2,18 [4] x:\dir\subdir\Test\TestComponent.cshtml) - BoolProperty - AttributeStructure.DoubleQuotes
+                        IntermediateToken - (55:2,18 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - true
+                    ComponentAttribute - (82:3,20 [9] x:\dir\subdir\Test\TestComponent.cshtml) - StringProperty - AttributeStructure.DoubleQuotes
+                        HtmlContent - (82:3,20 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+                            IntermediateToken - (82:3,20 [9] x:\dir\subdir\Test\TestComponent.cshtml) - Html - My string
+                    ComponentAttribute - (114:4,20 [14] x:\dir\subdir\Test\TestComponent.cshtml) - ObjectProperty - AttributeStructure.DoubleQuotes
+                        IntermediateToken - (114:4,20 [14] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - new SomeType()

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.mappings.txt
@@ -1,14 +1,14 @@
-Source Location: (32:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (31:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |123|
 Generated Location: (977:25,17 [3] )
 |123|
 
-Source Location: (56:2,18 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (55:2,18 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |true|
 Generated Location: (1246:34,18 [4] )
 |true|
 
-Source Location: (115:4,20 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (114:4,20 [14] x:\dir\subdir\Test\TestComponent.cshtml)
 |new SomeType()|
 Generated Location: (1540:44,20 [14] )
 |new SomeType()|

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.ir.txt
@@ -14,14 +14,14 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
-                MarkupElement - (45:3,0 [55] x:\dir\subdir\Test\TestComponent.cshtml) - elem
-                    HtmlAttribute - (50:3,5 [25] x:\dir\subdir\Test\TestComponent.cshtml) -  data-abc=" - "
-                        HtmlAttributeValue - (61:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - 
-                            IntermediateToken - (61:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Literal
-                        HtmlAttributeValue - (68:3,23 [6] x:\dir\subdir\Test\TestComponent.cshtml) -  
-                            IntermediateToken - (69:3,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - value
-                    HtmlAttribute - (75:3,30 [22] x:\dir\subdir\Test\TestComponent.cshtml) -  data-def=" - "
-                        CSharpExpressionAttributeValue - (86:3,41 [10] x:\dir\subdir\Test\TestComponent.cshtml) - 
-                            IntermediateToken - (88:3,43 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - myValue
+                CSharpCode - (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n  var myValue = "Expression value";\n
+                MarkupElement - (44:3,0 [55] x:\dir\subdir\Test\TestComponent.cshtml) - elem
+                    HtmlAttribute - (49:3,5 [25] x:\dir\subdir\Test\TestComponent.cshtml) -  data-abc=" - "
+                        HtmlAttributeValue - (60:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - 
+                            IntermediateToken - (60:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Literal
+                        HtmlAttributeValue - (67:3,23 [6] x:\dir\subdir\Test\TestComponent.cshtml) -  
+                            IntermediateToken - (68:3,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - value
+                    HtmlAttribute - (74:3,30 [22] x:\dir\subdir\Test\TestComponent.cshtml) -  data-def=" - "
+                        CSharpExpressionAttributeValue - (85:3,41 [10] x:\dir\subdir\Test\TestComponent.cshtml) - 
+                            IntermediateToken - (87:3,43 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - myValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.mappings.txt
@@ -1,14 +1,14 @@
-Source Location: (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-| 
+Source Location: (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml)
+|
   var myValue = "Expression value";
 |
-Generated Location: (854:24,2 [40] )
-| 
+Generated Location: (854:24,2 [39] )
+|
   var myValue = "Expression value";
 |
 
-Source Location: (88:3,43 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (87:3,43 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |myValue|
-Generated Location: (1077:33,43 [7] )
+Generated Location: (1076:33,43 [7] )
 |myValue|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.codegen.cs
@@ -22,7 +22,7 @@ namespace Test
         {
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-   
+  
   var myValue = "Expression value";
 
 #line default

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.ir.txt
@@ -14,14 +14,14 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
-                MarkupElement - (45:3,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - elem
-                    HtmlAttribute - (50:3,5 [25] x:\dir\subdir\Test\TestComponent.cshtml) -  data-abc=" - "
-                        HtmlAttributeValue - (61:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - 
-                            IntermediateToken - (61:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Literal
-                        HtmlAttributeValue - (68:3,23 [6] x:\dir\subdir\Test\TestComponent.cshtml) -  
-                            IntermediateToken - (69:3,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - value
-                    HtmlAttribute - (75:3,30 [20] x:\dir\subdir\Test\TestComponent.cshtml) -  data-def=" - "
-                        CSharpExpressionAttributeValue - (86:3,41 [8] x:\dir\subdir\Test\TestComponent.cshtml) - 
-                            IntermediateToken - (87:3,42 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - myValue
+                CSharpCode - (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n  var myValue = "Expression value";\n
+                MarkupElement - (44:3,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - elem
+                    HtmlAttribute - (49:3,5 [25] x:\dir\subdir\Test\TestComponent.cshtml) -  data-abc=" - "
+                        HtmlAttributeValue - (60:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - 
+                            IntermediateToken - (60:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Literal
+                        HtmlAttributeValue - (67:3,23 [6] x:\dir\subdir\Test\TestComponent.cshtml) -  
+                            IntermediateToken - (68:3,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - value
+                    HtmlAttribute - (74:3,30 [20] x:\dir\subdir\Test\TestComponent.cshtml) -  data-def=" - "
+                        CSharpExpressionAttributeValue - (85:3,41 [8] x:\dir\subdir\Test\TestComponent.cshtml) - 
+                            IntermediateToken - (86:3,42 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - myValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.mappings.txt
@@ -1,14 +1,14 @@
-Source Location: (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-| 
+Source Location: (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml)
+|
   var myValue = "Expression value";
 |
-Generated Location: (854:24,2 [40] )
-| 
+Generated Location: (854:24,2 [39] )
+|
   var myValue = "Expression value";
 |
 
-Source Location: (87:3,42 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (86:3,42 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |myValue|
-Generated Location: (1076:33,42 [7] )
+Generated Location: (1075:33,42 [7] )
 |myValue|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.codegen.cs
@@ -8,6 +8,13 @@ namespace Test
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+using Microsoft.AspNetCore.Components.Web;
+
+#line default
+#line hidden
+#nullable disable
     public partial class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
     {
         #pragma warning disable 219
@@ -20,25 +27,26 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
+            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, 
 #nullable restore
-#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-  
-  var myValue = "Expression value";
+#line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
+                   OnClick
 
 #line default
 #line hidden
 #nullable disable
-            __o = 
-#nullable restore
-#line 4 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                           myValue
-
-#line default
-#line hidden
-#nullable disable
-            ;
+            );
         }
         #pragma warning restore 1998
+#nullable restore
+#line 5 "x:\dir\subdir\Test\TestComponent.cshtml"
+       
+    void OnClick() {
+    }
+
+#line default
+#line hidden
+#nullable disable
     }
 }
 #pragma warning restore 1591

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.ir.txt
@@ -1,0 +1,34 @@
+Document - 
+    NamespaceDeclaration -  - Test
+        UsingDirective - (3:1,1 [12] ) - System
+        UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
+        UsingDirective - (53:3,1 [17] ) - System.Linq
+        UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [37] ) - Microsoft.AspNetCore.Components
+        UsingDirective - (1:0,1 [41] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Components.Web
+        ClassDeclaration -  - public partial - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
+            DesignTimeDirective - 
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
+                IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
+            MethodDeclaration -  - protected override - void - BuildRenderTree
+                HtmlContent - (42:0,42 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (42:0,42 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+                MarkupElement - (44:1,0 [43] x:\dir\subdir\Test\TestComponent.cshtml) - div
+                    HtmlContent - (49:1,5 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (49:1,5 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n  
+                    MarkupElement - (53:2,2 [26] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                        HtmlAttribute - (70:2,19 [7] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                            CSharpExpressionAttributeValue -  - 
+                                IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, 
+                                IntermediateToken - (70:2,19 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
+                                IntermediateToken -  - CSharp - )
+                    HtmlContent - (79:2,28 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (79:2,28 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+                HtmlContent - (87:3,6 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (87:3,6 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (96:4,7 [31] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (96:4,7 [31] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    void OnClick() {\n    }\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.mappings.txt
@@ -1,0 +1,21 @@
+Source Location: (1:0,1 [41] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web|
+Generated Location: (320:12,0 [41] )
+|using Microsoft.AspNetCore.Components.Web|
+
+Source Location: (70:2,19 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|OnClick|
+Generated Location: (1174:32,19 [7] )
+|OnClick|
+
+Source Location: (96:4,7 [31] x:\dir\subdir\Test\TestComponent.cshtml)
+|
+    void OnClick() {
+    }
+|
+Generated Location: (1375:42,7 [31] )
+|
+    void OnClick() {
+    }
+|
+

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.codegen.cs
@@ -22,7 +22,7 @@ namespace Test
         {
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-   
+  
   var myValue = "Expression value";
 
 #line default

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.ir.txt
@@ -14,12 +14,12 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
-                MarkupElement - (45:3,0 [38] x:\dir\subdir\Test\TestComponent.cshtml) - div
-                    CSharpExpression - (51:3,6 [7] x:\dir\subdir\Test\TestComponent.cshtml)
-                        IntermediateToken - (51:3,6 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - myValue
-                    HtmlContent - (58:3,13 [1] x:\dir\subdir\Test\TestComponent.cshtml)
-                        IntermediateToken - (58:3,13 [1] x:\dir\subdir\Test\TestComponent.cshtml) - Html -  
-                    HtmlContent - (76:3,31 [1] x:\dir\subdir\Test\TestComponent.cshtml)
-                        IntermediateToken - (76:3,31 [1] x:\dir\subdir\Test\TestComponent.cshtml) - Html -  
+                CSharpCode - (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n  var myValue = "Expression value";\n
+                MarkupElement - (44:3,0 [38] x:\dir\subdir\Test\TestComponent.cshtml) - div
+                    CSharpExpression - (50:3,6 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (50:3,6 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - myValue
+                    HtmlContent - (57:3,13 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (57:3,13 [1] x:\dir\subdir\Test\TestComponent.cshtml) - Html -  
+                    HtmlContent - (75:3,31 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (75:3,31 [1] x:\dir\subdir\Test\TestComponent.cshtml) - Html -  

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.mappings.txt
@@ -1,14 +1,14 @@
-Source Location: (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-| 
+Source Location: (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml)
+|
   var myValue = "Expression value";
 |
-Generated Location: (854:24,2 [40] )
-| 
+Generated Location: (854:24,2 [39] )
+|
   var myValue = "Expression value";
 |
 
-Source Location: (51:3,6 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (50:3,6 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |myValue|
-Generated Location: (1020:32,6 [7] )
+Generated Location: (1019:32,6 [7] )
 |myValue|
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.codegen.cs
@@ -42,7 +42,7 @@ using Microsoft.AspNetCore.Components.Web;
 #nullable restore
 #line 4 "x:\dir\subdir\Test\TestComponent.cshtml"
        
-    Task OnClick(MouseEventArgs e) 
+    Task OnClick(MouseEventArgs e)
     {
         return Task.CompletedTask;
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
@@ -14,5 +14,5 @@ Document -
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, 
                             IntermediateToken - (92:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
                             IntermediateToken -  - CSharp - )
-            CSharpCode - (112:3,7 [89] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (112:3,7 [89] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick(MouseEventArgs e) \n    {\n        return Task.CompletedTask;\n    }\n
+            CSharpCode - (112:3,7 [88] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (112:3,7 [88] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick(MouseEventArgs e)\n    {\n        return Task.CompletedTask;\n    }\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
-Source Location: (112:3,7 [89] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (112:3,7 [88] x:\dir\subdir\Test\TestComponent.cshtml)
 |
-    Task OnClick(MouseEventArgs e) 
+    Task OnClick(MouseEventArgs e)
     {
         return Task.CompletedTask;
     }
 |
-Generated Location: (1340:43,7 [89] )
+Generated Location: (1340:43,7 [88] )
 |
-    Task OnClick(MouseEventArgs e) 
+    Task OnClick(MouseEventArgs e)
     {
         return Task.CompletedTask;
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
@@ -42,7 +42,7 @@ using Microsoft.AspNetCore.Components.Web;
 #nullable restore
 #line 4 "x:\dir\subdir\Test\TestComponent.cshtml"
        
-    Task OnClick() 
+    Task OnClick()
     {
         return Task.CompletedTask;
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
@@ -14,5 +14,5 @@ Document -
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, 
                             IntermediateToken - (92:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
                             IntermediateToken -  - CSharp - )
-            CSharpCode - (112:3,7 [73] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (112:3,7 [73] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick() \n    {\n        return Task.CompletedTask;\n    }\n
+            CSharpCode - (112:3,7 [72] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (112:3,7 [72] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick()\n    {\n        return Task.CompletedTask;\n    }\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
-Source Location: (112:3,7 [73] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (112:3,7 [72] x:\dir\subdir\Test\TestComponent.cshtml)
 |
-    Task OnClick() 
+    Task OnClick()
     {
         return Task.CompletedTask;
     }
 |
-Generated Location: (1340:43,7 [73] )
+Generated Location: (1340:43,7 [72] )
 |
-    Task OnClick() 
+    Task OnClick()
     {
         return Task.CompletedTask;
     }

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.ir.txt
@@ -14,5 +14,5 @@ Document -
                     ComponentAttribute - (24:0,24 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - __value => person.Name = __value
-            CSharpCode - (57:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (57:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Person person = new Person();\n
+            CSharpCode - (56:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (56:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Person person = new Person();\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
@@ -1,4 +1,4 @@
-Source Location: (57:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (56:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     Person person = new Person();
 |

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_StartEndTag/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_StartEndTag/TestComponent.mappings.txt
@@ -1,0 +1,9 @@
+Source Location: (45:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
+|
+    public string ParentValue { get; set; } = "hi";
+|
+Generated Location: (932:30,7 [55] )
+|
+    public string ParentValue { get; set; } = "hi";
+|
+

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithoutCloseTag/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithoutCloseTag/TestComponent.codegen.cs
@@ -10,35 +10,34 @@ namespace Test
     using Microsoft.AspNetCore.Components;
     public partial class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
     {
-        #pragma warning disable 219
-        private void __RazorDirectiveTokenHelpers__() {
-        }
-        #pragma warning restore 219
-        #pragma warning disable 0414
-        private static System.Object __o = null;
-        #pragma warning restore 0414
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
+            __builder.OpenElement(0, "div");
+            __builder.AddMarkupContent(1, "\r\n  ");
+            __builder.OpenElement(2, "input");
+            __builder.AddAttribute(3, "@bind", 
 #nullable restore
-#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-  
-  var myValue = "Expression value";
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                 ParentValue
 
 #line default
 #line hidden
 #nullable disable
-            __o = 
-#nullable restore
-#line 4 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                           myValue
-
-#line default
-#line hidden
-#nullable disable
-            ;
+            );
+            __builder.CloseElement();
+            __builder.AddMarkupContent(4, "\r\n");
+            __builder.CloseElement();
         }
         #pragma warning restore 1998
+#nullable restore
+#line 4 "x:\dir\subdir\Test\TestComponent.cshtml"
+       
+    public string ParentValue { get; set; } = "hi";
+
+#line default
+#line hidden
+#nullable disable
     }
 }
 #pragma warning restore 1591

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithoutCloseTag/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithoutCloseTag/TestComponent.ir.txt
@@ -1,0 +1,20 @@
+Document - 
+    NamespaceDeclaration -  - Test
+        UsingDirective - (3:1,1 [14] ) - System
+        UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
+        UsingDirective - (53:3,1 [19] ) - System.Linq
+        UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
+        ClassDeclaration -  - public partial - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
+            MethodDeclaration -  - protected override - void - BuildRenderTree
+                MarkupElement - (0:0,0 [45] x:\dir\subdir\Test\TestComponent.cshtml) - div
+                    HtmlContent - (5:0,5 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (5:0,5 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n  
+                    MarkupElement - (9:1,2 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                        HtmlAttribute - (15:1,8 [21] x:\dir\subdir\Test\TestComponent.cshtml) -  @bind=" - "
+                            CSharpExpressionAttributeValue - (23:1,16 [12] x:\dir\subdir\Test\TestComponent.cshtml) - 
+                                IntermediateToken - (24:1,17 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
+                    HtmlContent - (37:1,30 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (37:1,30 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (54:3,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (54:3,7 [55] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public string ParentValue { get; set; } = "hi";\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithoutCloseTag/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithoutCloseTag/TestComponent.mappings.txt
@@ -1,0 +1,9 @@
+Source Location: (54:3,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
+|
+    public string ParentValue { get; set; } = "hi";
+|
+Generated Location: (1133:34,7 [55] )
+|
+    public string ParentValue { get; set; } = "hi";
+|
+

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.ir.txt
@@ -7,13 +7,13 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public partial - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                Component - (0:0,0 [132] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
-                    ComponentAttribute - (32:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml) - IntProperty - AttributeStructure.DoubleQuotes
-                        IntermediateToken - (32:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - 123
-                    ComponentAttribute - (56:2,18 [4] x:\dir\subdir\Test\TestComponent.cshtml) - BoolProperty - AttributeStructure.DoubleQuotes
-                        IntermediateToken - (56:2,18 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - true
-                    ComponentAttribute - (83:3,20 [9] x:\dir\subdir\Test\TestComponent.cshtml) - StringProperty - AttributeStructure.DoubleQuotes
-                        HtmlContent - (83:3,20 [9] x:\dir\subdir\Test\TestComponent.cshtml)
-                            IntermediateToken - (83:3,20 [9] x:\dir\subdir\Test\TestComponent.cshtml) - Html - My string
-                    ComponentAttribute - (115:4,20 [14] x:\dir\subdir\Test\TestComponent.cshtml) - ObjectProperty - AttributeStructure.DoubleQuotes
-                        IntermediateToken - (115:4,20 [14] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - new SomeType()
+                Component - (0:0,0 [131] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent
+                    ComponentAttribute - (31:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml) - IntProperty - AttributeStructure.DoubleQuotes
+                        IntermediateToken - (31:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - 123
+                    ComponentAttribute - (55:2,18 [4] x:\dir\subdir\Test\TestComponent.cshtml) - BoolProperty - AttributeStructure.DoubleQuotes
+                        IntermediateToken - (55:2,18 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - true
+                    ComponentAttribute - (82:3,20 [9] x:\dir\subdir\Test\TestComponent.cshtml) - StringProperty - AttributeStructure.DoubleQuotes
+                        HtmlContent - (82:3,20 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+                            IntermediateToken - (82:3,20 [9] x:\dir\subdir\Test\TestComponent.cshtml) - Html - My string
+                    ComponentAttribute - (114:4,20 [14] x:\dir\subdir\Test\TestComponent.cshtml) - ObjectProperty - AttributeStructure.DoubleQuotes
+                        IntermediateToken - (114:4,20 [14] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - new SomeType()

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-   
+  
   var myValue = "Expression value";
 
 #line default

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.ir.txt
@@ -7,14 +7,14 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public partial - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
-                MarkupElement - (45:3,0 [55] x:\dir\subdir\Test\TestComponent.cshtml) - elem
-                    HtmlAttribute - (50:3,5 [25] x:\dir\subdir\Test\TestComponent.cshtml) -  data-abc=" - "
-                        HtmlAttributeValue - (61:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - 
-                            IntermediateToken - (61:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Literal
-                        HtmlAttributeValue - (68:3,23 [6] x:\dir\subdir\Test\TestComponent.cshtml) -  
-                            IntermediateToken - (69:3,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - value
-                    HtmlAttribute - (75:3,30 [22] x:\dir\subdir\Test\TestComponent.cshtml) -  data-def=" - "
-                        CSharpExpressionAttributeValue - (86:3,41 [10] x:\dir\subdir\Test\TestComponent.cshtml) - 
-                            IntermediateToken - (88:3,43 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - myValue
+                CSharpCode - (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n  var myValue = "Expression value";\n
+                MarkupElement - (44:3,0 [55] x:\dir\subdir\Test\TestComponent.cshtml) - elem
+                    HtmlAttribute - (49:3,5 [25] x:\dir\subdir\Test\TestComponent.cshtml) -  data-abc=" - "
+                        HtmlAttributeValue - (60:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - 
+                            IntermediateToken - (60:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Literal
+                        HtmlAttributeValue - (67:3,23 [6] x:\dir\subdir\Test\TestComponent.cshtml) -  
+                            IntermediateToken - (68:3,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - value
+                    HtmlAttribute - (74:3,30 [22] x:\dir\subdir\Test\TestComponent.cshtml) -  data-def=" - "
+                        CSharpExpressionAttributeValue - (85:3,41 [10] x:\dir\subdir\Test\TestComponent.cshtml) - 
+                            IntermediateToken - (87:3,43 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - myValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.mappings.txt
@@ -1,9 +1,9 @@
-Source Location: (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-| 
+Source Location: (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml)
+|
   var myValue = "Expression value";
 |
-Generated Location: (586:17,2 [40] )
-| 
+Generated Location: (586:17,2 [39] )
+|
   var myValue = "Expression value";
 |
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-   
+  
   var myValue = "Expression value";
 
 #line default

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.ir.txt
@@ -7,14 +7,14 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public partial - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
-                MarkupElement - (45:3,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - elem
-                    HtmlAttribute - (50:3,5 [25] x:\dir\subdir\Test\TestComponent.cshtml) -  data-abc=" - "
-                        HtmlAttributeValue - (61:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - 
-                            IntermediateToken - (61:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Literal
-                        HtmlAttributeValue - (68:3,23 [6] x:\dir\subdir\Test\TestComponent.cshtml) -  
-                            IntermediateToken - (69:3,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - value
-                    HtmlAttribute - (75:3,30 [20] x:\dir\subdir\Test\TestComponent.cshtml) -  data-def=" - "
-                        CSharpExpressionAttributeValue - (86:3,41 [8] x:\dir\subdir\Test\TestComponent.cshtml) - 
-                            IntermediateToken - (87:3,42 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - myValue
+                CSharpCode - (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n  var myValue = "Expression value";\n
+                MarkupElement - (44:3,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - elem
+                    HtmlAttribute - (49:3,5 [25] x:\dir\subdir\Test\TestComponent.cshtml) -  data-abc=" - "
+                        HtmlAttributeValue - (60:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - 
+                            IntermediateToken - (60:3,16 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Literal
+                        HtmlAttributeValue - (67:3,23 [6] x:\dir\subdir\Test\TestComponent.cshtml) -  
+                            IntermediateToken - (68:3,24 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - value
+                    HtmlAttribute - (74:3,30 [20] x:\dir\subdir\Test\TestComponent.cshtml) -  data-def=" - "
+                        CSharpExpressionAttributeValue - (85:3,41 [8] x:\dir\subdir\Test\TestComponent.cshtml) - 
+                            IntermediateToken - (86:3,42 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - myValue

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.mappings.txt
@@ -1,9 +1,9 @@
-Source Location: (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-| 
+Source Location: (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml)
+|
   var myValue = "Expression value";
 |
-Generated Location: (586:17,2 [40] )
-| 
+Generated Location: (586:17,2 [39] )
+|
   var myValue = "Expression value";
 |
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.codegen.cs
@@ -6,16 +6,10 @@ namespace Test
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-using System.Threading.Tasks;
-
-#line default
-#line hidden
-#nullable disable
-#nullable restore
-#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
 using Microsoft.AspNetCore.Components.Web;
 
 #line default
@@ -23,33 +17,30 @@ using Microsoft.AspNetCore.Components.Web;
 #nullable disable
     public partial class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
     {
-        #pragma warning disable 219
-        private void __RazorDirectiveTokenHelpers__() {
-        }
-        #pragma warning restore 219
-        #pragma warning disable 0414
-        private static System.Object __o = null;
-        #pragma warning restore 0414
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
-            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, 
+            __builder.OpenElement(0, "div");
+            __builder.AddMarkupContent(1, "\r\n  ");
+            __builder.OpenElement(2, "input");
+            __builder.AddAttribute(3, "onclick", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, 
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
-                 OnClick
+                   OnClick
 
 #line default
 #line hidden
 #nullable disable
-            );
+            ));
+            __builder.CloseElement();
+            __builder.AddMarkupContent(4, "\r\n");
+            __builder.CloseElement();
         }
         #pragma warning restore 1998
 #nullable restore
-#line 4 "x:\dir\subdir\Test\TestComponent.cshtml"
+#line 5 "x:\dir\subdir\Test\TestComponent.cshtml"
        
-    Task OnClick(MouseEventArgs e)
-    {
-        return Task.CompletedTask;
+    void OnClick() {
     }
 
 #line default

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.ir.txt
@@ -1,0 +1,23 @@
+Document - 
+    NamespaceDeclaration -  - Test
+        UsingDirective - (3:1,1 [14] ) - System
+        UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
+        UsingDirective - (53:3,1 [19] ) - System.Linq
+        UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
+        UsingDirective - (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Components.Web
+        ClassDeclaration -  - public partial - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
+            MethodDeclaration -  - protected override - void - BuildRenderTree
+                MarkupElement - (44:1,0 [43] x:\dir\subdir\Test\TestComponent.cshtml) - div
+                    HtmlContent - (49:1,5 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (49:1,5 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n  
+                    MarkupElement - (53:2,2 [26] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                        HtmlAttribute - (70:2,19 [7] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                            CSharpExpressionAttributeValue -  - 
+                                IntermediateToken -  - CSharp - Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, 
+                                IntermediateToken - (70:2,19 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
+                                IntermediateToken -  - CSharp - )
+                    HtmlContent - (79:2,28 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (79:2,28 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (96:4,7 [31] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (96:4,7 [31] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    void OnClick() {\n    }\n

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+Source Location: (96:4,7 [31] x:\dir\subdir\Test\TestComponent.cshtml)
+|
+    void OnClick() {
+    }
+|
+Generated Location: (1417:41,7 [31] )
+|
+    void OnClick() {
+    }
+|
+

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         {
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-   
+  
   var myValue = "Expression value";
 
 #line default

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.ir.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.ir.txt
@@ -7,9 +7,9 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public partial - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                CSharpCode - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp -  \n  var myValue = "Expression value";\n
-                MarkupElement - (45:3,0 [38] x:\dir\subdir\Test\TestComponent.cshtml) - div
-                    CSharpExpression - (51:3,6 [7] x:\dir\subdir\Test\TestComponent.cshtml)
-                        IntermediateToken - (51:3,6 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - myValue
+                CSharpCode - (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n  var myValue = "Expression value";\n
+                MarkupElement - (44:3,0 [38] x:\dir\subdir\Test\TestComponent.cshtml) - div
+                    CSharpExpression - (50:3,6 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (50:3,6 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - myValue
                     MarkupBlock -  -   

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.mappings.txt
@@ -1,9 +1,9 @@
-Source Location: (2:0,2 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-| 
+Source Location: (2:0,2 [39] x:\dir\subdir\Test\TestComponent.cshtml)
+|
   var myValue = "Expression value";
 |
-Generated Location: (586:17,2 [40] )
-| 
+Generated Location: (586:17,2 [39] )
+|
   var myValue = "Expression value";
 |
 

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/ParserTests/TagHelperBlockRewriterTest/AllowsCompatibleTagStructures_DirectiveAttribute_SelfClosing.cspans.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/ParserTests/TagHelperBlockRewriterTest/AllowsCompatibleTagStructures_DirectiveAttribute_SelfClosing.cspans.txt
@@ -1,0 +1,7 @@
+Markup span at (0:0,0 [7] ) (Accepts:Any) - Parent: Tag block at (0:0,0 [25] )
+Transition span at (7:0,7 [1] ) (Accepts:None) - Parent: Expression block at (7:0,7 [8] )
+Code span at (8:0,8 [7] ) (Accepts:NonWhitespace) - Parent: Expression block at (7:0,7 [8] )
+Markup span at (15:0,15 [2] ) (Accepts:Any) - Parent: Tag block at (0:0,0 [25] )
+Transition span at (17:0,17 [1] ) (Accepts:None) - Parent: Expression block at (17:0,17 [5] )
+Code span at (18:0,18 [4] ) (Accepts:NonWhitespace) - Parent: Expression block at (17:0,17 [5] )
+Markup span at (22:0,22 [3] ) (Accepts:Any) - Parent: Tag block at (0:0,0 [25] )

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/ParserTests/TagHelperBlockRewriterTest/AllowsCompatibleTagStructures_DirectiveAttribute_SelfClosing.stree.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/ParserTests/TagHelperBlockRewriterTest/AllowsCompatibleTagStructures_DirectiveAttribute_SelfClosing.stree.txt
@@ -1,0 +1,32 @@
+RazorDocument - [0..25)::25 - [<input @onclick="@test"/>]
+    MarkupBlock - [0..25)::25
+        MarkupElement - [0..25)::25
+            MarkupStartTag - [0..25)::25 - [<input @onclick="@test"/>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[input];
+                MarkupMiscAttributeContent - [6..23)::17
+                    MarkupTextLiteral - [6..7)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    CSharpCodeBlock - [7..15)::8
+                        CSharpImplicitExpression - [7..15)::8
+                            CSharpTransition - [7..8)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                Transition;[@];
+                            CSharpImplicitExpressionBody - [8..15)::7
+                                CSharpCodeBlock - [8..15)::7
+                                    CSharpExpressionLiteral - [8..15)::7 - [onclick] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                        Identifier;[onclick];
+                    MarkupTextLiteral - [15..17)::2 - [="] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Equals;[=];
+                        DoubleQuote;["];
+                    CSharpCodeBlock - [17..22)::5
+                        CSharpImplicitExpression - [17..22)::5
+                            CSharpTransition - [17..18)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                Transition;[@];
+                            CSharpImplicitExpressionBody - [18..22)::4
+                                CSharpCodeBlock - [18..22)::4
+                                    CSharpExpressionLiteral - [18..22)::4 - [test] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                        Identifier;[test];
+                    MarkupTextLiteral - [22..23)::1 - ["] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                ForwardSlash;[/];
+                CloseAngle;[>];

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/ParserTests/TagHelperBlockRewriterTest/AllowsCompatibleTagStructures_DirectiveAttribute_Void.cspans.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/ParserTests/TagHelperBlockRewriterTest/AllowsCompatibleTagStructures_DirectiveAttribute_Void.cspans.txt
@@ -1,0 +1,7 @@
+Markup span at (0:0,0 [7] ) (Accepts:Any) - Parent: Tag block at (0:0,0 [24] )
+Transition span at (7:0,7 [1] ) (Accepts:None) - Parent: Expression block at (7:0,7 [8] )
+Code span at (8:0,8 [7] ) (Accepts:NonWhitespace) - Parent: Expression block at (7:0,7 [8] )
+Markup span at (15:0,15 [2] ) (Accepts:Any) - Parent: Tag block at (0:0,0 [24] )
+Transition span at (17:0,17 [1] ) (Accepts:None) - Parent: Expression block at (17:0,17 [5] )
+Code span at (18:0,18 [4] ) (Accepts:NonWhitespace) - Parent: Expression block at (17:0,17 [5] )
+Markup span at (22:0,22 [2] ) (Accepts:Any) - Parent: Tag block at (0:0,0 [24] )

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/ParserTests/TagHelperBlockRewriterTest/AllowsCompatibleTagStructures_DirectiveAttribute_Void.stree.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/ParserTests/TagHelperBlockRewriterTest/AllowsCompatibleTagStructures_DirectiveAttribute_Void.stree.txt
@@ -1,0 +1,31 @@
+RazorDocument - [0..24)::24 - [<input @onclick="@test">]
+    MarkupBlock - [0..24)::24
+        MarkupElement - [0..24)::24
+            MarkupStartTag - [0..24)::24 - [<input @onclick="@test">] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[input];
+                MarkupMiscAttributeContent - [6..23)::17
+                    MarkupTextLiteral - [6..7)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    CSharpCodeBlock - [7..15)::8
+                        CSharpImplicitExpression - [7..15)::8
+                            CSharpTransition - [7..8)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                Transition;[@];
+                            CSharpImplicitExpressionBody - [8..15)::7
+                                CSharpCodeBlock - [8..15)::7
+                                    CSharpExpressionLiteral - [8..15)::7 - [onclick] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                        Identifier;[onclick];
+                    MarkupTextLiteral - [15..17)::2 - [="] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Equals;[=];
+                        DoubleQuote;["];
+                    CSharpCodeBlock - [17..22)::5
+                        CSharpImplicitExpression - [17..22)::5
+                            CSharpTransition - [17..18)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                Transition;[@];
+                            CSharpImplicitExpressionBody - [18..22)::4
+                                CSharpCodeBlock - [18..22)::4
+                                    CSharpExpressionLiteral - [18..22)::4 - [test] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                        Identifier;[test];
+                    MarkupTextLiteral - [22..23)::1 - ["] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                CloseAngle;[>];


### PR DESCRIPTION
This change updates tag helper binding logic to allow directive
attributes (when they appear alone) to bind to any kind of tag
(start/end, void, self-closing).

Tag Helpers don't have a semantic that allows this level of flexibility
- using StartTagOnly as suggested in the issue means that this would
*only* work for void elements.

There's no change to any of the directive attribute implementations
because this is a global change in the tag helper infra.

Issue aspnet/AspNetCore#10498