### PR TITLE
Remove .NET Framework build for source-build.

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/Microsoft.NET.Sdk.Razor.csproj
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/Microsoft.NET.Sdk.Razor.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains MSBuild support for Razor.</Description>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework);net46</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">$(DefaultNetCoreTargetFramework)</TargetFrameworks>
 
     <TargetName>Microsoft.NET.Sdk.Razor.Tasks</TargetName>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>


### PR DESCRIPTION
This allows source-build to get rid of the prebuilt .NET FX reference assemblies.

cc @JunTaoLuo 