### PR TITLE
Pass through the correct LangVersion to csc

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Compilation.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Compilation.targets
@@ -111,12 +111,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <UseSharedCompilation>true</UseSharedCompilation>
     </PropertyGroup>
 
-    <PropertyGroup Condition="('$(TargetFrameworkIdentifier)' != '.NETCoreApp' OR '$(TargetFrameworkVersion)' != 'v3.0') AND
-                            ('$(TargetFrameworkIdentifier)' != '.NETStandard' OR '$(TargetFrameworkVersion)' != 'v2.1')">
-      <MaxSupportedLangVersion Condition="'$(MaxSupportedLangVersion)' == ''">7.3</MaxSupportedLangVersion>
-      <LangVersion Condition="'$(LangVersion)' == ''">$(MaxSupportedLangVersion)</LangVersion>
-    </PropertyGroup>
-
     <Csc
          AdditionalLibPaths="$(AdditionalLibPaths)"
          AddModules="@(AddModules)"


### PR DESCRIPTION
Fixes [997705](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/997705)

#### Description
Razor used to set the used C# language version in project by having a custom logic. We don't really need to set `LangVersion` manually anymore because of [this](https://github.com/agocke/roslyn/commit/17e25dca2016f0d245abc1ad22e0aa8556e14f3c) change in Roslyn.

#### Customer impact
New ASP.NET Core Razor Page application would fail at build, when running from VS.

#### Regression
Yes

#### Risk
Low: We expect Roslyn to do the [right thing](https://github.com/dotnet/roslyn/pull/38967/).
I verified this fixes the issue in VS manually.