### PR TITLE
Add support for using a 3.0 SDK on VS 16.4.

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.DesignTime.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.DesignTime.targets
@@ -48,6 +48,17 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <!--
+    In order to properly support Blazor partial classes we need to ensure that older SDKs don't
+    add declaration files to the compile list. We do all the compilation work in-memory in latest
+    VS.
+  -->
+  <Target Name="_RemoveRazorDeclartionsFromCompile" AfterTargets="RazorGenerateComponentDeclaration">
+    <ItemGroup Condition="'$(DesignTimeBuild)'=='true'">
+      <Compile Remove="@(_RazorComponentDeclaration)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
     WebSdk imports these capabilities for nesting in DotNetCoreWeb projects.
     Conditinally import these capabilities if the project isn't targeting the WebSdk.
    -->


### PR DESCRIPTION
- The 3.0 SDK adds RazorDeclaration files to the compile list if they exist. If a user builds in VS and then does a project level operation (adding a property group or item group to their project file) a design time build will trigger for unrelated reasons and declaration files will be included as part of the C# compilation resulting in duplicate member errors. This change ensures that even if declaration files are added we then remove them to ensure we avoid those declaration additions.
- One unfortunate aspect of this change is that declarations are added to the compile list for a brief moment resulting in errors and then are instantly removed in some situations. I say "some situations" because when this happens it is highly dependent on how / when the project system decides to perform a design time build.

aspnet/AspNetCore#14646