### PR TITLE
Add support for partial component class editing -> refresh components.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/ComponentDetectionConventions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/ComponentDetectionConventions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Razor
+{
+    internal static class ComponentDetectionConventions
+    {
+        public static bool IsComponent(INamedTypeSymbol symbol, INamedTypeSymbol icomponentSymbol)
+        {
+            if (symbol is null)
+            {
+                throw new ArgumentNullException(nameof(symbol));
+            }
+
+            if (icomponentSymbol is null)
+            {
+                throw new ArgumentNullException(nameof(icomponentSymbol));
+            }
+
+            return
+                symbol.DeclaredAccessibility == Accessibility.Public &&
+                !symbol.IsAbstract &&
+                symbol.AllInterfaces.Contains(icomponentSymbol);
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/ComponentTagHelperDescriptorProvider.cs
@@ -573,10 +573,8 @@ namespace Microsoft.CodeAnalysis.Razor
                     return false;
                 }
 
-                return
-                    symbol.DeclaredAccessibility == Accessibility.Public &&
-                    !symbol.IsAbstract &&
-                    symbol.AllInterfaces.Contains(_symbols.IComponent);
+                var isComponent = ComponentDetectionConventions.IsComponent(symbol, _symbols.IComponent);
+                return isComponent;
             }
         }
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServices.Razor.Test;
 using Moq;
@@ -26,6 +28,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var cshtmlDocumentInfo = DocumentInfo.Create(CshtmlDocumentId, "Test", filePath: "file.cshtml.g.cs");
             RazorDocumentId = DocumentId.CreateNewId(projectId1);
             var razorDocumentInfo = DocumentInfo.Create(RazorDocumentId, "Test", filePath: "file.razor.g.cs");
+            PartialComponentClassDocumentId = DocumentId.CreateNewId(projectId1);
+            var partialComponentClassDocumentInfo = DocumentInfo.Create(PartialComponentClassDocumentId, "Test", filePath: "file.razor.cs");
 
             SolutionWithTwoProjects = Workspace.CurrentSolution
                 .AddProject(ProjectInfo.Create(
@@ -35,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                     "One",
                     LanguageNames.CSharp,
                     filePath: "One.csproj",
-                    documents: new[] { cshtmlDocumentInfo, razorDocumentInfo }))
+                    documents: new[] { cshtmlDocumentInfo, razorDocumentInfo, partialComponentClassDocumentInfo }))
                 .AddProject(ProjectInfo.Create(
                     projectId2,
                     VersionStamp.Default,
@@ -83,6 +87,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         public DocumentId CshtmlDocumentId { get; }
 
         public DocumentId RazorDocumentId { get; }
+
+        public DocumentId PartialComponentClassDocumentId { get; }
 
         [ForegroundTheory]
         [InlineData(WorkspaceChangeKind.SolutionAdded)]
@@ -254,6 +260,59 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         }
 
         [ForegroundFact]
+        public async Task WorkspaceChanged_DocumentChanged_PartialComponent_UpdatesProjectState_AfterDelay()
+        {
+            // Arrange
+            var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
+            var detector = new WorkspaceProjectStateChangeDetector(workspaceStateGenerator)
+            {
+                EnqueueDelay = 1,
+                BlockDelayedUpdateWorkEnqueue = new ManualResetEventSlim(initialState: false),
+            };
+
+            Workspace.TryApplyChanges(SolutionWithTwoProjects);
+            var projectManager = new TestProjectSnapshotManager(new[] { detector }, Workspace);
+            projectManager.ProjectAdded(HostProjectOne);
+            workspaceStateGenerator.ClearQueue();
+
+            var sourceText = SourceText.From(
+$@"
+public partial class TestComponent : {ComponentsApi.IComponent.MetadataName} {{}}
+namespace Microsoft.AspNetCore.Components
+{{
+    public interface IComponent {{}}
+}}
+");
+            var syntaxTreeRoot = CSharpSyntaxTree.ParseText(sourceText).GetRoot();
+            var solution = SolutionWithTwoProjects
+                .WithDocumentText(PartialComponentClassDocumentId, sourceText)
+                .WithDocumentSyntaxRoot(PartialComponentClassDocumentId, syntaxTreeRoot, PreservationMode.PreserveIdentity);
+            var document = solution.GetDocument(PartialComponentClassDocumentId);
+
+            // The change detector only operates when a semantic model / syntax tree is available.
+            await document.GetSyntaxRootAsync();
+            await document.GetSemanticModelAsync();
+
+            var e = new WorkspaceChangeEventArgs(WorkspaceChangeKind.DocumentChanged, oldSolution: solution, newSolution: solution, projectId: ProjectNumberOne.Id, PartialComponentClassDocumentId);
+            
+            // Act
+            detector.Workspace_WorkspaceChanged(Workspace, e);
+
+            // Assert
+            //
+            // The change hasn't come through yet.
+            Assert.Empty(workspaceStateGenerator.UpdateQueue);
+
+            detector.BlockDelayedUpdateWorkEnqueue.Set();
+
+            await detector._deferredUpdates.Single().Value;
+
+            var update = Assert.Single(workspaceStateGenerator.UpdateQueue);
+            Assert.Equal(update.workspaceProject.Id, ProjectNumberOne.Id);
+            Assert.Equal(update.projectSnapshot.FilePath, HostProjectOne.FilePath);
+        }
+
+        [ForegroundFact]
         public void WorkspaceChanged_ProjectRemovedEvent_QueuesProjectStateRemoval()
         {
             // Arrange
@@ -294,6 +353,188 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             Assert.Collection(
                 workspaceStateGenerator.UpdateQueue,
                 p => Assert.Equal(ProjectNumberThree.Id, p.workspaceProject.Id));
+        }
+
+        [Fact]
+        public async Task IsPartialComponentClass_InitializedDocument_ReturnsTrue()
+        {
+            // Arrange
+            var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
+            var detector = new WorkspaceProjectStateChangeDetector(workspaceStateGenerator);
+            var sourceText = SourceText.From(
+$@"
+public partial class TestComponent : {ComponentsApi.IComponent.MetadataName} {{}}
+namespace Microsoft.AspNetCore.Components
+{{
+    public interface IComponent {{}}
+}}
+");
+            var syntaxTreeRoot = CSharpSyntaxTree.ParseText(sourceText).GetRoot();
+            var solution = SolutionWithTwoProjects
+                .WithDocumentText(PartialComponentClassDocumentId, sourceText)
+                .WithDocumentSyntaxRoot(PartialComponentClassDocumentId, syntaxTreeRoot, PreservationMode.PreserveIdentity);
+            var document = solution.GetDocument(PartialComponentClassDocumentId);
+
+            // Initialize document
+            await document.GetSyntaxRootAsync();
+            await document.GetSemanticModelAsync();
+
+            // Act
+            var result = detector.IsPartialComponentClass(document);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsPartialComponentClass_Uninitialized_ReturnsFalse()
+        {
+            // Arrange
+            var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
+            var detector = new WorkspaceProjectStateChangeDetector(workspaceStateGenerator);
+            var sourceText = SourceText.From(
+$@"
+public partial class TestComponent : {ComponentsApi.IComponent.MetadataName} {{}}
+namespace Microsoft.AspNetCore.Components
+{{
+    public interface IComponent {{}}
+}}
+");
+            var syntaxTreeRoot = CSharpSyntaxTree.ParseText(sourceText).GetRoot();
+            var solution = SolutionWithTwoProjects
+                .WithDocumentText(PartialComponentClassDocumentId, sourceText)
+                .WithDocumentSyntaxRoot(PartialComponentClassDocumentId, syntaxTreeRoot, PreservationMode.PreserveIdentity);
+            var document = solution.GetDocument(PartialComponentClassDocumentId);
+
+            // Act
+            var result = detector.IsPartialComponentClass(document);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsPartialComponentClass_UninitializedSemanticModel_ReturnsFalse()
+        {
+            // Arrange
+            var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
+            var detector = new WorkspaceProjectStateChangeDetector(workspaceStateGenerator);
+            var sourceText = SourceText.From(
+$@"
+public partial class TestComponent : {ComponentsApi.IComponent.MetadataName} {{}}
+namespace Microsoft.AspNetCore.Components
+{{
+    public interface IComponent {{}}
+}}
+");
+            var syntaxTreeRoot = CSharpSyntaxTree.ParseText(sourceText).GetRoot();
+            var solution = SolutionWithTwoProjects
+                .WithDocumentText(PartialComponentClassDocumentId, sourceText)
+                .WithDocumentSyntaxRoot(PartialComponentClassDocumentId, syntaxTreeRoot, PreservationMode.PreserveIdentity);
+            var document = solution.GetDocument(PartialComponentClassDocumentId);
+
+            await document.GetSyntaxRootAsync();
+
+            // Act
+            var result = detector.IsPartialComponentClass(document);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsPartialComponentClass_NonClass_ReturnsFalse()
+        {
+            // Arrange
+            var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
+            var detector = new WorkspaceProjectStateChangeDetector(workspaceStateGenerator);
+            var sourceText = SourceText.From(string.Empty);
+            var syntaxTreeRoot = CSharpSyntaxTree.ParseText(sourceText).GetRoot();
+            var solution = SolutionWithTwoProjects
+                .WithDocumentText(PartialComponentClassDocumentId, sourceText)
+                .WithDocumentSyntaxRoot(PartialComponentClassDocumentId, syntaxTreeRoot, PreservationMode.PreserveIdentity);
+            var document = solution.GetDocument(PartialComponentClassDocumentId);
+
+            // Initialize document
+            await document.GetSyntaxRootAsync();
+            await document.GetSemanticModelAsync();
+
+            // Act
+            var result = detector.IsPartialComponentClass(document);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsPartialComponentClass_MultipleClassesOneComponentPartial_ReturnsTrue()
+        {
+
+            // Arrange
+            var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
+            var detector = new WorkspaceProjectStateChangeDetector(workspaceStateGenerator);
+            var sourceText = SourceText.From(
+$@"
+public partial class NonComponent1 {{}}
+public class NonComponent2 {{}}
+public partial class TestComponent : {ComponentsApi.IComponent.MetadataName} {{}}
+public partial class NonComponent3 {{}}
+public class NonComponent4 {{}}
+namespace Microsoft.AspNetCore.Components
+{{
+    public interface IComponent {{}}
+}}
+");
+            var syntaxTreeRoot = CSharpSyntaxTree.ParseText(sourceText).GetRoot();
+            var solution = SolutionWithTwoProjects
+                .WithDocumentText(PartialComponentClassDocumentId, sourceText)
+                .WithDocumentSyntaxRoot(PartialComponentClassDocumentId, syntaxTreeRoot, PreservationMode.PreserveIdentity);
+            var document = solution.GetDocument(PartialComponentClassDocumentId);
+
+            // Initialize document
+            await document.GetSyntaxRootAsync();
+            await document.GetSemanticModelAsync();
+
+            // Act
+            var result = detector.IsPartialComponentClass(document);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task IsPartialComponentClass_NonComponents_ReturnsFalse()
+        {
+
+            // Arrange
+            var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
+            var detector = new WorkspaceProjectStateChangeDetector(workspaceStateGenerator);
+            var sourceText = SourceText.From(
+$@"
+public partial class NonComponent1 {{}}
+public class NonComponent2 {{}}
+public partial class NonComponent3 {{}}
+public class NonComponent4 {{}}
+namespace Microsoft.AspNetCore.Components
+{{
+    public interface IComponent {{}}
+}}
+");
+            var syntaxTreeRoot = CSharpSyntaxTree.ParseText(sourceText).GetRoot();
+            var solution = SolutionWithTwoProjects
+                .WithDocumentText(PartialComponentClassDocumentId, sourceText)
+                .WithDocumentSyntaxRoot(PartialComponentClassDocumentId, syntaxTreeRoot, PreservationMode.PreserveIdentity);
+            var document = solution.GetDocument(PartialComponentClassDocumentId);
+
+            // Initialize document
+            await document.GetSyntaxRootAsync();
+            await document.GetSemanticModelAsync();
+
+            // Act
+            var result = detector.IsPartialComponentClass(document);
+
+            // Assert
+            Assert.False(result);
         }
 
         private class TestProjectSnapshotManager : DefaultProjectSnapshotManager


### PR DESCRIPTION
- We now do aggressive detection on the type of C# class that's being edited. In order to not impact C# scenarios we only do work if C# assets are available to us. Meaning, we inspect the old document and if that document has its' semantic model available we spend cycles to determine if it's a component. In the case that we find a C# component class that wasn't previously caught we enqueue an update.
- Our IComponent detection logic has to be "fuzzy" because we don't have access to the C# compilation at the workspace change detection layer. Therefore we need to look at type names and do string comparisons vs. looking up specific types in the compilation.
- Added several tests to ensure we enqueue and that we properly detect component classes.

aspnet/AspNetCore#14646