### PR TITLE
Remove directive attribute completions from element completion list.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperCompletionService.cs
@@ -243,6 +243,14 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
             void UpdateCompletions(string tagName, TagHelperDescriptor possibleDescriptor)
             {
+                if (possibleDescriptor.BoundAttributes.Any(boundAttribute => boundAttribute.IsDirectiveAttribute()))
+                {
+                    // This is a TagHelper that ultimately represents a DirectiveAttribute. In classic Razor TagHelper land TagHelpers with bound attribute descriptors
+                    // are valuable to show in the completion list to understand what was possible for a certain tag; however, with Blazor directive attributes stand
+                    // on their own and shouldn't be indicated at the element level completion.
+                    return;
+                }
+
                 if (!elementCompletions.TryGetValue(tagName, out var existingRuleDescriptors))
                 {
                     existingRuleDescriptors = new HashSet<TagHelperDescriptor>();


### PR DESCRIPTION
- This removes the excess amount of directive attribute completions that show up when completing a component.
- Added a test to verify directive attributes no longer show up in element completions.

aspnet/AspNetCore#9133
