### PR TITLE
Retarget rzc.dll to netcoreapp3.0

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Tools/Microsoft.AspNetCore.Razor.Tools.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Tools/Microsoft.AspNetCore.Razor.Tools.csproj
@@ -3,7 +3,13 @@
   <PropertyGroup>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This assembly contains infrastructure supporting Razor MSBuild integration.</Description>
 
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <!--
+      This is intentionally targeting netcoreapp3.0. This allows using the Microsoft.NET.Sdk.Razor package without having to solve diamond dependency problems in AspNetCore.
+      We use a runtimeconfig.json.template to allow roll forwards.
+      In addition, the SDK stamps an exact version of the shared fx to use in all runtimeconfig.json that are contained in the SDK.
+      See the discussion here: https://github.com/aspnet/AspNetCore-Internal/issues/3201#issuecomment-539631557
+    -->
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>rzc</AssemblyName>
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Tools/runtimeconfig.template.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Tools/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "rollForwardOnNoCandidateFx": 2
+}

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/Microsoft.NET.Sdk.Razor.csproj
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/Microsoft.NET.Sdk.Razor.csproj
@@ -46,7 +46,7 @@
     <!-- Layout tasks, compiler, and extensions in the sdk-output folder. The entire folder structure gets packaged as-is into the SDK -->
     <MSBuild
       Projects="..\Microsoft.AspNetCore.Razor.Tools\Microsoft.AspNetCore.Razor.Tools.csproj"
-      Properties="PublishDir=$(SdkOutputPath)tools\$(DefaultNetCoreTargetFramework);TargetFramework=$(DefaultNetCoreTargetFramework)"
+      Properties="PublishDir=$(SdkOutputPath)tools\netcoreapp3.0;TargetFramework=netcoreapp3.0"
       Targets="Publish" />
 
     <ItemGroup>

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.CodeGeneration.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.CodeGeneration.targets
@@ -39,7 +39,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_RazorGenerateInputsHash></_RazorGenerateInputsHash>
     <_RazorGenerateInputsHashFile>$(IntermediateOutputPath)$(MSBuildProjectName).RazorCoreGenerate.cache</_RazorGenerateInputsHashFile>
 
-    <_RazorToolAssembly Condition="'$(_RazorToolAssembly)'==''">$(RazorSdkDirectoryRoot)tools\netcoreapp3.1\rzc.dll</_RazorToolAssembly>
+    <_RazorToolAssembly Condition="'$(_RazorToolAssembly)'==''">$(RazorSdkDirectoryRoot)tools\netcoreapp3.0\rzc.dll</_RazorToolAssembly>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Based on the discussions here: https://github.com/aspnet/AspNetCore-Internal/issues/3201#issuecomment-539631557

rzc.dll targeting netcoreapp3.1 causes shared fx version conflicts when consumed as a package in the AspNetCore repo.
A fairly trivial workaround is to have it target it netcoreapp3.0 and allow it to roll-forward to the available shared fx.
This follows csc.dll's behavior, as well as solves the version conflict.

Fixes https://github.com/aspnet/AspNetCore-Internal/issues/3201

