### PR TITLE
Properly parse (in VS) newly added files to project.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
@@ -229,8 +229,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
             Debug.Assert(_projectEngine.FileSystem != null);
 
             // We might not have a document snapshot in the case of an ephemeral project.
-            // If we can't be sure, then just assume it's an MVC view since that's likely anyway.
-            var fileKind = _documentTracker.ProjectSnapshot?.GetDocument(_documentTracker.FilePath)?.FileKind ?? FileKinds.Legacy;
+            // If we don't have a document then infer the FileKind from the FilePath.
+            var fileKind = _documentTracker.ProjectSnapshot?.GetDocument(_documentTracker.FilePath)?.FileKind ?? FileKinds.GetFileKindFromFilePath(_documentTracker.FilePath);
 
             var projectDirectory = Path.GetDirectoryName(_documentTracker.ProjectPath);
             _parser = new BackgroundParser(_projectEngine, FilePath, projectDirectory, fileKind);


### PR DESCRIPTION
- Prior to this it would take roughly 4-5 seconds before one could edit a Razor file correctly because if our project system wasn't yet aware of a Blazor component it wouldn't let you edit it as if it was one.
- Found that we were forcing legacy FileKind behavior despite the current FilePath when parsing Razor files that had no project system association.
- Added an integration test to ensure we can properly parse Rzor components when there is no document snapshot associated.

### Before
![image](https://i.imgur.com/xyNP5aU.gif)

### After
![image](https://i.imgur.com/jz0O5S0.gif)

aspnet/AspNetCore#11816