### PR TITLE
Fix Razor < 3.0 projects null-refing when WorkspaceChanged events fire.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
@@ -185,6 +185,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }
 
             var icomponentType = semanticModel.Compilation.GetTypeByMetadataName(ComponentsApi.IComponent.MetadataName);
+            if (icomponentType == null)
+            {
+                // IComponent is not available in the compilation.
+                return false;
+            }
 
             foreach (var classDeclaration in classDeclarations)
             {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
@@ -356,6 +356,33 @@ namespace Microsoft.AspNetCore.Components
         }
 
         [Fact]
+        public async Task IsPartialComponentClass_NoIComponent_ReturnsFalse()
+        {
+            // Arrange
+            var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
+            var detector = new WorkspaceProjectStateChangeDetector(workspaceStateGenerator);
+            var sourceText = SourceText.From(
+$@"
+public partial class TestComponent{{}}
+");
+            var syntaxTreeRoot = CSharpSyntaxTree.ParseText(sourceText).GetRoot();
+            var solution = SolutionWithTwoProjects
+                .WithDocumentText(PartialComponentClassDocumentId, sourceText)
+                .WithDocumentSyntaxRoot(PartialComponentClassDocumentId, syntaxTreeRoot, PreservationMode.PreserveIdentity);
+            var document = solution.GetDocument(PartialComponentClassDocumentId);
+
+            // Initialize document
+            await document.GetSyntaxRootAsync();
+            await document.GetSemanticModelAsync();
+
+            // Act
+            var result = detector.IsPartialComponentClass(document);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
         public async Task IsPartialComponentClass_InitializedDocument_ReturnsTrue()
         {
             // Arrange


### PR DESCRIPTION
@KirillOsenkov found this when porting Blazor bits to VS4Mac because they handle stuff slightly differently over there.

- In Visual Studio a null-ref is thrown when we cannot find an IComponent type.
- This was missed because shockingly there's 0 end-user impact to this null reference exception. VS doesn't crash, our bits don't stop being called, Roslyn just reports the error and then continues on its merry way.
- The issue that this solves from my perspective with this throwing is that anyone debugging Visual Studio with Just My Code turned to false will encounter these exceptions in Razor < 3.0 projects.
- Added a test to verify we no longer explode.

@danroth27 / @mkArtakMSFT Do we want to go through QB mode (it's QB mode for the rest of the 16.4 release) to get this in? Read above to see why I'm even asking the question 😄 
