### PR TITLE
Associate inputs and outputs for .Views dll with a set in FastUpToDate check

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -307,7 +307,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       Add all cshtml files to UpToDateCheckInput - a collection of files used by FastUpToDateCheck to determine
       if any of the the project inputs have changed.
     -->
-    <UpToDateCheckInput Condition="'$(RazorCompileOnBuild)'=='true'" Include="@(Content->WithMetadataValue('Extension', '.cshtml'))" />
+    <UpToDateCheckInput Condition="'$(RazorCompileOnBuild)'=='true'" Include="@(Content->WithMetadataValue('Extension', '.cshtml'))" Set="RazorViews" />
 
     <!--
       Add all .razor files to UpToDateCheckInput. Component compilation is not controlled by RazorCompileOnBuild,
@@ -320,7 +320,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       if any of the project's outputs have changed.
     -->
     <UpToDateCheckBuilt Include="@(RazorIntermediateAssembly)"
-      Condition="'$(RazorCompileOnBuild)'=='true' AND '@(Content->WithMetadataValue('Extension', '.cshtml'))' != ''" />
+      Condition="'$(RazorCompileOnBuild)'=='true' AND '@(Content->WithMetadataValue('Extension', '.cshtml'))' != ''" Set="RazorViews" />
 
     <!-- Set up watchers for dotnet-watch -->
     <Watch Include="@(Content->WithMetadataValue('Extension', '.razor'))" />


### PR DESCRIPTION
Follow up to https://github.com/dotnet/project-system/issues/5596

FastUpToDateCheck now has a way to associate inputs and outputs using the Set attribute.
This change prevents FastUpToDateCheck from rebuilding a project when a *.cshtml file is
newer than the project's dll output.

Fixes https://github.com/aspnet/AspNetCore/issues/13204


