### PR TITLE
Fix project state improperly caching during matching RootNamespace & ProjectWorkspaceState updates.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -333,7 +333,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 throw new ArgumentNullException(nameof(hostProject));
             }
 
-            if (HostProject.Configuration.Equals(hostProject.Configuration))
+            if (HostProject.Configuration.Equals(hostProject.Configuration) &&
+                HostProject.RootNamespace == hostProject.RootNamespace)
             {
                 return this;
             }
@@ -355,8 +356,17 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         public ProjectState WithProjectWorkspaceState(ProjectWorkspaceState projectWorkspaceState)
         {
-            var difference = ProjectDifference.ProjectWorkspaceStateChanged;
+            if (ProjectWorkspaceState == projectWorkspaceState)
+            {
+                return this;
+            }
 
+            if (ProjectWorkspaceState != null && ProjectWorkspaceState.Equals(projectWorkspaceState))
+            {
+                return this;
+            }
+
+            var difference = ProjectDifference.ProjectWorkspaceStateChanged;
             var documents = Documents.ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.WithProjectWorkspaceStateChange(), FilePathComparer.Instance);
             var state = new ProjectState(this, difference, HostProject, projectWorkspaceState, documents, ImportsToRelatedDocuments);
             return state;

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
@@ -162,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                             TestProjectData.SomeProjectNestedFile3.FilePath,
                         },
                         kvp.Value.OrderBy(f => f));
-           },
+                },
                 kvp =>
                 {
                     Assert.Equal(TestProjectData.SomeProjectNestedImportFile.TargetPath, kvp.Key);
@@ -542,6 +543,31 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         }
 
         [Fact]
+        public void ProjectState_WithHostProject_RootNamespaceChange_UpdatesConfigurationState()
+        {
+            // Arrange
+            var original = ProjectState.Create(Workspace.Services, HostProject, ProjectWorkspaceState)
+                .WithAddedHostDocument(Documents[2], DocumentState.EmptyLoader)
+                .WithAddedHostDocument(Documents[1], DocumentState.EmptyLoader);
+            var hostProjectWithRootNamespaceChange = new HostProject(
+                original.HostProject.FilePath,
+                original.HostProject.Configuration,
+                "ChangedRootNamespace");
+
+            // Force init
+            var originalTagHelpers = original.TagHelpers;
+            var originalProjectWorkspaceStateVersion = original.ConfigurationVersion;
+
+            TagHelperResolver.TagHelpers = SomeTagHelpers;
+
+            // Act
+            var state = original.WithHostProject(hostProjectWithRootNamespaceChange);
+
+            // Assert
+            Assert.NotSame(original, state);
+        }
+
+        [Fact]
         public void ProjectState_WithHostProject_NoConfigurationChange_Noops()
         {
             // Arrange
@@ -673,7 +699,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var originalTagHelpers = original.TagHelpers;
             var originalProjectWorkspaceStateVersion = original.ProjectWorkspaceStateVersion;
 
-            var changed = new ProjectWorkspaceState(ProjectWorkspaceState.TagHelpers, default);
+            var changed = new ProjectWorkspaceState(ProjectWorkspaceState.TagHelpers, LanguageVersion.CSharp6);
 
             // Act
             var state = original.WithProjectWorkspaceState(changed);
@@ -685,10 +711,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var actualTagHelpers = state.TagHelpers;
             var actualProjectWorkspaceStateVersion = state.ProjectWorkspaceStateVersion;
 
-            // The configuration didn't change, and the tag helpers didn't actually change
-            Assert.Same(original.ProjectEngine, state.ProjectEngine);
+            // The C# language version changed, and the tag helpers didn't change
+            Assert.NotSame(original.ProjectEngine, state.ProjectEngine);
             Assert.Same(originalTagHelpers, actualTagHelpers);
-            Assert.Equal(originalProjectWorkspaceStateVersion, actualProjectWorkspaceStateVersion);
+            Assert.NotEqual(originalProjectWorkspaceStateVersion, actualProjectWorkspaceStateVersion);
 
             Assert.NotSame(original.Documents[Documents[1].FilePath], state.Documents[Documents[1].FilePath]);
             Assert.NotSame(original.Documents[Documents[2].FilePath], state.Documents[Documents[2].FilePath]);
@@ -729,6 +755,30 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             Assert.NotSame(original.Documents[Documents[1].FilePath], state.Documents[Documents[1].FilePath]);
             Assert.NotSame(original.Documents[Documents[2].FilePath], state.Documents[Documents[2].FilePath]);
+        }
+
+        [Fact]
+        public void ProjectState_WithProjectWorkspaceState_IdenticalState_Caches()
+        {
+            // Arrange
+            var original = ProjectState.Create(Workspace.Services, HostProject, ProjectWorkspaceState)
+                .WithAddedHostDocument(Documents[2], DocumentState.EmptyLoader)
+                .WithAddedHostDocument(Documents[1], DocumentState.EmptyLoader);
+
+            // Force init
+            var originalTagHelpers = original.TagHelpers;
+            var originalProjectWorkspaceStateVersion = original.ProjectWorkspaceStateVersion;
+
+            var changed = new ProjectWorkspaceState(original.TagHelpers, original.CSharpLanguageVersion);
+
+            // Now create some tag helpers
+            TagHelperResolver.TagHelpers = SomeTagHelpers;
+
+            // Act
+            var state = original.WithProjectWorkspaceState(changed);
+
+            // Assert
+            Assert.Same(original, state);
         }
 
         [Fact]

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
@@ -17,7 +17,12 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
     {
         public DefaultProjectSnapshotManagerTest()
         {
-            TagHelperResolver = new TestTagHelperResolver();
+            var someTagHelpers = new List<TagHelperDescriptor>();
+            someTagHelpers.Add(TagHelperDescriptorBuilder.Create("Test1", "TestAssembly").Build());
+            TagHelperResolver = new TestTagHelperResolver()
+            {
+                TagHelpers = someTagHelpers,
+            };
 
             Documents = new HostDocument[]
             {


### PR DESCRIPTION
- Only updating a project's root namespace wouldn't trigger updates because we weren't comparing the previous and current root namespaces.
- Updating a projects ProjectWorkspaceState (TagHelpers) would always result in re-computation of a Razor document even if the before and after TagHelpers were exactly the same, we now compare current and previous and do the right thing.
- Added tests

