### PR TITLE
Ensure 3.0 Razor SDKs don't add duplicate Razor document declarations/files.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultRemoteTextLoaderFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultRemoteTextLoaderFactory.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 
                 TextAndVersion textAndVersion;
 
-                using (var stream = File.OpenRead(physicalFilePath))
+                using (var stream = new FileStream(physicalFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete))
                 {
                     var version = VersionStamp.Create(prevLastWriteTime);
                     var text = SourceText.From(stream);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/PrecompiledRazorPageSuppressor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/PrecompiledRazorPageSuppressor.cs
@@ -33,7 +33,8 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             _workspace.WorkspaceChanged += Workspace_WorkspaceChanged;
         }
 
-        private void Workspace_WorkspaceChanged(object sender, WorkspaceChangeEventArgs args)
+        // Internal for testing
+        internal void Workspace_WorkspaceChanged(object sender, WorkspaceChangeEventArgs args)
         {
             switch (args.Kind)
             {
@@ -65,12 +66,8 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                         break;
                     }
 
-                    if (!document.FilePath.Contains("RazorDeclaration"))
-                    {
-                        // Razor output file that is not a declaration file.
-                        _workspace.RemoveDocument(document.Id);
-                        break;
-                    }
+                    // Razor output file
+                    _workspace.RemoveDocument(document.Id);
 
                     break;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
@@ -72,6 +72,10 @@ export class RazorDocumentManager implements IRazorDocumentManager {
                 continue;
             }
 
+            if (textDocument.isClosed) {
+                continue;
+            }
+
             this.openDocument(textDocument.uri);
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/BackgroundDocumentProcessedPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/BackgroundDocumentProcessedPublisherTest.cs
@@ -1,30 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
-using OmniSharp;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 {
-    public class BackgroundDocumentProcessedPublisherTest : OmniSharpTestBase
+    public class BackgroundDocumentProcessedPublisherTest : OmniSharpWorkspaceTestBase
     {
-        public BackgroundDocumentProcessedPublisherTest()
-        {
-            Workspace = TestOmniSharpWorkspace.Create();
-            var projectId = ProjectId.CreateNewId();
-            var projectInfo = ProjectInfo.Create(projectId, VersionStamp.Default, "TestProject", "TestAssembly", LanguageNames.CSharp, filePath: "/path/to/project.csproj");
-            Workspace.AddProject(projectInfo);
-            Project = Workspace.CurrentSolution.Projects.FirstOrDefault();
-        }
-
-        private OmniSharpWorkspace Workspace { get; }
-
-        private Project Project { get; }
-
         [Fact]
         public async Task DocumentProcessed_CSHTML_Noops()
         {
@@ -287,15 +272,6 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             Assert.NotSame(newSolution, Workspace.CurrentSolution);
             var currentBackgroundDocument = Workspace.CurrentSolution.GetDocument(backgroundDocument.Id);
             Assert.Null(currentBackgroundDocument);
-        }
-
-        private Document AddRoslynDocument(string filePath)
-        {
-            var backgroundDocumentId = DocumentId.CreateNewId(Project.Id);
-            var backgroundDocumentInfo = DocumentInfo.Create(backgroundDocumentId, filePath ?? "EmptyFile", filePath: filePath);
-            Workspace.AddDocument(backgroundDocumentInfo);
-            var addedDocument = Workspace.CurrentSolution.GetDocument(backgroundDocumentId);
-            return addedDocument;
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/OmniSharpTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/OmniSharpTestBase.cs
@@ -13,7 +13,7 @@ using Xunit;
 namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 {
     [Collection("MSBuildLocator")]
-    public class OmniSharpTestBase : LanguageServerTestBase
+    public abstract class OmniSharpTestBase : LanguageServerTestBase
     {
         private readonly MethodInfo _createTestProjectSnapshotMethod;
         private readonly MethodInfo _createWithDocumentsTestProjectSnapshotMethod;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/OmniSharpWorkspaceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/OmniSharpWorkspaceTestBase.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using OmniSharp;
+
+namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
+{
+    public abstract class OmniSharpWorkspaceTestBase : OmniSharpTestBase
+    {
+        public OmniSharpWorkspaceTestBase()
+        {
+            Workspace = TestOmniSharpWorkspace.Create();
+            var projectId = ProjectId.CreateNewId();
+            var projectInfo = ProjectInfo.Create(projectId, VersionStamp.Default, "TestProject", "TestAssembly", LanguageNames.CSharp, filePath: "/path/to/project.csproj");
+            Workspace.AddProject(projectInfo);
+            Project = Workspace.CurrentSolution.Projects.FirstOrDefault();
+        }
+
+        protected OmniSharpWorkspace Workspace { get; }
+
+        protected Project Project { get; }
+
+        protected Document AddRoslynDocument(string filePath)
+        {
+            var backgroundDocumentId = DocumentId.CreateNewId(Project.Id);
+            var backgroundDocumentInfo = DocumentInfo.Create(backgroundDocumentId, filePath ?? "EmptyFile", filePath: filePath);
+            Workspace.AddDocument(backgroundDocumentInfo);
+            var addedDocument = Workspace.CurrentSolution.GetDocument(backgroundDocumentId);
+            return addedDocument;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/PrecompiledRazorPageSuppressorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/PrecompiledRazorPageSuppressorTest.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
+{
+    public class PrecompiledRazorPageSuppressorTest : OmniSharpWorkspaceTestBase
+    {
+        [Fact]
+        public void Workspace_WorkspaceChanged_NullFilePath_Noops()
+        {
+            // Arrange
+            var originalSolution = Workspace.CurrentSolution;
+            var addedDocument = AddRoslynDocument(filePath: null);
+            var newSolution = Workspace.CurrentSolution;
+            var workspaceChangeEventArgs = new WorkspaceChangeEventArgs(
+                WorkspaceChangeKind.DocumentChanged,
+                originalSolution,
+                newSolution,
+                addedDocument.Project.Id,
+                addedDocument.Id);
+            var processedPublisher = new PrecompiledRazorPageSuppressor(Workspace);
+
+            // Act
+            processedPublisher.Workspace_WorkspaceChanged(sender: null, workspaceChangeEventArgs);
+
+            // Assert
+            Assert.Same(newSolution, Workspace.CurrentSolution);
+        }
+
+        [Fact]
+        public void Workspace_WorkspaceChanged_CommonCSharpFiles_Noops()
+        {
+            // Arrange
+            var originalSolution = Workspace.CurrentSolution;
+            var addedDocument = AddRoslynDocument(filePath: "/path/file.cs");
+            var newSolution = Workspace.CurrentSolution;
+            var workspaceChangeEventArgs = new WorkspaceChangeEventArgs(
+                WorkspaceChangeKind.DocumentChanged,
+                originalSolution,
+                newSolution,
+                addedDocument.Project.Id,
+                addedDocument.Id);
+            var processedPublisher = new PrecompiledRazorPageSuppressor(Workspace);
+
+            // Act
+            processedPublisher.Workspace_WorkspaceChanged(sender: null, workspaceChangeEventArgs);
+
+            // Assert
+            Assert.Same(newSolution, Workspace.CurrentSolution);
+        }
+
+        [Fact]
+        public void Workspace_WorkspaceChanged_RazorTargetAssemblyInfo_RemovesDocument()
+        {
+            // Arrange
+            var originalSolution = Workspace.CurrentSolution;
+            var addedDocument = AddRoslynDocument(filePath: "/path/obj/Debug/netcoreapp3.0/TheApp.RazorTargetAssemblyInfo.cs");
+            var newSolution = Workspace.CurrentSolution;
+            var workspaceChangeEventArgs = new WorkspaceChangeEventArgs(
+                WorkspaceChangeKind.DocumentChanged,
+                originalSolution,
+                newSolution,
+                addedDocument.Project.Id,
+                addedDocument.Id);
+            var processedPublisher = new PrecompiledRazorPageSuppressor(Workspace);
+
+            // Act
+            processedPublisher.Workspace_WorkspaceChanged(sender: null, workspaceChangeEventArgs);
+
+            // Assert
+            Assert.NotSame(newSolution, Workspace.CurrentSolution);
+            var potentialDocument = Workspace.CurrentSolution.GetDocument(addedDocument.Id);
+            Assert.Null(potentialDocument);
+        }
+
+        [Fact]
+        public void Workspace_WorkspaceChanged_RazorAssemblyInfo_RemovesDocument()
+        {
+            // Arrange
+            var originalSolution = Workspace.CurrentSolution;
+            var addedDocument = AddRoslynDocument(filePath: "/path/obj/Debug/netcoreapp3.0/TheApp.RazorAssemblyInfo.cs");
+            var newSolution = Workspace.CurrentSolution;
+            var workspaceChangeEventArgs = new WorkspaceChangeEventArgs(
+                WorkspaceChangeKind.DocumentChanged,
+                originalSolution,
+                newSolution,
+                addedDocument.Project.Id,
+                addedDocument.Id);
+            var processedPublisher = new PrecompiledRazorPageSuppressor(Workspace);
+
+            // Act
+            processedPublisher.Workspace_WorkspaceChanged(sender: null, workspaceChangeEventArgs);
+
+            // Assert
+            Assert.NotSame(newSolution, Workspace.CurrentSolution);
+            var potentialDocument = Workspace.CurrentSolution.GetDocument(addedDocument.Id);
+            Assert.Null(potentialDocument);
+        }
+
+        [Theory]
+        [InlineData(".cshtml.g.cs")]
+        [InlineData(".razor.g.cs")]
+        [InlineData(".g.cshtml.cs")]
+        public void Workspace_WorkspaceChanged_DynamicallyGeneratedDocuments_RemovesDocument(string extension)
+        {
+            // Arrange
+            var originalSolution = Workspace.CurrentSolution;
+            var addedDocument = AddRoslynDocument(filePath: "/path/obj/Debug/netcoreapp3.0/Razor/Index" + extension);
+            var newSolution = Workspace.CurrentSolution;
+            var workspaceChangeEventArgs = new WorkspaceChangeEventArgs(
+                WorkspaceChangeKind.DocumentChanged,
+                originalSolution,
+                newSolution,
+                addedDocument.Project.Id,
+                addedDocument.Id);
+            var processedPublisher = new PrecompiledRazorPageSuppressor(Workspace);
+
+            // Act
+            processedPublisher.Workspace_WorkspaceChanged(sender: null, workspaceChangeEventArgs);
+
+            // Assert
+            Assert.NotSame(newSolution, Workspace.CurrentSolution);
+            var potentialDocument = Workspace.CurrentSolution.GetDocument(addedDocument.Id);
+            Assert.Null(potentialDocument);
+        }
+    }
+}


### PR DESCRIPTION
- Prior to 3.1 Razor SDK would add Razor declarations to the compile list, we now need to remove all dynamically added Razor C# documents because we control which Razor documents are generated and added to the workspace.
- Also found that when the Razor document manager initializes it was opening all documents on add even if they weren't open. Unfortunately we can't currently test the Razor document manager because it depends on VSCode runtime APIs that we've yet to mock/abstract at the unit test layer.
- Added an `OmniSharpWorkspaceTestBase` to handle workspace creation.
- Added `PrecompiledRazorPageSuppressor` tests.