### PR TITLE
Fix VSCode Razor development configuration helpers.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
@@ -83,7 +83,7 @@
             },
             {
                 "command": "extension.configureRazorDevMode",
-                "title": "Configure workspace for Razor extension development.",
+                "title": "Configure workspace for Razor extension development",
                 "category": "Razor"
             },
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/src/RazorDevModeHelpers.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/src/RazorDevModeHelpers.ts
@@ -39,15 +39,22 @@ export async function registerRazorDevModeHelpers(context: vscode.ExtensionConte
         await vscode.commands.executeCommand('workbench.action.reloadWindow');
     });
     context.subscriptions.push(configureSubscription);
+}
 
+export function ensureWorkspaceIsConfigured() {
+    const razorConfiguration = vscode.workspace.getConfiguration('razor');
     if (!razorConfiguration.get('devmode')) {
         // Running in a workspace without devmode enabled. We should prompt the user to configure the workspace.
-        vscode.window.showWarningMessage(
+        vscode.window.showErrorMessage(
             'This workspace is not configured to use the local Razor extension.',
-            'Configure and Reload', 'Cancel').then(async (reloadResponse) => {
-                if (reloadResponse === 'Configure and reload?') {
+            'Configure and Reload').then(async (reloadResponse) => {
+                if (reloadResponse === 'Configure and Reload') {
                     await vscode.commands.executeCommand('extension.configureRazorDevMode');
                 }
             });
+
+        return false;
     }
+
+    return true;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/src/extension.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/src/extension.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs';
 import * as razorExtensionPackage from 'microsoft.aspnetcore.razor.vscode';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { registerRazorDevModeHelpers } from './RazorDevModeHelpers';
+import { ensureWorkspaceIsConfigured, registerRazorDevModeHelpers } from './RazorDevModeHelpers';
 
 let activationResolver: (value?: any) => void;
 export const extensionActivated = new Promise(resolve => {
@@ -43,11 +43,17 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('extension.razorActivated', () => extensionActivated);
 
     await registerRazorDevModeHelpers(context);
+    const workspaceConfigured = ensureWorkspaceIsConfigured();
 
-    await razorExtensionPackage.activate(
-        context,
-        languageServerDir,
-        hostEventStream);
+    if (workspaceConfigured) {
+        await razorExtensionPackage.activate(
+            context,
+            languageServerDir,
+            hostEventStream);
+    } else {
+        console.log('Razor workspace was not configured, extension activation skipped.');
+        console.log('To configure your workspace run the following command (ctrl+shift+p) in the experimental instance "Razor: Configure workspace for Razor extension development"');
+    }
 
     activationResolver();
 }


### PR DESCRIPTION
- Prior to this our warning dialog response was not being handled correctly.
- Stopped activating the development extension if the workspace wasn't configured. Did this because attempting to activate the Razor dev mode extension would occasionally fail due to a race between the official O# extension's Razor support and our dev variant both trying to register identical commands/functionality. This stopped activation and killed all behavior in the extension.