### PR TITLE
Change "RunExtension" to watch Razor library.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,7 @@
                 "${workspaceFolder}/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/dist/**/*.js",
                 "${workspaceFolder}/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/dist/**/*.js",
             ],
-            "preLaunchTask": "CompileExtension"
+            "preLaunchTask": "WatchLibraryAndCompileExtension"
         },
         {
             "type": "node",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,9 @@
         {
             "label": "CompilePackage",
             "command": "dotnet",
-            "args": [ "build" ],
+            "args": [
+                "build"
+            ],
             "options": {
                 "cwd": "src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/"
             },
@@ -14,21 +16,41 @@
             }
         },
         {
-          "label": "CompileLibrary",
-          "command": "dotnet",
-          "args": [ "build" ],
-          "options": {
-              "cwd": "src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/"
-          },
-          "problemMatcher": "$tsc-watch",
-          "presentation": {
-              "reveal": "silent"
-          }
+            "label": "CompileLibrary",
+            "command": "dotnet",
+            "args": [
+                "build"
+            ],
+            "options": {
+                "cwd": "src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/"
+            },
+            "problemMatcher": "$tsc-watch",
+            "presentation": {
+                "reveal": "silent"
+            }
+        },
+        {
+            "label": "WatchLibraryAndCompileExtension",
+            "type": "npm",
+            "script": "watch",
+            "problemMatcher": "$tsc-watch",
+            "options": {
+                "cwd": "src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/"
+            },
+            "isBackground": true,
+            "presentation": {
+                "reveal": "silent"
+            },
+            "dependsOn": [
+                "CompileExtension"
+            ]
         },
         {
             "label": "CompileExtension",
             "command": "dotnet",
-            "args": [ "build" ],
+            "args": [
+                "build"
+            ],
             "options": {
                 "cwd": "src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/"
             },
@@ -43,7 +65,9 @@
         {
             "label": "CompileUnitTests",
             "command": "dotnet",
-            "args": [ "build" ],
+            "args": [
+                "build"
+            ],
             "options": {
                 "cwd": "src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Test/"
             },
@@ -55,7 +79,9 @@
         {
             "label": "CompileFunctionalTest",
             "command": "dotnet",
-            "args": [ "build" ],
+            "args": [
+                "build"
+            ],
             "options": {
                 "cwd": "src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/"
             },
@@ -63,8 +89,8 @@
             "presentation": {
                 "reveal": "silent"
             },
-            "dependsOn":[
-              "CompileExtension"
+            "dependsOn": [
+                "CompileExtension"
             ]
         },
     ]


### PR DESCRIPTION
- With this change there's no reason to repeatedly run the VSCode extension. Instead you can make changes in the library and then just ctrl + r to reload the experimental instance and see the changes.
- VSCode's tasks support is limited when it comes to background commands (npm watch) because it typically will wait for a command to exit. Due to its limitations a background task must be the top level task that is called so that it's the "last" task that's in the pipeline; this way VSCode knows when to do the final launch command. In our case this means I had to add a `WatchLibraryAndCompileExtension` that in the background watched the library and then dependently compiled the extension (can't do both).