### PR TITLE
LSP: On document open populate Razor documents C#

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CSharpPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CSharpPublisher.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal abstract class CSharpPublisher : ProjectSnapshotChangeTrigger
+    {
+        public abstract void Publish(string filePath, SourceText sourceText, long hostDocumentVersion);
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultCSharpPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultCSharpPublisher.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class DefaultCSharpPublisher : CSharpPublisher
+    {
+        private static readonly SourceText EmptySourceText = SourceText.From(string.Empty);
+        private readonly Dictionary<string, SourceText> _publishedSourceText;
+        private readonly Lazy<ILanguageServer> _server;
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+        private ProjectSnapshotManagerBase _projectSnapshotManager;
+
+        public DefaultCSharpPublisher(
+            ForegroundDispatcher foregroundDispatcher,
+            Lazy<ILanguageServer> server)
+        {
+            if (foregroundDispatcher is null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            if (server is null)
+            {
+                throw new ArgumentNullException(nameof(server));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher;
+            _server = server;
+            _publishedSourceText = new Dictionary<string, SourceText>(FilePathComparer.Instance);
+        }
+
+        public override void Initialize(ProjectSnapshotManagerBase projectManager)
+        {
+            _projectSnapshotManager = projectManager;
+            _projectSnapshotManager.Changed += ProjectSnapshotManager_Changed;
+        }
+
+        public override void Publish(string filePath, SourceText sourceText, long hostDocumentVersion)
+        {
+            if (filePath is null)
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+
+            if (sourceText is null)
+            {
+                throw new ArgumentNullException(nameof(sourceText));
+            }
+
+            _foregroundDispatcher.AssertForegroundThread();
+
+            if (!_publishedSourceText.TryGetValue(filePath, out var previouslyPublishedText))
+            {
+                previouslyPublishedText = EmptySourceText;
+            }
+
+            IReadOnlyList<TextChange> textChanges = Array.Empty<TextChange>();
+            if (!sourceText.ContentEquals(previouslyPublishedText))
+            {
+                textChanges = sourceText.GetTextChanges(previouslyPublishedText);
+            }
+
+            _publishedSourceText[filePath] = sourceText;
+
+            var request = new UpdateCSharpBufferRequest()
+            {
+                HostDocumentFilePath = filePath,
+                Changes = textChanges,
+                HostDocumentVersion = hostDocumentVersion,
+            };
+
+            _server.Value.Client.SendRequest("updateCSharpBuffer", request);
+        }
+
+        private void ProjectSnapshotManager_Changed(object sender, ProjectChangeEventArgs args)
+        {
+            _foregroundDispatcher.AssertForegroundThread();
+
+            switch (args.Kind)
+            {
+                case ProjectChangeKind.DocumentChanged:
+                case ProjectChangeKind.DocumentRemoved:
+                    if (_publishedSourceText.ContainsKey(args.DocumentFilePath) &&
+                        !_projectSnapshotManager.IsDocumentOpen(args.DocumentFilePath))
+                    {
+                        // Document closed or removed, evict published source text.
+                        var removed = _publishedSourceText.Remove(args.DocumentFilePath);
+
+                        Debug.Assert(removed, "Published source text should be protected by the foreground thread and should never fail to remove.");
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedCodeContainerStore.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedCodeContainerStore.cs
@@ -3,28 +3,25 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
-using Microsoft.CodeAnalysis.Text;
-using OmniSharp.Extensions.LanguageServer.Server;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class DefaultGeneratedCodeContainerStore : GeneratedCodeContainerStore
     {
         private readonly ConcurrentDictionary<string, GeneratedCodeContainer> _store;
-        private readonly Lazy<ILanguageServer> _server;
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly DocumentVersionCache _documentVersionCache;
+        private readonly CSharpPublisher _csharpPublisher;
         private ProjectSnapshotManagerBase _projectSnapshotManager;
 
         public DefaultGeneratedCodeContainerStore(
             ForegroundDispatcher foregroundDispatcher,
             DocumentVersionCache documentVersionCache,
-            Lazy<ILanguageServer> server)
+            CSharpPublisher csharpPublisher)
         {
             if (foregroundDispatcher == null)
             {
@@ -36,14 +33,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 throw new ArgumentNullException(nameof(documentVersionCache));
             }
 
-            if (server == null)
+            if (csharpPublisher is null)
             {
-                throw new ArgumentNullException(nameof(server));
+                throw new ArgumentNullException(nameof(csharpPublisher));
             }
 
             _foregroundDispatcher = foregroundDispatcher;
             _documentVersionCache = documentVersionCache;
-            _server = server;
+            _csharpPublisher = csharpPublisher;
             _store = new ConcurrentDictionary<string, GeneratedCodeContainer>(FilePathComparer.Instance);
         }
 
@@ -96,18 +93,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 var generatedCodeContainer = (GeneratedCodeContainer)sender;
 
-                IReadOnlyList<TextChange> textChanges;
-
-                if (args.NewText.ContentEquals(args.OldText))
-                {
-                    // If the content is equal then no need to update the underlying CSharp buffer.
-                    textChanges = Array.Empty<TextChange>();
-                }
-                else
-                {
-                    textChanges = args.NewText.GetTextChanges(args.OldText);
-                }
-
                 var latestDocument = generatedCodeContainer.LatestDocument;
 
                 Task.Factory.StartNew(() =>
@@ -124,14 +109,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         return;
                     }
 
-                    var request = new UpdateCSharpBufferRequest()
-                    {
-                        HostDocumentFilePath = filePath,
-                        Changes = textChanges,
-                        HostDocumentVersion = hostDocumentVersion,
-                    };
-
-                    _server.Value.Client.SendRequest("updateCSharpBuffer", request);
+                    _csharpPublisher.Publish(filePath, args.NewText, hostDocumentVersion);
                 }, CancellationToken.None, TaskCreationOptions.None, _foregroundDispatcher.ForegroundScheduler);
             };
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
@@ -98,6 +98,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
                         var foregroundDispatcher = new VSCodeForegroundDispatcher();
                         services.AddSingleton<ForegroundDispatcher>(foregroundDispatcher);
+
+                        var csharpPublisher = new DefaultCSharpPublisher(foregroundDispatcher, new Lazy<OmniSharp.Extensions.LanguageServer.Protocol.Server.ILanguageServer>(() => server));
+                        services.AddSingleton<ProjectSnapshotChangeTrigger>(csharpPublisher);
+                        services.AddSingleton<CSharpPublisher>(csharpPublisher);
+
                         services.AddSingleton<RazorCompletionFactsService, DefaultRazorCompletionFactsService>();
                         var documentVersionCache = new DefaultDocumentVersionCache(foregroundDispatcher);
                         services.AddSingleton<DocumentVersionCache>(documentVersionCache);
@@ -105,7 +110,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         var containerStore = new DefaultGeneratedCodeContainerStore(
                             foregroundDispatcher,
                             documentVersionCache,
-                            new Lazy<ILanguageServer>(() => server));
+                            csharpPublisher);
                         services.AddSingleton<GeneratedCodeContainerStore>(containerStore);
                         services.AddSingleton<ProjectSnapshotChangeTrigger>(containerStore);
                     }));

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -137,7 +137,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             _foregroundDispatcher.AssertForegroundThread();
 
             var textDocumentPath = _filePathNormalizer.Normalize(filePath);
-            if (!_documentResolver.TryResolveDocument(textDocumentPath, out var _))
+            if (!_documentResolver.TryResolveDocument(textDocumentPath, out _))
             {
                 // Document hasn't been added. This usually occurs when VSCode trumps all other initialization 
                 // processes and pre-initializes already open documents.
@@ -153,8 +153,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
 
             _logger.LogInformation($"Opening document '{textDocumentPath}' in project '{projectSnapshot.FilePath}'.");
             _projectSnapshotManagerAccessor.Instance.DocumentOpened(defaultProject.HostProject.FilePath, textDocumentPath, sourceText);
+
             TrackDocumentVersion(textDocumentPath, version);
 
+            if (_documentResolver.TryResolveDocument(textDocumentPath, out var documentSnapshot))
+            {
+                // Start generating the C# for the document so it can immediately be ready for incoming requests.
+                documentSnapshot.GetGeneratedOutputAsync();
+            }
         }
 
         public override void CloseDocument(string filePath)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/UnsynchronizableContentDocumentProcessedListener.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/UnsynchronizableContentDocumentProcessedListener.cs
@@ -2,10 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
-using Microsoft.CodeAnalysis.Text;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -13,13 +12,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     {
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly DocumentVersionCache _documentVersionCache;
-        private readonly ILanguageServer _router;
+        private readonly CSharpPublisher _csharpPublisher;
         private ProjectSnapshotManager _projectManager;
 
         public UnsynchronizableContentDocumentProcessedListener(
             ForegroundDispatcher foregroundDispatcher,
             DocumentVersionCache documentVersionCache,
-            ILanguageServer router)
+            CSharpPublisher csharpPublisher)
         {
             if (foregroundDispatcher == null)
             {
@@ -31,14 +30,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 throw new ArgumentNullException(nameof(documentVersionCache));
             }
 
-            if (router == null)
+            if (csharpPublisher is null)
             {
-                throw new ArgumentNullException(nameof(router));
+                throw new ArgumentNullException(nameof(csharpPublisher));
             }
 
             _foregroundDispatcher = foregroundDispatcher;
             _documentVersionCache = documentVersionCache;
-            _router = router;
+            _csharpPublisher = csharpPublisher;
         }
 
         public override void DocumentProcessed(DocumentSnapshot document)
@@ -73,14 +72,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 // Documents are identical but we didn't synchronize them because they didn't need to be re-evaluated.
 
-                var request = new UpdateCSharpBufferRequest()
-                {
-                    HostDocumentFilePath = document.FilePath,
-                    Changes = Array.Empty<TextChange>(),
-                    HostDocumentVersion = syncVersion
-                };
+                var result = document.TryGetText(out var latestText);
+                Debug.Assert(result, "We just successfully retrieved the text version, this should always return true.");
 
-                _router.Client.SendRequest("updateCSharpBuffer", request);
+                _csharpPublisher.Publish(document.FilePath, latestText, syncVersion);
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/BackgroundDocumentProcessedPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/BackgroundDocumentProcessedPublisher.cs
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             {
                 switch (args.Kind)
                 {
-                    case WorkspaceChangeKind.DocumentChanged:
+                    case WorkspaceChangeKind.DocumentAdded:
                         {
                             // We could technically listen for DocumentAdded here but just because a document gets added doesn't mean it has content included.
                             // Therefore we need to wait for content to populated for Razor files so we don't preemptively remove the corresponding background

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/src/RazorDevModeHelpers.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/src/RazorDevModeHelpers.ts
@@ -23,6 +23,7 @@ export async function registerRazorDevModeHelpers(context: vscode.ExtensionConte
 
     const configureSubscription = vscode.commands.registerCommand('extension.configureRazorDevMode', async () => {
         await razorConfiguration.update('devmode', true);
+        await razorConfiguration.update('trace', 'Verbose');
 
         const pluginPath = path.join(
             __dirname, '..', '..', '..', '..', '..', 'artifacts', 'bin', 'Microsoft.AspNetCore.Razor.OmniSharpPlugin', 'Debug', 'net472', 'Microsoft.AspNetCore.Razor.OmniSharpPlugin.dll');

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
@@ -198,6 +198,8 @@ export class RazorDocumentManager implements IRazorDocumentManager {
             csharpProjectedDocument.update(updateBufferRequest.changes, updateBufferRequest.hostDocumentVersion);
 
             this.notifyDocumentChange(document, RazorDocumentChangeKind.csharpChanged);
+        } else {
+            this.logger.logWarning('Failed to update the C# document buffer. This is unexpected and may result in incorrect C# interactions.');
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLogger.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLogger.ts
@@ -36,6 +36,12 @@ export class RazorLogger implements vscode.Disposable {
         this.logWithmarker(message);
     }
 
+    public logWarning(message: string) {
+        // Always log warnings
+        const warningPrefixedMessage = `(Warning) ${message}`;
+        this.logAlways(warningPrefixedMessage);
+    }
+
     public logError(message: string, error: Error) {
         // Always log errors
         const errorPrefixedMessage = `(Error) ${message}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultCSharpPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultCSharpPublisherTest.cs
@@ -1,0 +1,274 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class DefaultCSharpPublisherTest : LanguageServerTestBase
+    {
+        public DefaultCSharpPublisherTest()
+        {
+            Server = new TestServer();
+            ProjectManager = TestProjectSnapshotManager.Create(Dispatcher);
+            ProjectManager.AllowNotifyListeners = true;
+            HostProject = new HostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
+            ProjectManager.ProjectAdded(HostProject);
+            HostDocument = new HostDocument("/path/to/file.razor", "file.razor");
+            ProjectManager.DocumentAdded(HostProject, HostDocument, new EmptyTextLoader(HostDocument.FilePath));
+        }
+
+        private TestServer Server { get; }
+
+        private TestProjectSnapshotManager ProjectManager { get; }
+
+        private HostProject HostProject { get; }
+
+        private HostDocument HostDocument { get; }
+
+        [Fact]
+        public void Publish_FirstTime_PublishesEntireSourceText()
+        {
+            // Arrange
+            var csharpPublisher = new DefaultCSharpPublisher(Dispatcher, new Lazy<ILanguageServer>(() => Server));
+            var content = "// C# content";
+            var sourceText = SourceText.From(content);
+
+            // Act
+            csharpPublisher.Publish("/path/to/file.razor", sourceText, 123);
+
+            // Assert
+            var updateRequest = Assert.Single(Server.UpdateRequests);
+            Assert.Equal("/path/to/file.razor", updateRequest.HostDocumentFilePath);
+            var textChange = Assert.Single(updateRequest.Changes);
+            Assert.Equal(content, textChange.NewText);
+            Assert.Equal(123, updateRequest.HostDocumentVersion);
+        }
+
+        [Fact]
+        public void Publish_SecondTime_PublishesSourceTextDifferences()
+        {
+            // Arrange
+            var csharpPublisher = new DefaultCSharpPublisher(Dispatcher, new Lazy<ILanguageServer>(() => Server));
+            var initialSourceText = SourceText.From("// Initial content");
+            csharpPublisher.Publish("/path/to/file.razor", initialSourceText, 123);
+            var change = new TextChange(
+                new TextSpan(initialSourceText.Length, 0),
+                "!!");
+            var changedSourceText = initialSourceText.WithChanges(change);
+
+            // Act
+            csharpPublisher.Publish("/path/to/file.razor", changedSourceText, 124);
+
+            // Assert
+            Assert.Equal(2, Server.UpdateRequests.Count);
+            var updateRequest = Server.UpdateRequests.Last();
+            Assert.Equal("/path/to/file.razor", updateRequest.HostDocumentFilePath);
+            var textChange = Assert.Single(updateRequest.Changes);
+            Assert.Equal(change, textChange);
+            Assert.Equal(124, updateRequest.HostDocumentVersion);
+        }
+
+        [Fact]
+        public void Publish_SecondTime_IdenticalContent_NoTextChanges()
+        {
+            // Arrange
+            var csharpPublisher = new DefaultCSharpPublisher(Dispatcher, new Lazy<ILanguageServer>(() => Server));
+            var sourceTextContent = "// The content";
+            var initialSourceText = SourceText.From(sourceTextContent);
+            csharpPublisher.Publish("/path/to/file.razor", initialSourceText, 123);
+            var identicalSourceText = SourceText.From(sourceTextContent);
+
+            // Act
+            csharpPublisher.Publish("/path/to/file.razor", identicalSourceText, 124);
+
+            // Assert
+            Assert.Equal(2, Server.UpdateRequests.Count);
+            var updateRequest = Server.UpdateRequests.Last();
+            Assert.Equal("/path/to/file.razor", updateRequest.HostDocumentFilePath);
+            Assert.Empty(updateRequest.Changes);
+            Assert.Equal(124, updateRequest.HostDocumentVersion);
+        }
+
+        [Fact]
+        public void Publish_DifferentFileSameContent_PublishesEverything()
+        {
+            // Arrange
+            var csharpPublisher = new DefaultCSharpPublisher(Dispatcher, new Lazy<ILanguageServer>(() => Server));
+            var sourceTextContent = "// The content";
+            var initialSourceText = SourceText.From(sourceTextContent);
+            csharpPublisher.Publish("/path/to/file1.razor", initialSourceText, 123);
+            var identicalSourceText = SourceText.From(sourceTextContent);
+
+            // Act
+            csharpPublisher.Publish("/path/to/file2.razor", identicalSourceText, 123);
+
+            // Assert
+            Assert.Equal(2, Server.UpdateRequests.Count);
+            var updateRequest = Server.UpdateRequests.Last();
+            Assert.Equal("/path/to/file2.razor", updateRequest.HostDocumentFilePath);
+            var textChange = Assert.Single(updateRequest.Changes);
+            Assert.Equal(sourceTextContent, textChange.NewText);
+            Assert.Equal(123, updateRequest.HostDocumentVersion);
+        }
+
+        [Fact]
+        public void ProjectSnapshotManager_DocumentChanged_OpenDocument_PublishesEmptyTextChanges()
+        {
+            // Arrange
+            var csharpPublisher = new DefaultCSharpPublisher(Dispatcher, new Lazy<ILanguageServer>(() => Server));
+            csharpPublisher.Initialize(ProjectManager);
+            var sourceTextContent = "// The content";
+            var initialSourceText = SourceText.From(sourceTextContent);
+            csharpPublisher.Publish(HostDocument.FilePath, initialSourceText, 123);
+
+            // Act
+            ProjectManager.DocumentOpened(HostProject.FilePath, HostDocument.FilePath, initialSourceText);
+            csharpPublisher.Publish(HostDocument.FilePath, initialSourceText, 123);
+
+            // Assert
+            Assert.Equal(2, Server.UpdateRequests.Count);
+            var updateRequest = Server.UpdateRequests.Last();
+            Assert.Equal(HostDocument.FilePath, updateRequest.HostDocumentFilePath);
+            Assert.Empty(updateRequest.Changes);
+            Assert.Equal(123, updateRequest.HostDocumentVersion);
+        }
+
+        [Fact]
+        public void ProjectSnapshotManager_DocumentChanged_ClosedDocument_RepublishesTextChanges()
+        {
+            // Arrange
+            var csharpPublisher = new DefaultCSharpPublisher(Dispatcher, new Lazy<ILanguageServer>(() => Server));
+            csharpPublisher.Initialize(ProjectManager);
+            var sourceTextContent = "// The content";
+            var initialSourceText = SourceText.From(sourceTextContent);
+            csharpPublisher.Publish(HostDocument.FilePath, initialSourceText, 123);
+            ProjectManager.DocumentOpened(HostProject.FilePath, HostDocument.FilePath, initialSourceText);
+
+            // Act
+            ProjectManager.DocumentClosed(HostProject.FilePath, HostDocument.FilePath, new EmptyTextLoader(HostDocument.FilePath));
+            csharpPublisher.Publish(HostDocument.FilePath, initialSourceText, 123);
+
+            // Assert
+            Assert.Equal(2, Server.UpdateRequests.Count);
+            var updateRequest = Server.UpdateRequests.Last();
+            Assert.Equal(HostDocument.FilePath, updateRequest.HostDocumentFilePath);
+            var textChange = Assert.Single(updateRequest.Changes);
+            Assert.Equal(sourceTextContent, textChange.NewText);
+            Assert.Equal(123, updateRequest.HostDocumentVersion);
+        }
+
+        [Fact]
+        public void ProjectSnapshotManager_DocumentRemoved_RepublishesTextChanges()
+        {
+            // Arrange
+            var csharpPublisher = new DefaultCSharpPublisher(Dispatcher, new Lazy<ILanguageServer>(() => Server));
+            csharpPublisher.Initialize(ProjectManager);
+            var sourceTextContent = "// The content";
+            var initialSourceText = SourceText.From(sourceTextContent);
+            csharpPublisher.Publish(HostDocument.FilePath, initialSourceText, 123);
+
+            // Act
+            ProjectManager.DocumentRemoved(HostProject, HostDocument);
+            csharpPublisher.Publish(HostDocument.FilePath, initialSourceText, 123);
+
+            // Assert
+            Assert.Equal(2, Server.UpdateRequests.Count);
+            var updateRequest = Server.UpdateRequests.Last();
+            Assert.Equal(HostDocument.FilePath, updateRequest.HostDocumentFilePath);
+            var textChange = Assert.Single(updateRequest.Changes);
+            Assert.Equal(sourceTextContent, textChange.NewText);
+            Assert.Equal(123, updateRequest.HostDocumentVersion);
+        }
+
+        private class TestServer : ILanguageServer
+        {
+            public TestServer()
+            {
+                var synchronizedDocuments = new List<UpdateCSharpBufferRequest>();
+                UpdateRequests = synchronizedDocuments;
+                Client = new TestClient(synchronizedDocuments);
+            }
+
+            public IReadOnlyList<UpdateCSharpBufferRequest> UpdateRequests { get; }
+
+            public ILanguageServerClient Client { get; }
+
+            public ILanguageServerDocument Document => throw new NotImplementedException();
+
+            public ILanguageServerWindow Window => throw new NotImplementedException();
+
+            public ILanguageServerWorkspace Workspace => throw new NotImplementedException();
+
+            public IDisposable AddHandler(string method, IJsonRpcHandler handler) => throw new NotImplementedException();
+
+            public IDisposable AddHandler(string method, Func<IServiceProvider, IJsonRpcHandler> handlerFunc) => throw new NotImplementedException();
+
+            public IDisposable AddHandler<T>() where T : IJsonRpcHandler => throw new NotImplementedException();
+
+            public IDisposable AddHandlers(params IJsonRpcHandler[] handlers) => throw new NotImplementedException();
+
+            public IDisposable AddTextDocumentIdentifier(params ITextDocumentIdentifier[] handlers) => throw new NotImplementedException();
+
+            public IDisposable AddTextDocumentIdentifier<T>() where T : ITextDocumentIdentifier => throw new NotImplementedException();
+
+            public TaskCompletionSource<JToken> GetRequest(long id) => throw new NotImplementedException();
+
+            public void SendNotification(string method) => throw new NotImplementedException();
+
+            public void SendNotification<T>(string method, T @params) => throw new NotImplementedException();
+
+            public Task<TResponse> SendRequest<T, TResponse>(string method, T @params) => throw new NotImplementedException();
+
+            public Task<TResponse> SendRequest<TResponse>(string method) => throw new NotImplementedException();
+
+            public Task SendRequest<T>(string method, T @params) => throw new NotImplementedException();
+
+            private class TestClient : ILanguageServerClient
+            {
+                private readonly List<UpdateCSharpBufferRequest> _updateRequests;
+
+                public TestClient(List<UpdateCSharpBufferRequest> updateRequests)
+                {
+                    if (updateRequests == null)
+                    {
+                        throw new ArgumentNullException(nameof(updateRequests));
+                    }
+
+                    _updateRequests = updateRequests;
+                }
+
+                public Task SendRequest<T>(string method, T @params)
+                {
+                    var updateRequest = @params as UpdateCSharpBufferRequest;
+
+                    _updateRequests.Add(updateRequest);
+
+                    return Task.CompletedTask;
+                }
+
+                public TaskCompletionSource<JToken> GetRequest(long id) => throw new NotImplementedException();
+
+                public void SendNotification(string method) => throw new NotImplementedException();
+
+                public void SendNotification<T>(string method, T @params) => throw new NotImplementedException();
+
+                public Task<TResponse> SendRequest<T, TResponse>(string method, T @params) => throw new NotImplementedException();
+
+                public Task<TResponse> SendRequest<TResponse>(string method) => throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedCodeContainerStoreTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedCodeContainerStoreTest.cs
@@ -17,8 +17,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public DefaultGeneratedCodeContainerStoreTest()
         {
             var documentVersionCache = Mock.Of<DocumentVersionCache>();
-            var server = new Lazy<ILanguageServer>(() => null);
-            Store = new DefaultGeneratedCodeContainerStore(Dispatcher, documentVersionCache, server);
+            var csharpPublisher = Mock.Of<CSharpPublisher>();
+            Store = new DefaultGeneratedCodeContainerStore(Dispatcher, documentVersionCache, csharpPublisher);
             ProjectManager = TestProjectSnapshotManager.Create(Dispatcher);
             Store.Initialize(ProjectManager);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultHostDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultHostDocumentFactoryTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var store = new DefaultGeneratedCodeContainerStore(
                 Dispatcher,
                 Mock.Of<DocumentVersionCache>(),
-                new Lazy<ILanguageServer>(() => null));
+                Mock.Of<CSharpPublisher>());
             Factory = new DefaultHostDocumentFactory(Dispatcher, store);
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/BackgroundDocumentProcessedPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/BackgroundDocumentProcessedPublisherTest.cs
@@ -182,14 +182,14 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         }
 
         [Fact]
-        public void WorkspaceChanged_DocumentChanged_NoFilePathRoslynDocument_Noops()
+        public void WorkspaceChanged_DocumentAdded_NoFilePathRoslynDocument_Noops()
         {
             // Arrange
             var originalSolution = Workspace.CurrentSolution;
             var addedDocument = AddRoslynDocument(filePath: null);
             var newSolution = Workspace.CurrentSolution;
             var workspaceChangeEventArgs = new WorkspaceChangeEventArgs(
-                WorkspaceChangeKind.DocumentChanged,
+                WorkspaceChangeKind.DocumentAdded,
                 originalSolution,
                 newSolution,
                 addedDocument.Project.Id,
@@ -211,7 +211,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var addedDocument = AddRoslynDocument("/path/to/Counter.razor" + BackgroundDocumentProcessedPublisher.BackgroundVirtualDocumentSuffix);
             var newSolution = Workspace.CurrentSolution;
             var workspaceChangeEventArgs = new WorkspaceChangeEventArgs(
-                WorkspaceChangeKind.DocumentChanged,
+                WorkspaceChangeKind.DocumentAdded,
                 originalSolution,
                 newSolution,
                 addedDocument.Project.Id,
@@ -233,7 +233,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var addedDocument = AddRoslynDocument("/path/to/Counter.razor" + BackgroundDocumentProcessedPublisher.ActiveVirtualDocumentSuffix);
             var newSolution = Workspace.CurrentSolution;
             var workspaceChangeEventArgs = new WorkspaceChangeEventArgs(
-                WorkspaceChangeKind.DocumentChanged,
+                WorkspaceChangeKind.DocumentAdded,
                 originalSolution,
                 newSolution,
                 addedDocument.Project.Id,
@@ -258,7 +258,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var activeDocument = AddRoslynDocument(filePath + BackgroundDocumentProcessedPublisher.ActiveVirtualDocumentSuffix);
             var newSolution = Workspace.CurrentSolution;
             var workspaceChangeEventArgs = new WorkspaceChangeEventArgs(
-                WorkspaceChangeKind.DocumentChanged,
+                WorkspaceChangeKind.DocumentAdded,
                 originalSolution,
                 newSolution,
                 activeDocument.Project.Id,


### PR DESCRIPTION
- Added a C# publisher that's responsible for maintaining the clients understanding of the C# document. For each C# publish it tracks the `SourceText` that was previously published and diffs the two to find the minimal text changes that are needed to update the client. Prior to this we were making a lot of assumptions about the content of the clients C# buffer; one of which was that it had content when it actually didn't.
- Changed the `UnsynchronizableContentDocumentProcessedListener` and `DefaultGeneratedCodeContainerStore` to use the `CSharpPublisher` instead of independently publishing their C# to the client.
- Updated the open document event from clients to trigger a Razor document snapshots generation to warm the data/publish the C#.
- Updated the `BackgroundDocumentProcessedPublisher` in the O# plugin to respond to `DocumentAdded` events instead of `DocumentChanged` events to synchronize active/background documents. We can do this now that `DocumentAdded` will always correspond with published Razor C#.
- Updated the `RazorDevModeHelpers` to also set `razor.trace` to `Verbose` when the workspace is configured for local Razor dev.
- Updated existing tests and added new.

aspnet/AspNetCore#14295