### PR TITLE
Enable building `blazor-wasm` branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,7 @@ trigger:
   batch: true
   branches:
     include:
+      - blazor-wasm
       - master
       - release/*
 


### PR DESCRIPTION
Making sure the `blazor-wasm` branches are being built.