### PR TITLE
Publish C# for CSHTML files.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/BackgroundDocumentProcessedPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/BackgroundDocumentProcessedPublisher.cs
@@ -81,10 +81,10 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 
             _foregroundDispatcher.AssertForegroundThread();
 
-            if (!FileKinds.IsComponent(document.FileKind) || FileKinds.IsComponentImport(document.FileKind))
+            if (FileKinds.IsComponentImport(document.FileKind))
             {
-                // Today we only support publishing Razor component files to the workspace. We could choose to publish more but we're being
-                // purposefuly restrictive.
+                // Razor component imports don't have any C# to generate anyways, don't do the work. This doesn't capture _ViewImports.cshtml because we never
+                // associated a FileKind with those files.
                 return;
             }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/BackgroundDocumentProcessedPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/BackgroundDocumentProcessedPublisherTest.cs
@@ -11,22 +11,6 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
     public class BackgroundDocumentProcessedPublisherTest : OmniSharpWorkspaceTestBase
     {
         [Fact]
-        public async Task DocumentProcessed_CSHTML_Noops()
-        {
-            // Arrange
-            var project = CreateProjectSnapshot(Project.FilePath, new[] { "/path/to/file.cshtml" });
-            var document = project.GetDocument("/path/to/file.cshtml");
-            var originalSolution = Workspace.CurrentSolution;
-            var processedPublisher = new BackgroundDocumentProcessedPublisher(Dispatcher, Workspace, LoggerFactory);
-
-            // Act
-            await RunOnForegroundAsync(() => processedPublisher.DocumentProcessed(document));
-
-            // Assert
-            Assert.Same(originalSolution, Workspace.CurrentSolution);
-        }
-
-        [Fact]
         public async Task DocumentProcessed_Import_Noops()
         {
             // Arrange
@@ -77,11 +61,27 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         }
 
         [Fact]
-        public async Task DocumentProcessed_NoActiveDocument_AddsDocument()
+        public async Task DocumentProcessed_NoActiveDocument_AddsRazorDocument()
         {
             // Arrange
             var projectSnapshot = CreateProjectSnapshot(Project.FilePath, new[] { "/path/to/Counter.razor" });
             var document = projectSnapshot.GetDocument("/path/to/Counter.razor");
+            var processedPublisher = new BackgroundDocumentProcessedPublisher(Dispatcher, Workspace, LoggerFactory);
+
+            // Act
+            await RunOnForegroundAsync(() => processedPublisher.DocumentProcessed(document));
+
+            // Assert
+            var project = Assert.Single(Workspace.CurrentSolution.Projects);
+            Assert.Contains(project.Documents, roslynDocument => roslynDocument.FilePath.StartsWith(document.FilePath));
+        }
+
+        [Fact]
+        public async Task DocumentProcessed_NoActiveDocument_AddsCSHTMLDocument()
+        {
+            // Arrange
+            var projectSnapshot = CreateProjectSnapshot(Project.FilePath, new[] { "/path/to/Index.cshtml" });
+            var document = projectSnapshot.GetDocument("/path/to/Index.cshtml");
             var processedPublisher = new BackgroundDocumentProcessedPublisher(Dispatcher, Workspace, LoggerFactory);
 
             // Act


### PR DESCRIPTION
- This is to enable things like go-to-definition/rename