### PR TITLE
Add support for HTML + C# hover/quick info.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorHoverProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorHoverProvider.ts
@@ -1,0 +1,79 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode';
+import { RazorLanguageFeatureBase } from './RazorLanguageFeatureBase';
+
+export class RazorHoverProvider
+    extends RazorLanguageFeatureBase
+    implements vscode.HoverProvider {
+
+    public async provideHover(
+        document: vscode.TextDocument, position: vscode.Position,
+        token: vscode.CancellationToken) {
+
+        const projection = await this.getProjection(document, position, token);
+        if (!projection) {
+            return;
+        }
+
+        const results = await vscode.commands.executeCommand<vscode.Hover[]>(
+            'vscode.executeHoverProvider',
+            projection.uri,
+            projection.position);
+
+        if (!results || results.length === 0) {
+            return;
+        }
+
+        // At the vscode.HoverProvider layer we can only return a single hover result. Because of this limitation we need to
+        // be smart about combining multiple hovers content or only take a single hover result. For now we'll only take one
+        // of them and then based on user feedback we can change this approach in the future.
+        const applicableHover = results.filter(item => item.range)[0];
+        if (!applicableHover) {
+            // No hovers available with a range.
+            return;
+        }
+
+        // Re-map the projected hover range to the host document range
+        const remappedResponse = await this.serviceClient.mapToDocumentRange(
+            projection.languageKind,
+            applicableHover.range!,
+            document.uri);
+
+        if (!remappedResponse) {
+            // Couldn't remap the projected hover location, there's no hover information available.
+            return;
+        }
+
+        if (document.version !== remappedResponse.hostDocumentVersion) {
+            // This hover result is for a different version of the text document, bail.
+            return;
+        }
+
+        const rewrittenContent = new Array<vscode.MarkedString>();
+        for (const content of applicableHover.contents) {
+            // For some reason VSCode doesn't respect the hover contents as-is. Because of this we need to look at each permutation
+            // of "content" (MarkdownString | string | { language: string; value: string }) and re-compute it as a MarkdownString or
+            // string.
+
+            if (typeof content === 'string') {
+                rewrittenContent.push(content);
+            } else if ((content as { language: string; value: string }).language) {
+                const contentObject = (content as { language: string; value: string });
+                const markdownString = new vscode.MarkdownString();
+                markdownString.appendCodeblock(contentObject.value, contentObject.language);
+                rewrittenContent.push(markdownString);
+            } else {
+                const contentValue = (content as vscode.MarkdownString).value;
+                const markdownString = new vscode.MarkdownString(contentValue);
+                rewrittenContent.push(markdownString);
+            }
+        }
+
+        const hover = new vscode.Hover(rewrittenContent, remappedResponse.range);
+        return hover;
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
@@ -18,6 +18,7 @@ import { RazorDefinitionProvider } from './RazorDefinitionProvider';
 import { RazorDocumentManager } from './RazorDocumentManager';
 import { RazorDocumentSynchronizer } from './RazorDocumentSynchronizer';
 import { RazorDocumentTracker } from './RazorDocumentTracker';
+import { RazorHoverProvider } from './RazorHoverProvider';
 import { RazorImplementationProvider } from './RazorImplementationProvider';
 import { RazorLanguage } from './RazorLanguage';
 import { RazorLanguageConfiguration } from './RazorLanguageConfiguration';
@@ -79,6 +80,10 @@ export async function activate(context: ExtensionContext, languageServerDir: str
                 documentSynchronizer,
                 documentManager,
                 languageServiceClient);
+            const hoverProvider = new RazorHoverProvider(
+                documentSynchronizer,
+                documentManager,
+                languageServiceClient);
 
             localRegistrations.push(
                 languageConfiguration.register(),
@@ -97,6 +102,9 @@ export async function activate(context: ExtensionContext, languageServerDir: str
                 vscode.languages.registerImplementationProvider(
                     RazorLanguage.id,
                     implementationProvider),
+                vscode.languages.registerHoverProvider(
+                    RazorLanguage.documentSelector,
+                    hoverProvider),
                 projectTracker.register(),
                 projectManager.register(),
                 documentManager.register(),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/Hover.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/Hover.test.ts
@@ -1,0 +1,70 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert';
+import { afterEach, before, beforeEach } from 'mocha';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {
+    mvcWithComponentsRoot,
+    pollUntil,
+    waitForProjectReady,
+} from './TestUtil';
+
+let cshtmlDoc: vscode.TextDocument;
+let editor: vscode.TextEditor;
+
+suite('Completions', () => {
+    before(async () => {
+        await waitForProjectReady(mvcWithComponentsRoot);
+    });
+
+    beforeEach(async () => {
+        const filePath = path.join(mvcWithComponentsRoot, 'Views', 'Home', 'Index.cshtml');
+        cshtmlDoc = await vscode.workspace.openTextDocument(filePath);
+        editor = await vscode.window.showTextDocument(cshtmlDoc);
+    });
+
+    afterEach(async () => {
+        await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor');
+        await pollUntil(() => vscode.window.visibleTextEditors.length === 0, 1000);
+    });
+
+    test('Can perform hovers on C#', async () => {
+        const firstLine = new vscode.Position(0, 0);
+        await editor.edit(edit => edit.insert(firstLine, '<p>@DateTime.Now</p>\n'));
+        const hoverResult = await vscode.commands.executeCommand<vscode.Hover[]>(
+            'vscode.executeHoverProvider',
+            cshtmlDoc.uri,
+            new vscode.Position(0, 6));
+        const expectedRange = new vscode.Range(
+            new vscode.Position(0, 4),
+            new vscode.Position(0, 12));
+
+        assert.ok(hoverResult, 'Should have a hover result for DateTime.Now');
+        if (hoverResult) {
+            assert.equal(hoverResult.length, 1, 'Someone else unexpectedly may be providing hover results');
+            assert.deepEqual(hoverResult[0].range, expectedRange, 'C# hover range should be DateTime.Now');
+        }
+    });
+
+    test('Can perform hovers on HTML', async () => {
+        const firstLine = new vscode.Position(0, 0);
+        await editor.edit(edit => edit.insert(firstLine, '<p>@DateTime.Now</p>\n'));
+        const hoverResult = await vscode.commands.executeCommand<vscode.Hover[]>(
+            'vscode.executeHoverProvider',
+            cshtmlDoc.uri,
+            new vscode.Position(0, 1));
+        const expectedRange = new vscode.Range(
+            new vscode.Position(0, 1),
+            new vscode.Position(0, 2));
+
+        assert.ok(hoverResult, 'Should have a hover result for <p>');
+        if (hoverResult) {
+            assert.equal(hoverResult.length, 1, 'Someone else unexpectedly may be providing hover results');
+            assert.deepEqual(hoverResult[0].range, expectedRange, 'HTML hover range should be p');
+        }
+    });
+});


### PR DESCRIPTION
- As part of the hover provider I needed to rebuild the content in order for it to properly show. This looked to be a bug in VSCode. Will reach out to them.
- Added Hover functional tests to validate the C# + HTML experiences.
- Found a race condition in the `BackgroundDocumentProcessedPublisher` where files would attempt to be removed in a racey situation which didn't actually remove them.

aspnet/AspNetCore#14329