### PR TITLE
Add explicit expression support to Razor grammar.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -9,6 +9,9 @@
       "include": "#escaped-transition"
     },
     {
+      "include": "#directives"
+    },
+    {
       "include": "#implicit-expression"
     },
     {
@@ -72,10 +75,6 @@
         }
       ],
       "end": "(?=[\\s<])"
-    },
-    "await-prefix": {
-      "name": "keyword.other.await.cs",
-      "match": "(await)\\s+"
     },
     "implicit-expression-body": {
       "patterns": [
@@ -221,11 +220,63 @@
         }
       }
     },
-    "balanced-curlybraces-csharp": {
+    "directives": {
+      "patterns": [
+        {
+          "include": "#code-directive"
+        },
+        {
+          "include": "#functions-directive"
+        }
+      ]
+    },
+    "code-directive": {
+      "begin": "(@)(code)\\s*",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.code"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#directive-codeblock"
+        }
+      ],
+      "end": "(?<=})|\\s"
+    },
+    "functions-directive": {
+      "begin": "(@)(functions)\\s*",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.functions"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#directive-codeblock"
+        }
+      ],
+      "end": "(?<=})|\\s"
+    },
+    "directive-codeblock": {
       "begin": "(\\{)",
       "beginCaptures": {
         "1": {
-          "name": "punctuation.curlybrace.open.cs"
+          "name": "keyword.control.razor.directive.codeblock.open"
         }
       },
       "name": "razor.test.balanced.curlybraces",
@@ -237,9 +288,13 @@
       "end": "(\\})",
       "endCaptures": {
         "1": {
-          "name": "punctuation.curlybrace.close.cs"
+          "name": "keyword.control.razor.directive.codeblock.close"
         }
       }
+    },
+    "await-prefix": {
+      "name": "keyword.other.await.cs",
+      "match": "(await)\\s+"
     }
   }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -9,6 +9,9 @@
       "include": "#escaped-transition"
     },
     {
+      "include": "#implicit-expression"
+    },
+    {
       "include": "text.html.basic"
     }
   ],
@@ -45,6 +48,196 @@
       "endCaptures": {
         "0": {
           "name": "keyword.control.cshtml"
+        }
+      }
+    },
+    "implicit-expression": {
+      "name": "meta.expression.implicit.cshtml",
+      "begin": "(@)",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        }
+      },
+      "patterns": [
+        {
+          "include": "#await-prefix"
+        },
+        {
+          "include": "#implicit-expression-body"
+        }
+      ],
+      "end": "(?=[\\s<])"
+    },
+    "await-prefix": {
+      "name": "keyword.other.await.cs",
+      "match": "(await)\\s+"
+    },
+    "implicit-expression-body": {
+      "patterns": [
+        {
+          "include": "#implicit-expression-invocation-start"
+        },
+        {
+          "include": "#implicit-expression-accessor-start"
+        }
+      ],
+      "end": "(?=[\\s<])"
+    },
+    "implicit-expression-invocation-start": {
+      "begin": "([_[:alpha:]][_[:alnum:]]*)(?=\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#implicit-expression-continuation"
+        }
+      ],
+      "end": "(?=[\\s<])"
+    },
+    "implicit-expression-accessor-start": {
+      "begin": "([_[:alpha:]][_[:alnum:]]*)",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.other.object.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#implicit-expression-continuation"
+        }
+      ],
+      "end": "(?=[\\s<])"
+    },
+    "implicit-expression-continuation": {
+      "patterns": [
+        {
+          "include": "#balanced-parenthesis-csharp"
+        },
+        {
+          "include": "#balanced-brackets-csharp"
+        },
+        {
+          "include": "#implicit-expression-invocation"
+        },
+        {
+          "include": "#implicit-expression-accessor"
+        },
+        {
+          "include": "#implicit-expression-extension"
+        }
+      ],
+      "end": "(?=[\\s<])"
+    },
+    "implicit-expression-accessor": {
+      "match": "(?<=\\.)[_[:alpha:]][_[:alnum:]]*",
+      "name": "variable.other.object.property.cs"
+    },
+    "implicit-expression-invocation": {
+      "match": "(?<=\\.)[_[:alpha:]][_[:alnum:]]*(?=\\()",
+      "name": "entity.name.function.cs"
+    },
+    "implicit-expression-operator": {
+      "patterns": [
+        {
+          "include": "#implicit-expression-dot-operator"
+        },
+        {
+          "include": "#implicit-expression-null-conditional-operator"
+        },
+        {
+          "include": "#implicit-expression-null-forgiveness-operator"
+        }
+      ]
+    },
+    "implicit-expression-dot-operator": {
+      "match": "(\\.)(?=[_[:alpha:]][_[:alnum:]]*)",
+      "captures": {
+        "1": {
+          "name": "punctuation.accessor.cs"
+        }
+      }
+    },
+    "implicit-expression-null-conditional-operator": {
+      "match": "(\\?)(?=[.\\[])",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.null-conditional.cs"
+        }
+      }
+    },
+    "implicit-expression-null-forgiveness-operator": {
+      "match": "(\\!)(?=(?:\\.[_[:alpha:]][_[:alnum:]]*)|\\?|[\\[\\(])",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.logical.cs"
+        }
+      }
+    },
+    "balanced-parenthesis-csharp": {
+      "begin": "(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.parenthesis.open.cs"
+        }
+      },
+      "name": "razor.test.balanced.parenthesis",
+      "patterns": [
+        {
+          "include": "source.cs"
+        }
+      ],
+      "end": "(\\))",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.parenthesis.close.cs"
+        }
+      }
+    },
+    "balanced-brackets-csharp": {
+      "begin": "(\\[)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.squarebracket.open.cs"
+        }
+      },
+      "name": "razor.test.balanced.brackets",
+      "patterns": [
+        {
+          "include": "source.cs"
+        }
+      ],
+      "end": "(\\])",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.squarebracket.close.cs"
+        }
+      }
+    },
+    "balanced-curlybraces-csharp": {
+      "begin": "(\\{)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.curlybrace.open.cs"
+        }
+      },
+      "name": "razor.test.balanced.curlybraces",
+      "patterns": [
+        {
+          "include": "source.cs"
+        }
+      ],
+      "end": "(\\})",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.curlybrace.close.cs"
         }
       }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -3,6 +3,9 @@
   "scopeName": "text.aspnetcorerazor",
   "patterns": [
     {
+      "include": "#explicit-razor-expression"
+    },
+    {
       "include": "#escaped-transition"
     },
     {
@@ -13,6 +16,37 @@
     "escaped-transition": {
       "name": "constant.character.escape.razor.transition",
       "match": "@@"
+    },
+    "transition": {
+      "match": "@",
+      "name": "keyword.control.cshtml.transition"
+    },
+    "explicit-razor-expression": {
+      "name": "meta.expression.explicit.cshtml",
+      "begin": "(@)\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.control.cshtml"
+        },
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.cs#expression"
+        }
+      ],
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "keyword.control.cshtml"
+        }
+      }
     }
   }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -1,6 +1,7 @@
 name: ASP.NET Razor
 scopeName: text.aspnetcorerazor
 patterns:
+  - include: '#explicit-razor-expression'
   - include: '#escaped-transition'
   - include: 'text.html.basic'
 
@@ -8,3 +9,19 @@ repository:
   escaped-transition:
     name: constant.character.escape.razor.transition
     match: '@@'
+
+  transition:
+    match: '@'
+    name: keyword.control.cshtml.transition
+
+  explicit-razor-expression:
+    name: 'meta.expression.explicit.cshtml'
+    begin: '(@)\('
+    beginCaptures:
+      0: { name: 'keyword.control.cshtml' }
+      1: { patterns: [ include: '#transition' ] }
+    patterns:
+      - include: 'source.cs#expression'
+    end: '\)'
+    endCaptures:
+      0: { name: 'keyword.control.cshtml' }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -3,6 +3,7 @@ scopeName: text.aspnetcorerazor
 patterns:
   - include: '#explicit-razor-expression'
   - include: '#escaped-transition'
+  - include: '#directives'
   - include: '#implicit-expression'
   - include: 'text.html.basic'
 
@@ -15,7 +16,7 @@ repository:
     match: '@'
     name: keyword.control.cshtml.transition
 
-  # ----------  Explicit Expression ------------
+# ----------  Explicit Expression ------------
 
   explicit-razor-expression:
     name: 'meta.expression.explicit.cshtml'
@@ -29,7 +30,7 @@ repository:
     endCaptures:
       0: { name: 'keyword.control.cshtml' }
 
-  # ----------  Implicit Expression ------------
+# ----------  Implicit Expression ------------
 
   implicit-expression:
     name: 'meta.expression.implicit.cshtml'
@@ -127,16 +128,45 @@ repository:
     endCaptures:
       1: { name: 'punctuation.squarebracket.close.cs' }
 
-  balanced-curlybraces-csharp:
+# ----------  Directives ------------
+
+  #>>>>> @code and @functions <<<<<
+
+  directives:
+    patterns:
+      - include: '#code-directive'
+      - include: '#functions-directive'
+
+  code-directive:
+    begin: '(@)(code)\s*'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.razor.directive.code'}
+    patterns:
+      - include: '#directive-codeblock'
+    end: '(?<=})|\s'
+
+  functions-directive:
+    begin: '(@)(functions)\s*'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.razor.directive.functions'}
+    patterns:
+      - include: '#directive-codeblock'
+    end: '(?<=})|\s'
+
+  directive-codeblock:
     begin: '(\{)'
     beginCaptures:
-      1: { name: 'punctuation.curlybrace.open.cs' }
-    name: 'razor.test.balanced.curlybraces'
+      1: { name: 'keyword.control.razor.directive.codeblock.open' }
+    name: 'meta.structure.razor.directive.codeblock'
     patterns:
       - include: 'source.cs'
     end: '(\})'
     endCaptures:
-      1: { name: 'punctuation.curlybrace.close.cs' }
+      1: { name: 'keyword.control.razor.directive.codeblock.close' }
+
+  # ----------  Misc C# ------------
 
   await-prefix:
     name: 'keyword.other.await.cs'

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -3,6 +3,7 @@ scopeName: text.aspnetcorerazor
 patterns:
   - include: '#explicit-razor-expression'
   - include: '#escaped-transition'
+  - include: '#implicit-expression'
   - include: 'text.html.basic'
 
 repository:
@@ -13,6 +14,8 @@ repository:
   transition:
     match: '@'
     name: keyword.control.cshtml.transition
+
+  # ----------  Explicit Expression ------------
 
   explicit-razor-expression:
     name: 'meta.expression.explicit.cshtml'
@@ -25,3 +28,116 @@ repository:
     end: '\)'
     endCaptures:
       0: { name: 'keyword.control.cshtml' }
+
+  # ----------  Implicit Expression ------------
+
+  implicit-expression:
+    name: 'meta.expression.implicit.cshtml'
+    begin: '(@)'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+    patterns:
+      - include: '#await-prefix'
+      - include: '#implicit-expression-body'
+    end: '(?=[\s<])'
+
+  implicit-expression-body:
+    patterns:
+      - include: '#implicit-expression-invocation-start'
+      - include: '#implicit-expression-accessor-start'
+    end: '(?=[\s<])'
+
+  # CSharp colors method invocations differently than accessors
+  # This captures situations where you do @SomeMethod()
+  implicit-expression-invocation-start:
+    begin: '([_[:alpha:]][_[:alnum:]]*)(?=\()'
+    beginCaptures:
+      1: { name: 'entity.name.function.cs' }
+    patterns:
+      - include: '#implicit-expression-continuation'
+    end: '(?=[\s<])'
+
+  # CSharp colors property accessors differently than methods
+  # This captures situations where you do @SomeProperty
+  implicit-expression-accessor-start:
+    begin: '([_[:alpha:]][_[:alnum:]]*)'
+    beginCaptures:
+      1: { name: 'variable.other.object.cs' }
+    patterns:
+      - include: '#implicit-expression-continuation'
+    end: '(?=[\s<])'
+
+  implicit-expression-continuation:
+    patterns:
+      - include: '#balanced-parenthesis-csharp'
+      - include: '#balanced-brackets-csharp'
+      - include: '#implicit-expression-invocation'
+      - include: '#implicit-expression-accessor'
+      - include: '#implicit-expression-extension'
+    end: '(?=[\s<])'
+
+  implicit-expression-accessor:
+    match: '(?<=\.)[_[:alpha:]][_[:alnum:]]*'
+    name: 'variable.other.object.property.cs'
+
+  implicit-expression-invocation:
+    match: '(?<=\.)[_[:alpha:]][_[:alnum:]]*(?=\()'
+    name: 'entity.name.function.cs'
+
+  implicit-expression-operator:
+    patterns:
+      - include: '#implicit-expression-dot-operator'
+      - include: '#implicit-expression-null-conditional-operator'
+      - include: '#implicit-expression-null-forgiveness-operator'
+
+  implicit-expression-dot-operator:
+    match: '(\.)(?=[_[:alpha:]][_[:alnum:]]*)'
+    captures:
+      1: { name: 'punctuation.accessor.cs' }
+
+  implicit-expression-null-conditional-operator:
+    match: '(\?)(?=[.\[])'
+    captures:
+      1: { name: 'keyword.operator.null-conditional.cs' }
+
+  implicit-expression-null-forgiveness-operator:
+    match: '(\!)(?=(?:\.[_[:alpha:]][_[:alnum:]]*)|\?|[\[\(])'
+    captures:
+      1: { name: 'keyword.operator.logical.cs' }
+
+  balanced-parenthesis-csharp:
+    begin: '(\()'
+    beginCaptures:
+      1: { name: 'punctuation.parenthesis.open.cs' }
+    name: 'razor.test.balanced.parenthesis'
+    patterns:
+      - include: 'source.cs'
+    end: '(\))'
+    endCaptures:
+      1: { name: 'punctuation.parenthesis.close.cs' }
+
+  balanced-brackets-csharp:
+    begin: '(\[)'
+    beginCaptures:
+      1: { name: 'punctuation.squarebracket.open.cs' }
+    name: 'razor.test.balanced.brackets'
+    patterns:
+      - include: 'source.cs'
+    end: '(\])'
+    endCaptures:
+      1: { name: 'punctuation.squarebracket.close.cs' }
+
+  balanced-curlybraces-csharp:
+    begin: '(\{)'
+    beginCaptures:
+      1: { name: 'punctuation.curlybrace.open.cs' }
+    name: 'razor.test.balanced.curlybraces'
+    patterns:
+      - include: 'source.cs'
+    end: '(\})'
+    endCaptures:
+      1: { name: 'punctuation.curlybrace.close.cs' }
+
+  await-prefix:
+    name: 'keyword.other.await.cs'
+    match: '(await)\s+'

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/CodeDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/CodeDirective.ts
@@ -1,0 +1,36 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunCodeDirectiveSuite() {
+    describe('@code directive', () => {
+        it('No code block', async () => {
+            await assertMatchesSnapshot('@code');
+        });
+
+        it('Incomplete code block', async () => {
+            await assertMatchesSnapshot('@code {');
+        });
+
+        it('Single line', async () => {
+            await assertMatchesSnapshot('@code { public void Foo() {} }');
+        });
+
+        it('Multi line', async () => {
+            await assertMatchesSnapshot(
+                `@code {
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+    }
+}`);
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/ExplicitExpressions.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/ExplicitExpressions.ts
@@ -1,0 +1,42 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunExplicitExpressionSuite() {
+    describe('Explicit expressions', () => {
+        it('Empty', async () => {
+            await assertMatchesSnapshot('@()');
+        });
+
+        it('Single line simple', async () => {
+            await assertMatchesSnapshot('@(DateTime.Now)');
+        });
+
+        it('Single line complex', async () => {
+            await assertMatchesSnapshot('@(456 + new Array<int>(){1,2,3}[0] + await GetValueAsync<string>() ?? someArray[await DoMoreAsync(() => {})])');
+        });
+
+        it('Multi line', async () => {
+            await assertMatchesSnapshot(
+                `@(
+    Html.BeginForm(
+        "Login",
+        "Home",
+        new
+        {
+            @class = "someClass",
+            notValid = Html.DisplayFor<object>(
+                (_) => Model,
+                "name",
+                "someName",
+                new { })
+        })
+)`);
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/FunctionsDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/FunctionsDirective.ts
@@ -1,0 +1,36 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunFunctionsDirectiveSuite() {
+    describe('@functions directive', () => {
+        it('No code block', async () => {
+            await assertMatchesSnapshot('@functions');
+        });
+
+        it('Incomplete code block', async () => {
+            await assertMatchesSnapshot('@functions {');
+        });
+
+        it('Single line', async () => {
+            await assertMatchesSnapshot('@functions { public void Foo() {} }');
+        });
+
+        it('Multi line', async () => {
+            await assertMatchesSnapshot(
+                `@functions {
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+    }
+}`);
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -3,6 +3,7 @@
 * Licensed under the MIT License. See License.txt in the project root for license information.
 * ------------------------------------------------------------------------------------------ */
 
+import { RunExplicitExpressionSuite } from './ExplicitExpressions';
 import { RunTransitionsSuite } from './Transitions';
 
 // We bring together all test suites and wrap them in one here. The reason behind this is that
@@ -12,4 +13,5 @@ import { RunTransitionsSuite } from './Transitions';
 
 describe('Grammar tests', () => {
     RunTransitionsSuite();
+    RunExplicitExpressionSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -3,7 +3,9 @@
 * Licensed under the MIT License. See License.txt in the project root for license information.
 * ------------------------------------------------------------------------------------------ */
 
+import { RunCodeDirectiveSuite } from './CodeDirective';
 import { RunExplicitExpressionSuite } from './ExplicitExpressions';
+import { RunFunctionsDirectiveSuite } from './FunctionsDirective';
 import { RunImplicitExpressionSuite } from './ImplicitExpressions';
 import { RunTransitionsSuite } from './Transitions';
 
@@ -16,4 +18,6 @@ describe('Grammar tests', () => {
     RunTransitionsSuite();
     RunExplicitExpressionSuite();
     RunImplicitExpressionSuite();
+    RunCodeDirectiveSuite();
+    RunFunctionsDirectiveSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -4,6 +4,7 @@
 * ------------------------------------------------------------------------------------------ */
 
 import { RunExplicitExpressionSuite } from './ExplicitExpressions';
+import { RunImplicitExpressionSuite } from './ImplicitExpressions';
 import { RunTransitionsSuite } from './Transitions';
 
 // We bring together all test suites and wrap them in one here. The reason behind this is that
@@ -14,4 +15,5 @@ import { RunTransitionsSuite } from './Transitions';
 describe('Grammar tests', () => {
     RunTransitionsSuite();
     RunExplicitExpressionSuite();
+    RunImplicitExpressionSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/ImplicitExpressions.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/ImplicitExpressions.ts
@@ -1,0 +1,51 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunImplicitExpressionSuite() {
+    describe('Implicit Expressions', () => {
+        it('Empty', async () => {
+            await assertMatchesSnapshot('@');
+        });
+
+        it('Single line simple', async () => {
+            await assertMatchesSnapshot('@DateTime.Now');
+        });
+
+        it('Awaited property', async () => {
+            await assertMatchesSnapshot('@await AsyncProperty');
+        });
+
+        it('Awaited method invocation', async () => {
+            await assertMatchesSnapshot('@await AsyncMethod()');
+        });
+
+        it('Single line complex', async () => {
+            await assertMatchesSnapshot('@DateTime!.Now()[1234 + 5678](abc()!.Current, 1 + 2 + getValue())?.ToString[123](() => 456)');
+        });
+
+        it('Combined with HTML', async () => {
+            await assertMatchesSnapshot('<p>@DateTime.Now</p>');
+        });
+
+        it('Multi line', async () => {
+            await assertMatchesSnapshot(
+                `@DateTime!.Now()[1234 +
+5678](
+abc()!.Current,
+1 + 2 + getValue())?.ToString[123](
+() =>
+{
+    var x = 123;
+    var y = true;
+
+    return y ? x : 457;
+})`);
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -181,6 +181,207 @@ exports[`Grammar tests Explicit transitions Single line simple 1`] = `
 "
 `;
 
+exports[`Grammar tests Implicit Expressions Awaited method invocation 1`] = `
+"Line: @await AsyncMethod()
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 7 (await ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.other.await.cs
+ - token from 7 to 18 (AsyncMethod) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+"
+`;
+
+exports[`Grammar tests Implicit Expressions Awaited property 1`] = `
+"Line: @await AsyncProperty
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 7 (await ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.other.await.cs
+ - token from 7 to 20 (AsyncProperty) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+"
+`;
+
+exports[`Grammar tests Implicit Expressions Combined with HTML 1`] = `
+"Line: <p>@DateTime.Now</p>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, punctuation.definition.tag.begin.html
+ - token from 1 to 2 (p) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, entity.name.tag.html
+ - token from 2 to 3 (>) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, punctuation.definition.tag.end.html
+ - token from 3 to 4 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 4 to 12 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 12 to 13 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
+ - token from 13 to 16 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 16 to 18 (</) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, punctuation.definition.tag.begin.html
+ - token from 18 to 19 (p) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, entity.name.tag.html
+ - token from 19 to 20 (>) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, punctuation.definition.tag.end.html
+"
+`;
+
+exports[`Grammar tests Implicit Expressions Empty 1`] = `
+"Line: @
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+"
+`;
+
+exports[`Grammar tests Implicit Expressions Multi line 1`] = `
+"Line: @DateTime!.Now()[1234 +
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 9 to 11 (!.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
+ - token from 11 to 14 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 14 to 15 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 15 to 16 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 16 to 17 ([) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 17 to 21 (1234) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets
+ - token from 22 to 23 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, keyword.operator.arithmetic.cs
+
+Line: 5678](
+ - token from 0 to 4 (5678) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 4 to 5 (]) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 5 to 6 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+
+Line: abc()!.Current,
+ - token from 0 to 3 (abc) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 3 to 4 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 4 to 5 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 5 to 6 (!) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.logical.cs
+ - token from 6 to 7 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.accessor.cs
+ - token from 7 to 14 (Current) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.object.property.cs
+ - token from 14 to 16 (,) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+
+Line: 1 + 2 + getValue())?.ToString[123](
+ - token from 0 to 1 (1) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 1 to 2 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 2 to 3 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 4 to 5 (2) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 6 to 7 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 8 to 16 (getValue) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 16 to 17 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 17 to 18 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 18 to 19 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 19 to 21 (?.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
+ - token from 21 to 29 (ToString) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 29 to 30 ([) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 30 to 33 (123) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 33 to 34 (]) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 34 to 35 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+
+Line: () =>
+ - token from 0 to 1 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 3 to 5 (=>) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.arrow.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.curlybrace.open.cs
+
+Line:     var x = 123;
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 8 to 9 (x) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 12 to 15 (123) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 15 to 16 (;) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.terminator.statement.cs
+
+Line:     var y = true;
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 8 to 9 (y) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 12 to 16 (true) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.language.boolean.true.cs
+ - token from 16 to 17 (;) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.terminator.statement.cs
+
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+
+Line:     return y ? x : 457;
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 4 to 10 (return) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.control.flow.return.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 11 to 12 (y) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 13 to 14 (?) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.conditional.question-mark.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 15 to 16 (x) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 17 to 18 (:) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.conditional.colon.cs
+ - token from 18 to 19 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 19 to 22 (457) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 22 to 23 (;) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.terminator.statement.cs
+
+Line: })
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.curlybrace.close.cs
+ - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+"
+`;
+
+exports[`Grammar tests Implicit Expressions Single line complex 1`] = `
+"Line: @DateTime!.Now()[1234 + 5678](abc()!.Current, 1 + 2 + getValue())?.ToString[123](() => 456)
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 9 to 11 (!.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
+ - token from 11 to 14 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 14 to 15 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 15 to 16 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 16 to 17 ([) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 17 to 21 (1234) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets
+ - token from 22 to 23 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, keyword.operator.arithmetic.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets
+ - token from 24 to 28 (5678) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 28 to 29 (]) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 29 to 30 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 30 to 33 (abc) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 33 to 34 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 34 to 35 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 35 to 36 (!) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.logical.cs
+ - token from 36 to 37 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.accessor.cs
+ - token from 37 to 44 (Current) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.object.property.cs
+ - token from 44 to 46 (, ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 46 to 47 (1) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 47 to 48 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 48 to 49 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 49 to 50 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 50 to 51 (2) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 52 to 53 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 53 to 54 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 54 to 62 (getValue) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 62 to 63 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 63 to 64 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 64 to 65 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 65 to 67 (?.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
+ - token from 67 to 75 (ToString) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 75 to 76 ([) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 76 to 79 (123) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 79 to 80 (]) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 80 to 81 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 81 to 82 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 82 to 83 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 83 to 84 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 84 to 86 (=>) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.arrow.cs
+ - token from 86 to 87 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 87 to 90 (456) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 90 to 91 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+"
+`;
+
+exports[`Grammar tests Implicit Expressions Single line simple 1`] = `
+"Line: @DateTime.Now
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 9 to 10 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
+ - token from 10 to 13 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+"
+`;
+
 exports[`Grammar tests Transitions Escaped transitions 1`] = `
 "Line: @@
  - token from 0 to 2 (@@) with scopes text.aspnetcorerazor, constant.character.escape.razor.transition

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -1,5 +1,186 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Grammar tests Explicit transitions Empty 1`] = `
+"Line: @()
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 2 (() with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 2 to 3 ()) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml
+"
+`;
+
+exports[`Grammar tests Explicit transitions Multi line 1`] = `
+"Line: @(
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 2 (() with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml
+
+Line:     Html.BeginForm(
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 4 to 8 (Html) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, variable.other.object.cs
+ - token from 8 to 9 (.) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.accessor.cs
+ - token from 9 to 18 (BeginForm) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, entity.name.function.cs
+ - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+
+Line:         \\"Login\\",
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 8 to 9 (\\") with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 9 to 14 (Login) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, string.quoted.double.cs
+ - token from 14 to 15 (\\") with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 15 to 16 (,) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
+
+Line:         \\"Home\\",
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 8 to 9 (\\") with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 9 to 13 (Home) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, string.quoted.double.cs
+ - token from 13 to 14 (\\") with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 14 to 15 (,) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
+
+Line:         new
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 8 to 11 (new) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.other.new.cs
+
+Line:         {
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 8 to 9 ({) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.curlybrace.open.cs
+
+Line:             @class = \\"someClass\\",
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 12 to 18 (@class) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, variable.other.readwrite.cs
+ - token from 18 to 19 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 19 to 20 (=) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.operator.assignment.cs
+ - token from 20 to 21 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 21 to 22 (\\") with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 22 to 31 (someClass) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, string.quoted.double.cs
+ - token from 31 to 32 (\\") with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 32 to 33 (,) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
+
+Line:             notValid = Html.DisplayFor<object>(
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 12 to 20 (notValid) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, variable.other.readwrite.cs
+ - token from 20 to 21 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 21 to 22 (=) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.operator.assignment.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 23 to 27 (Html) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, variable.other.object.cs
+ - token from 27 to 28 (.) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.accessor.cs
+ - token from 28 to 38 (DisplayFor) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, entity.name.function.cs
+ - token from 38 to 39 (<) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.begin.cs
+ - token from 39 to 45 (object) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.type.cs
+ - token from 45 to 46 (>) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.end.cs
+ - token from 46 to 47 (() with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+
+Line:                 (_) => Model,
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 16 to 17 (() with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 17 to 18 (_) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, entity.name.variable.parameter.cs
+ - token from 18 to 19 ()) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 20 to 22 (=>) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.operator.arrow.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 23 to 28 (Model) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, variable.other.readwrite.cs
+ - token from 28 to 29 (,) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
+
+Line:                 \\"name\\",
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 16 to 17 (\\") with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 17 to 21 (name) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, string.quoted.double.cs
+ - token from 21 to 22 (\\") with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 22 to 23 (,) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
+
+Line:                 \\"someName\\",
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 16 to 17 (\\") with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 17 to 25 (someName) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, string.quoted.double.cs
+ - token from 25 to 26 (\\") with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 26 to 27 (,) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
+
+Line:                 new { })
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 16 to 19 (new) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.other.new.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 20 to 21 ({) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.curlybrace.open.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 22 to 23 (}) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.curlybrace.close.cs
+ - token from 23 to 24 ()) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+
+Line:         })
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.curlybrace.close.cs
+ - token from 9 to 10 ()) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+
+Line: )
+ - token from 0 to 1 ()) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml
+"
+`;
+
+exports[`Grammar tests Explicit transitions Single line complex 1`] = `
+"Line: @(456 + new Array<int>(){1,2,3}[0] + await GetValueAsync<string>() ?? someArray[await DoMoreAsync(() => {})])
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 2 (() with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 2 to 5 (456) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, constant.numeric.decimal.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 6 to 7 (+) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.operator.arithmetic.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 8 to 11 (new) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.other.new.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 12 to 17 (Array) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, storage.type.cs
+ - token from 17 to 18 (<) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.begin.cs
+ - token from 18 to 21 (int) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.type.cs
+ - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.end.cs
+ - token from 22 to 23 (() with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 23 to 24 ()) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 24 to 25 ({) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.curlybrace.open.cs
+ - token from 25 to 26 (1) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, constant.numeric.decimal.cs
+ - token from 26 to 27 (,) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
+ - token from 27 to 28 (2) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, constant.numeric.decimal.cs
+ - token from 28 to 29 (,) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
+ - token from 29 to 30 (3) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, constant.numeric.decimal.cs
+ - token from 30 to 31 (}) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.curlybrace.close.cs
+ - token from 31 to 32 ([) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.squarebracket.open.cs
+ - token from 32 to 33 (0) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, constant.numeric.decimal.cs
+ - token from 33 to 34 (]) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.squarebracket.close.cs
+ - token from 34 to 35 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 35 to 36 (+) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.operator.arithmetic.cs
+ - token from 36 to 37 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 37 to 42 (await) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.other.await.cs
+ - token from 42 to 43 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 43 to 56 (GetValueAsync) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, entity.name.function.cs
+ - token from 56 to 57 (<) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.begin.cs
+ - token from 57 to 63 (string) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.type.cs
+ - token from 63 to 64 (>) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.end.cs
+ - token from 64 to 65 (() with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 65 to 66 ()) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 66 to 67 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 67 to 69 (??) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.operator.null-coalescing.cs
+ - token from 69 to 70 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 70 to 79 (someArray) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, variable.other.object.property.cs
+ - token from 79 to 80 ([) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.squarebracket.open.cs
+ - token from 80 to 85 (await) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.other.await.cs
+ - token from 85 to 86 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 86 to 97 (DoMoreAsync) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, entity.name.function.cs
+ - token from 97 to 98 (() with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 98 to 99 (() with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 99 to 100 ()) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 100 to 101 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 101 to 103 (=>) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.operator.arrow.cs
+ - token from 103 to 104 ( ) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml
+ - token from 104 to 105 ({) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.curlybrace.open.cs
+ - token from 105 to 106 (}) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.curlybrace.close.cs
+ - token from 106 to 107 ()) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 107 to 108 (]) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.squarebracket.close.cs
+ - token from 108 to 109 ()) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml
+"
+`;
+
+exports[`Grammar tests Explicit transitions Single line simple 1`] = `
+"Line: @(DateTime.Now)
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 2 (() with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 2 to 10 (DateTime) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, variable.other.object.cs
+ - token from 10 to 11 (.) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.accessor.cs
+ - token from 11 to 14 (Now) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, variable.other.object.property.cs
+ - token from 14 to 15 ()) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml
+"
+`;
+
 exports[`Grammar tests Transitions Escaped transitions 1`] = `
 "Line: @@
  - token from 0 to 2 (@@) with scopes text.aspnetcorerazor, constant.character.escape.razor.transition

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -1,5 +1,185 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Grammar tests @code directive Incomplete code block 1`] = `
+"Line: @code {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 5 (code) with scopes text.aspnetcorerazor, keyword.control.razor.directive.code
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor
+ - token from 6 to 7 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.open
+"
+`;
+
+exports[`Grammar tests @code directive Multi line 1`] = `
+"Line: @code {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 5 (code) with scopes text.aspnetcorerazor, keyword.control.razor.directive.code
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor
+ - token from 6 to 7 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.open
+
+Line:     private int currentCount = 0;
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 12 to 15 (int) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.type.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 16 to 28 (currentCount) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 31 to 32 (0) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, constant.numeric.decimal.cs
+ - token from 32 to 33 (;) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.terminator.statement.cs
+
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+
+Line:     private void IncrementCount()
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 12 to 16 (void) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.type.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 17 to 31 (IncrementCount) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, entity.name.function.cs
+ - token from 31 to 32 (() with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.open.cs
+ - token from 32 to 33 ()) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.open.cs
+
+Line:         currentCount++;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 8 to 20 (currentCount) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, variable.other.readwrite.cs
+ - token from 20 to 22 (++) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.operator.increment.cs
+ - token from 22 to 23 (;) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.terminator.statement.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests @code directive No code block 1`] = `
+"Line: @code
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 5 (code) with scopes text.aspnetcorerazor, keyword.control.razor.directive.code
+"
+`;
+
+exports[`Grammar tests @code directive Single line 1`] = `
+"Line: @code { public void Foo() {} }
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 5 (code) with scopes text.aspnetcorerazor, keyword.control.razor.directive.code
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor
+ - token from 6 to 7 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.open
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 8 to 14 (public) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, storage.modifier.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 15 to 19 (void) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.type.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 20 to 23 (Foo) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, entity.name.function.cs
+ - token from 23 to 24 (() with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.open.cs
+ - token from 24 to 25 ()) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.close.cs
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 26 to 27 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.open.cs
+ - token from 27 to 28 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.close.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 29 to 30 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests @functions directive Incomplete code block 1`] = `
+"Line: @functions {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 10 (functions) with scopes text.aspnetcorerazor, keyword.control.razor.directive.functions
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor
+ - token from 11 to 12 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.open
+"
+`;
+
+exports[`Grammar tests @functions directive Multi line 1`] = `
+"Line: @functions {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 10 (functions) with scopes text.aspnetcorerazor, keyword.control.razor.directive.functions
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor
+ - token from 11 to 12 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.open
+
+Line:     private int currentCount = 0;
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 12 to 15 (int) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.type.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 16 to 28 (currentCount) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 31 to 32 (0) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, constant.numeric.decimal.cs
+ - token from 32 to 33 (;) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.terminator.statement.cs
+
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+
+Line:     private void IncrementCount()
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 12 to 16 (void) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.type.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 17 to 31 (IncrementCount) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, entity.name.function.cs
+ - token from 31 to 32 (() with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.open.cs
+ - token from 32 to 33 ()) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.open.cs
+
+Line:         currentCount++;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 8 to 20 (currentCount) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, variable.other.readwrite.cs
+ - token from 20 to 22 (++) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.operator.increment.cs
+ - token from 22 to 23 (;) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.terminator.statement.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests @functions directive No code block 1`] = `
+"Line: @functions
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 10 (functions) with scopes text.aspnetcorerazor, keyword.control.razor.directive.functions
+"
+`;
+
+exports[`Grammar tests @functions directive Single line 1`] = `
+"Line: @functions { public void Foo() {} }
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 10 (functions) with scopes text.aspnetcorerazor, keyword.control.razor.directive.functions
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor
+ - token from 11 to 12 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.open
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 13 to 19 (public) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, storage.modifier.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 20 to 24 (void) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.type.cs
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 25 to 28 (Foo) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, entity.name.function.cs
+ - token from 28 to 29 (() with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.open.cs
+ - token from 29 to 30 ()) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.close.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 31 to 32 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.open.cs
+ - token from 32 to 33 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.close.cs
+ - token from 33 to 34 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 34 to 35 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.close
+"
+`;
+
 exports[`Grammar tests Explicit transitions Empty 1`] = `
 "Line: @()
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml.transition


### PR DESCRIPTION
- Added tests to cover simple and complex explicit expression cases.
- Does not cover embedded transitions (templates)

aspnet/AspNetCore#14287