### PR TITLE
Add grammar support for @code and @functions directives.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -9,6 +9,9 @@
       "include": "#escaped-transition"
     },
     {
+      "include": "#directives"
+    },
+    {
       "include": "#implicit-expression"
     },
     {
@@ -72,10 +75,6 @@
         }
       ],
       "end": "(?=[\\s<])"
-    },
-    "await-prefix": {
-      "name": "keyword.other.await.cs",
-      "match": "(await)\\s+"
     },
     "implicit-expression-body": {
       "patterns": [
@@ -221,11 +220,63 @@
         }
       }
     },
-    "balanced-curlybraces-csharp": {
+    "directives": {
+      "patterns": [
+        {
+          "include": "#code-directive"
+        },
+        {
+          "include": "#functions-directive"
+        }
+      ]
+    },
+    "code-directive": {
+      "begin": "(@)(code)\\s*",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.code"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#directive-codeblock"
+        }
+      ],
+      "end": "(?<=})|\\s"
+    },
+    "functions-directive": {
+      "begin": "(@)(functions)\\s*",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.functions"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#directive-codeblock"
+        }
+      ],
+      "end": "(?<=})|\\s"
+    },
+    "directive-codeblock": {
       "begin": "(\\{)",
       "beginCaptures": {
         "1": {
-          "name": "punctuation.curlybrace.open.cs"
+          "name": "keyword.control.razor.directive.codeblock.open"
         }
       },
       "name": "razor.test.balanced.curlybraces",
@@ -237,9 +288,13 @@
       "end": "(\\})",
       "endCaptures": {
         "1": {
-          "name": "punctuation.curlybrace.close.cs"
+          "name": "keyword.control.razor.directive.codeblock.close"
         }
       }
+    },
+    "await-prefix": {
+      "name": "keyword.other.await.cs",
+      "match": "(await)\\s+"
     }
   }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -3,6 +3,7 @@ scopeName: text.aspnetcorerazor
 patterns:
   - include: '#explicit-razor-expression'
   - include: '#escaped-transition'
+  - include: '#directives'
   - include: '#implicit-expression'
   - include: 'text.html.basic'
 
@@ -15,7 +16,7 @@ repository:
     match: '@'
     name: keyword.control.cshtml.transition
 
-  # ----------  Explicit Expression ------------
+# ----------  Explicit Expression ------------
 
   explicit-razor-expression:
     name: 'meta.expression.explicit.cshtml'
@@ -29,7 +30,7 @@ repository:
     endCaptures:
       0: { name: 'keyword.control.cshtml' }
 
-  # ----------  Implicit Expression ------------
+# ----------  Implicit Expression ------------
 
   implicit-expression:
     name: 'meta.expression.implicit.cshtml'
@@ -127,16 +128,45 @@ repository:
     endCaptures:
       1: { name: 'punctuation.squarebracket.close.cs' }
 
-  balanced-curlybraces-csharp:
+# ----------  Directives ------------
+
+  #>>>>> @code and @functions <<<<<
+
+  directives:
+    patterns:
+      - include: '#code-directive'
+      - include: '#functions-directive'
+
+  code-directive:
+    begin: '(@)(code)\s*'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.razor.directive.code'}
+    patterns:
+      - include: '#directive-codeblock'
+    end: '(?<=})|\s'
+
+  functions-directive:
+    begin: '(@)(functions)\s*'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.razor.directive.functions'}
+    patterns:
+      - include: '#directive-codeblock'
+    end: '(?<=})|\s'
+
+  directive-codeblock:
     begin: '(\{)'
     beginCaptures:
-      1: { name: 'punctuation.curlybrace.open.cs' }
-    name: 'razor.test.balanced.curlybraces'
+      1: { name: 'keyword.control.razor.directive.codeblock.open' }
+    name: 'meta.structure.razor.directive.codeblock'
     patterns:
       - include: 'source.cs'
     end: '(\})'
     endCaptures:
-      1: { name: 'punctuation.curlybrace.close.cs' }
+      1: { name: 'keyword.control.razor.directive.codeblock.close' }
+
+  # ----------  Misc C# ------------
 
   await-prefix:
     name: 'keyword.other.await.cs'

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/CodeDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/CodeDirective.ts
@@ -1,0 +1,36 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunCodeDirectiveSuite() {
+    describe('@code directive', () => {
+        it('No code block', async () => {
+            await assertMatchesSnapshot('@code');
+        });
+
+        it('Incomplete code block', async () => {
+            await assertMatchesSnapshot('@code {');
+        });
+
+        it('Single line', async () => {
+            await assertMatchesSnapshot('@code { public void Foo() {} }');
+        });
+
+        it('Multi line', async () => {
+            await assertMatchesSnapshot(
+                `@code {
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+    }
+}`);
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/FunctionsDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/FunctionsDirective.ts
@@ -1,0 +1,36 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunFunctionsDirectiveSuite() {
+    describe('@functions directive', () => {
+        it('No code block', async () => {
+            await assertMatchesSnapshot('@functions');
+        });
+
+        it('Incomplete code block', async () => {
+            await assertMatchesSnapshot('@functions {');
+        });
+
+        it('Single line', async () => {
+            await assertMatchesSnapshot('@functions { public void Foo() {} }');
+        });
+
+        it('Multi line', async () => {
+            await assertMatchesSnapshot(
+                `@functions {
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+    }
+}`);
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -3,7 +3,9 @@
 * Licensed under the MIT License. See License.txt in the project root for license information.
 * ------------------------------------------------------------------------------------------ */
 
+import { RunCodeDirectiveSuite } from './CodeDirective';
 import { RunExplicitExpressionSuite } from './ExplicitExpressions';
+import { RunFunctionsDirectiveSuite } from './FunctionsDirective';
 import { RunImplicitExpressionSuite } from './ImplicitExpressions';
 import { RunTransitionsSuite } from './Transitions';
 
@@ -16,4 +18,6 @@ describe('Grammar tests', () => {
     RunTransitionsSuite();
     RunExplicitExpressionSuite();
     RunImplicitExpressionSuite();
+    RunCodeDirectiveSuite();
+    RunFunctionsDirectiveSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -1,5 +1,185 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Grammar tests @code directive Incomplete code block 1`] = `
+"Line: @code {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 5 (code) with scopes text.aspnetcorerazor, keyword.control.razor.directive.code
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor
+ - token from 6 to 7 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.open
+"
+`;
+
+exports[`Grammar tests @code directive Multi line 1`] = `
+"Line: @code {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 5 (code) with scopes text.aspnetcorerazor, keyword.control.razor.directive.code
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor
+ - token from 6 to 7 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.open
+
+Line:     private int currentCount = 0;
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 12 to 15 (int) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.type.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 16 to 28 (currentCount) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 31 to 32 (0) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, constant.numeric.decimal.cs
+ - token from 32 to 33 (;) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.terminator.statement.cs
+
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+
+Line:     private void IncrementCount()
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 12 to 16 (void) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.type.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 17 to 31 (IncrementCount) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, entity.name.function.cs
+ - token from 31 to 32 (() with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.open.cs
+ - token from 32 to 33 ()) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.open.cs
+
+Line:         currentCount++;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 8 to 20 (currentCount) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, variable.other.readwrite.cs
+ - token from 20 to 22 (++) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.operator.increment.cs
+ - token from 22 to 23 (;) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.terminator.statement.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests @code directive No code block 1`] = `
+"Line: @code
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 5 (code) with scopes text.aspnetcorerazor, keyword.control.razor.directive.code
+"
+`;
+
+exports[`Grammar tests @code directive Single line 1`] = `
+"Line: @code { public void Foo() {} }
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 5 (code) with scopes text.aspnetcorerazor, keyword.control.razor.directive.code
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor
+ - token from 6 to 7 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.open
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 8 to 14 (public) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, storage.modifier.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 15 to 19 (void) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.type.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 20 to 23 (Foo) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, entity.name.function.cs
+ - token from 23 to 24 (() with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.open.cs
+ - token from 24 to 25 ()) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.close.cs
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 26 to 27 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.open.cs
+ - token from 27 to 28 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.close.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 29 to 30 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests @functions directive Incomplete code block 1`] = `
+"Line: @functions {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 10 (functions) with scopes text.aspnetcorerazor, keyword.control.razor.directive.functions
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor
+ - token from 11 to 12 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.open
+"
+`;
+
+exports[`Grammar tests @functions directive Multi line 1`] = `
+"Line: @functions {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 10 (functions) with scopes text.aspnetcorerazor, keyword.control.razor.directive.functions
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor
+ - token from 11 to 12 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.open
+
+Line:     private int currentCount = 0;
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 12 to 15 (int) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.type.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 16 to 28 (currentCount) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 31 to 32 (0) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, constant.numeric.decimal.cs
+ - token from 32 to 33 (;) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.terminator.statement.cs
+
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+
+Line:     private void IncrementCount()
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 12 to 16 (void) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.type.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 17 to 31 (IncrementCount) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, entity.name.function.cs
+ - token from 31 to 32 (() with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.open.cs
+ - token from 32 to 33 ()) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.open.cs
+
+Line:         currentCount++;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 8 to 20 (currentCount) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, variable.other.readwrite.cs
+ - token from 20 to 22 (++) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.operator.increment.cs
+ - token from 22 to 23 (;) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.terminator.statement.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests @functions directive No code block 1`] = `
+"Line: @functions
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 10 (functions) with scopes text.aspnetcorerazor, keyword.control.razor.directive.functions
+"
+`;
+
+exports[`Grammar tests @functions directive Single line 1`] = `
+"Line: @functions { public void Foo() {} }
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 10 (functions) with scopes text.aspnetcorerazor, keyword.control.razor.directive.functions
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor
+ - token from 11 to 12 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.open
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 13 to 19 (public) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, storage.modifier.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 20 to 24 (void) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.type.cs
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 25 to 28 (Foo) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, entity.name.function.cs
+ - token from 28 to 29 (() with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.open.cs
+ - token from 29 to 30 ()) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.parenthesis.close.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 31 to 32 ({) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.open.cs
+ - token from 32 to 33 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, punctuation.curlybrace.close.cs
+ - token from 33 to 34 ( ) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces
+ - token from 34 to 35 (}) with scopes text.aspnetcorerazor, razor.test.balanced.curlybraces, keyword.control.razor.directive.codeblock.close
+"
+`;
+
 exports[`Grammar tests Explicit transitions Empty 1`] = `
 "Line: @()
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml.transition


### PR DESCRIPTION
- Added tests for `@code` and `@functions`.
- Does not support nested HTML.

aspnet/AspNetCore#14287