### PR TITLE
Add grammar support for the model directive.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -454,6 +454,9 @@
         },
         {
           "include": "#model-directive"
+        },
+        {
+          "include": "#namespace-directive"
         }
       ]
     },
@@ -645,6 +648,40 @@
               "include": "source.cs#type"
             }
           ]
+        }
+      }
+    },
+    "namespace-directive": {
+      "name": "meta.directive.namespace.razor",
+      "match": "(@)(namespace)\\s+([^\\s]+)?",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.namespace"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#namespace-directive-argument"
+            }
+          ]
+        }
+      }
+    },
+    "namespace-directive-argument": {
+      "match": "([_[:alpha:]][_[:alnum:]]*)(\\.)?",
+      "captures": {
+        "1": {
+          "name": "entity.name.type.namespace.cs"
+        },
+        "2": {
+          "name": "punctuation.accessor.cs"
         }
       }
     },

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -451,6 +451,9 @@
         },
         {
           "include": "#tagHelperPrefix-directive"
+        },
+        {
+          "include": "#model-directive"
         }
       ]
     },
@@ -621,6 +624,29 @@
     "unquoted-string-argument": {
       "name": "string.quoted.double.cs",
       "match": "[^$]+"
+    },
+    "model-directive": {
+      "name": "meta.directive.model.cshtml",
+      "match": "(@)(model)\\s+([^$]+)?",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.model"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "source.cs#type"
+            }
+          ]
+        }
+      }
     },
     "await-prefix": {
       "name": "keyword.other.await.cs",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -457,6 +457,9 @@
         },
         {
           "include": "#namespace-directive"
+        },
+        {
+          "include": "#inject-directive"
         }
       ]
     },
@@ -682,6 +685,32 @@
         },
         "2": {
           "name": "punctuation.accessor.cs"
+        }
+      }
+    },
+    "inject-directive": {
+      "name": "meta.directive.inject.cshtml",
+      "match": "(@)(inject)\\s*([\\S\\s]+?)?\\s*([_[:alpha:]][_[:alnum:]]*)?\\s*(?=$)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.inject"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "source.cs#type"
+            }
+          ]
+        },
+        "4": {
+          "name": "entity.name.variable.property.cs"
         }
       }
     },

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -247,6 +247,7 @@ repository:
       - include: '#addTagHelper-directive'
       - include: '#removeTagHelper-directive'
       - include: '#tagHelperPrefix-directive'
+      - include: '#model-directive'
 
   #>>>>> @code and @functions <<<<<
 
@@ -323,6 +324,16 @@ repository:
   unquoted-string-argument:
     name: 'string.quoted.double.cs'
     match: '[^$]+'
+
+  #>>>>> @model <<<<<
+
+  model-directive:
+    name: meta.directive.model.cshtml
+    match: '(@)(model)\s+([^$]+)?'
+    captures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.razor.directive.model'}
+      3: { patterns: [ include: 'source.cs#type' ] }
 
   # ----------  Misc C# ------------
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -248,6 +248,7 @@ repository:
       - include: '#removeTagHelper-directive'
       - include: '#tagHelperPrefix-directive'
       - include: '#model-directive'
+      - include: '#namespace-directive'
 
   #>>>>> @code and @functions <<<<<
 
@@ -283,7 +284,7 @@ repository:
   #>>>>> @page <<<<<
 
   page-directive:
-    name: meta.directive.page.cshtml
+    name: 'meta.directive.page.cshtml'
     match: '(@)(page)\s+([^$]+)?'
     captures:
       1: { patterns: [ include: '#transition' ] }
@@ -293,7 +294,7 @@ repository:
   #>>>>> @addTagHelper, @removeTagHelper and @tagHelperPrefix <<<<<
 
   addTagHelper-directive:
-    name: meta.directive.addTagHelper.razor
+    name: 'meta.directive.addTagHelper.razor'
     match: '(@)(addTagHelper)\s+([^$]+)?'
     captures:
       1: { patterns: [ include: '#transition' ] }
@@ -301,7 +302,7 @@ repository:
       3: { patterns: [ include: '#tagHelper-directive-argument' ] }
 
   removeTagHelper-directive:
-    name: meta.directive.removeTagHelper.razor
+    name: 'meta.directive.removeTagHelper.razor'
     match: '(@)(removeTagHelper)\s+([^$]+)?'
     captures:
       1: { patterns: [ include: '#transition' ] }
@@ -309,7 +310,7 @@ repository:
       3: { patterns: [ include: '#tagHelper-directive-argument' ] }
 
   tagHelperPrefix-directive:
-    name: meta.directive.tagHelperPrefix.razor
+    name: 'meta.directive.tagHelperPrefix.razor'
     match: '(@)(tagHelperPrefix)\s+([^$]+)?'
     captures:
       1: { patterns: [ include: '#transition' ] }
@@ -328,12 +329,28 @@ repository:
   #>>>>> @model <<<<<
 
   model-directive:
-    name: meta.directive.model.cshtml
+    name: 'meta.directive.model.cshtml'
     match: '(@)(model)\s+([^$]+)?'
     captures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.control.razor.directive.model'}
       3: { patterns: [ include: 'source.cs#type' ] }
+
+  #>>>>> @namespace <<<<<
+
+  namespace-directive:
+    name: 'meta.directive.namespace.razor'
+    match: '(@)(namespace)\s+([^\s]+)?'
+    captures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.razor.directive.namespace'}
+      3: { patterns: [ include: '#namespace-directive-argument' ] }
+
+  namespace-directive-argument:
+    match: '([_[:alpha:]][_[:alnum:]]*)(\.)?'
+    captures:
+      1: { name: 'entity.name.type.namespace.cs' }
+      2: { name: 'punctuation.accessor.cs' }
 
   # ----------  Misc C# ------------
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -249,6 +249,7 @@ repository:
       - include: '#tagHelperPrefix-directive'
       - include: '#model-directive'
       - include: '#namespace-directive'
+      - include: '#inject-directive'
 
   #>>>>> @code and @functions <<<<<
 
@@ -351,6 +352,17 @@ repository:
     captures:
       1: { name: 'entity.name.type.namespace.cs' }
       2: { name: 'punctuation.accessor.cs' }
+
+  #>>>>> @inject <<<<<
+
+  inject-directive:
+    name: 'meta.directive.inject.cshtml'
+    match: '(@)(inject)\s*([\S\s]+?)?\s*([_[:alpha:]][_[:alnum:]]*)?\s*(?=$)'
+    captures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.razor.directive.inject'}
+      3: { patterns: [ include: 'source.cs#type' ] }
+      4: { name: 'entity.name.variable.property.cs' }
 
   # ----------  Misc C# ------------
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -10,6 +10,7 @@ import { RunExplicitExpressionSuite } from './ExplicitExpressions';
 import { RunFunctionsDirectiveSuite } from './FunctionsDirective';
 import { RunImplicitExpressionSuite } from './ImplicitExpressions';
 import { RunModelDirectiveSuite } from './ModelDirective';
+import { RunNamespaceDirectiveSuite } from './NamespaceDirective';
 import { RunPageDirectiveSuite } from './PageDirective';
 import { RunRemoveTagHelperDirectiveSuite } from './RemoveTagHelperDirective';
 import { RunTagHelperPrefixDirectiveSuite } from './TagHelperPrefixDirective';
@@ -34,4 +35,5 @@ describe('Grammar tests', () => {
     RunRemoveTagHelperDirectiveSuite();
     RunTagHelperPrefixDirectiveSuite();
     RunModelDirectiveSuite();
+    RunNamespaceDirectiveSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -9,6 +9,7 @@ import { RunCodeDirectiveSuite } from './CodeDirective';
 import { RunExplicitExpressionSuite } from './ExplicitExpressions';
 import { RunFunctionsDirectiveSuite } from './FunctionsDirective';
 import { RunImplicitExpressionSuite } from './ImplicitExpressions';
+import { RunInjectDirectiveSuite } from './InjectDirective';
 import { RunModelDirectiveSuite } from './ModelDirective';
 import { RunNamespaceDirectiveSuite } from './NamespaceDirective';
 import { RunPageDirectiveSuite } from './PageDirective';
@@ -36,4 +37,5 @@ describe('Grammar tests', () => {
     RunTagHelperPrefixDirectiveSuite();
     RunModelDirectiveSuite();
     RunNamespaceDirectiveSuite();
+    RunInjectDirectiveSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -9,6 +9,7 @@ import { RunCodeDirectiveSuite } from './CodeDirective';
 import { RunExplicitExpressionSuite } from './ExplicitExpressions';
 import { RunFunctionsDirectiveSuite } from './FunctionsDirective';
 import { RunImplicitExpressionSuite } from './ImplicitExpressions';
+import { RunModelDirectiveSuite } from './ModelDirective';
 import { RunPageDirectiveSuite } from './PageDirective';
 import { RunRemoveTagHelperDirectiveSuite } from './RemoveTagHelperDirective';
 import { RunTagHelperPrefixDirectiveSuite } from './TagHelperPrefixDirective';
@@ -32,4 +33,5 @@ describe('Grammar tests', () => {
     RunAddTagHelperDirectiveSuite();
     RunRemoveTagHelperDirectiveSuite();
     RunTagHelperPrefixDirectiveSuite();
+    RunModelDirectiveSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/InjectDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/InjectDirective.ts
@@ -1,0 +1,40 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunInjectDirectiveSuite() {
+    describe('@inject directive', () => {
+        it('No parameters', async () => {
+            await assertMatchesSnapshot('@inject');
+        });
+
+        it('No parameters spaced', async () => {
+            await assertMatchesSnapshot('@inject              ');
+        });
+
+        it('Incomplete type, generic', async () => {
+            await assertMatchesSnapshot('@inject List<string');
+        });
+
+        it('Incomplete type, tuple', async () => {
+            await assertMatchesSnapshot('@inject (string abc, bool def');
+        });
+
+        it('Invalid property', async () => {
+            await assertMatchesSnapshot('@inject DateTime !Something');
+        });
+
+        it('Fulfilled inject', async () => {
+            await assertMatchesSnapshot('@inject DateTime TheTime');
+        });
+
+        it('Fulfilled inject spaced', async () => {
+            await assertMatchesSnapshot('@inject      DateTime        TheTime         ');
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/ModelDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/ModelDirective.ts
@@ -1,0 +1,36 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunModelDirectiveSuite() {
+    describe('@model directive', () => {
+        it('No model', async () => {
+            await assertMatchesSnapshot('@model');
+        });
+
+        it('No model spaced', async () => {
+            await assertMatchesSnapshot('@model              ');
+        });
+
+        it('Incomplete model, generic', async () => {
+            await assertMatchesSnapshot('@model List<string');
+        });
+
+        it('Incomplete model, tuple', async () => {
+            await assertMatchesSnapshot('@model (string abc, bool def');
+        });
+
+        it('Model provided', async () => {
+            await assertMatchesSnapshot('@model Person');
+        });
+
+        it('Model provided spaced', async () => {
+            await assertMatchesSnapshot('@model              Person         ');
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/NamespaceDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/NamespaceDirective.ts
@@ -1,0 +1,36 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunNamespaceDirectiveSuite() {
+    describe('@namespace directive', () => {
+        it('No namespace', async () => {
+            await assertMatchesSnapshot('@namespace');
+        });
+
+        it('No namespace spaced', async () => {
+            await assertMatchesSnapshot('@namespace              ');
+        });
+
+        it('Incomplete namespace', async () => {
+            await assertMatchesSnapshot('@namespace MyApp.');
+        });
+
+        it('Broken up namespace', async () => {
+            await assertMatchesSnapshot('@namespace     MyApp  .  Models  .   Data    ');
+        });
+
+        it('Namespace provided', async () => {
+            await assertMatchesSnapshot('@namespace MyApp');
+        });
+
+        it('Namespace provided spaced', async () => {
+            await assertMatchesSnapshot('@namespace     MyApp.Models.Data    ');
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -236,6 +236,83 @@ exports[`Grammar tests @functions directive Single line 1`] = `
 "
 `;
 
+exports[`Grammar tests @inject directive Fulfilled inject 1`] = `
+"Line: @inject DateTime TheTime
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 7 (inject) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.control.razor.directive.inject
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml
+ - token from 8 to 16 (DateTime) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, storage.type.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml
+ - token from 17 to 24 (TheTime) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, entity.name.variable.property.cs
+"
+`;
+
+exports[`Grammar tests @inject directive Fulfilled inject spaced 1`] = `
+"Line: @inject      DateTime        TheTime         
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 7 (inject) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.control.razor.directive.inject
+ - token from 7 to 13 (      ) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml
+ - token from 13 to 21 (DateTime) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, storage.type.cs
+ - token from 21 to 29 (        ) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml
+ - token from 29 to 36 (TheTime) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, entity.name.variable.property.cs
+ - token from 36 to 46 (         ) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml
+"
+`;
+
+exports[`Grammar tests @inject directive Incomplete type, generic 1`] = `
+"Line: @inject List<string
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 7 (inject) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.control.razor.directive.inject
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml
+ - token from 8 to 12 (List) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, storage.type.cs
+ - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, punctuation.definition.typeparameters.begin.cs
+ - token from 13 to 19 (string) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, entity.name.variable.property.cs
+"
+`;
+
+exports[`Grammar tests @inject directive Incomplete type, tuple 1`] = `
+"Line: @inject (string abc, bool def
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 7 (inject) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.control.razor.directive.inject
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml
+ - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, punctuation.parenthesis.open.cs
+ - token from 9 to 15 (string) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.type.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml
+ - token from 16 to 19 (abc) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, entity.name.variable.tuple-element.cs
+ - token from 19 to 20 (,) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, punctuation.separator.comma.cs
+ - token from 20 to 21 ( ) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml
+ - token from 21 to 25 (bool) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.type.cs
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml
+ - token from 26 to 29 (def) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, entity.name.variable.property.cs
+"
+`;
+
+exports[`Grammar tests @inject directive Invalid property 1`] = `
+"Line: @inject DateTime !Something
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 7 (inject) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.control.razor.directive.inject
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml
+ - token from 8 to 16 (DateTime) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, storage.type.cs
+ - token from 16 to 18 ( !) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml
+ - token from 18 to 27 (Something) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, entity.name.variable.property.cs
+"
+`;
+
+exports[`Grammar tests @inject directive No parameters 1`] = `
+"Line: @inject
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 7 (inject) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.control.razor.directive.inject
+"
+`;
+
+exports[`Grammar tests @inject directive No parameters spaced 1`] = `
+"Line: @inject              
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 7 (inject) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.control.razor.directive.inject
+ - token from 7 to 22 (              ) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml
+"
+`;
+
 exports[`Grammar tests @model directive Incomplete model, generic 1`] = `
 "Line: @model List<string
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.control.cshtml.transition

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -298,6 +298,64 @@ exports[`Grammar tests @model directive No model spaced 1`] = `
 "
 `;
 
+exports[`Grammar tests @namespace directive Broken up namespace 1`] = `
+"Line: @namespace     MyApp  .  Models  .   Data    
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, keyword.control.cshtml.transition
+ - token from 1 to 10 (namespace) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, keyword.control.razor.directive.namespace
+ - token from 10 to 15 (     ) with scopes text.aspnetcorerazor, meta.directive.namespace.razor
+ - token from 15 to 20 (MyApp) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, entity.name.type.namespace.cs
+ - token from 20 to 46 (  .  Models  .   Data    ) with scopes text.aspnetcorerazor
+"
+`;
+
+exports[`Grammar tests @namespace directive Incomplete namespace 1`] = `
+"Line: @namespace MyApp.
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, keyword.control.cshtml.transition
+ - token from 1 to 10 (namespace) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, keyword.control.razor.directive.namespace
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.directive.namespace.razor
+ - token from 11 to 16 (MyApp) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, entity.name.type.namespace.cs
+ - token from 16 to 17 (.) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, punctuation.accessor.cs
+"
+`;
+
+exports[`Grammar tests @namespace directive Namespace provided 1`] = `
+"Line: @namespace MyApp
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, keyword.control.cshtml.transition
+ - token from 1 to 10 (namespace) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, keyword.control.razor.directive.namespace
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.directive.namespace.razor
+ - token from 11 to 16 (MyApp) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, entity.name.type.namespace.cs
+"
+`;
+
+exports[`Grammar tests @namespace directive Namespace provided spaced 1`] = `
+"Line: @namespace     MyApp.Models.Data    
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, keyword.control.cshtml.transition
+ - token from 1 to 10 (namespace) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, keyword.control.razor.directive.namespace
+ - token from 10 to 15 (     ) with scopes text.aspnetcorerazor, meta.directive.namespace.razor
+ - token from 15 to 20 (MyApp) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, entity.name.type.namespace.cs
+ - token from 20 to 21 (.) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, punctuation.accessor.cs
+ - token from 21 to 27 (Models) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, entity.name.type.namespace.cs
+ - token from 27 to 28 (.) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, punctuation.accessor.cs
+ - token from 28 to 32 (Data) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, entity.name.type.namespace.cs
+ - token from 32 to 37 (    ) with scopes text.aspnetcorerazor
+"
+`;
+
+exports[`Grammar tests @namespace directive No namespace 1`] = `
+"Line: @namespace
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, keyword.control.cshtml.transition
+ - token from 1 to 10 (namespace) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, keyword.control.razor.directive.namespace
+"
+`;
+
+exports[`Grammar tests @namespace directive No namespace spaced 1`] = `
+"Line: @namespace              
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, keyword.control.cshtml.transition
+ - token from 1 to 10 (namespace) with scopes text.aspnetcorerazor, meta.directive.namespace.razor, keyword.control.razor.directive.namespace
+ - token from 10 to 25 (              ) with scopes text.aspnetcorerazor, meta.directive.namespace.razor
+"
+`;
+
 exports[`Grammar tests @page directive Incomplete route 1`] = `
 "Line: @page \\"
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.page.cshtml, keyword.control.cshtml.transition

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -236,6 +236,68 @@ exports[`Grammar tests @functions directive Single line 1`] = `
 "
 `;
 
+exports[`Grammar tests @model directive Incomplete model, generic 1`] = `
+"Line: @model List<string
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (model) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.control.razor.directive.model
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.model.cshtml
+ - token from 7 to 11 (List) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, storage.type.cs
+ - token from 11 to 12 (<) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, punctuation.definition.typeparameters.begin.cs
+ - token from 12 to 18 (string) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.type.cs
+"
+`;
+
+exports[`Grammar tests @model directive Incomplete model, tuple 1`] = `
+"Line: @model (string abc, bool def
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (model) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.control.razor.directive.model
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.model.cshtml
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.directive.model.cshtml, punctuation.parenthesis.open.cs
+ - token from 8 to 14 (string) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.type.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.directive.model.cshtml
+ - token from 15 to 18 (abc) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, entity.name.variable.tuple-element.cs
+ - token from 18 to 19 (,) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, punctuation.separator.comma.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.directive.model.cshtml
+ - token from 20 to 24 (bool) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.type.cs
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.directive.model.cshtml
+ - token from 25 to 28 (def) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, entity.name.variable.tuple-element.cs
+"
+`;
+
+exports[`Grammar tests @model directive Model provided 1`] = `
+"Line: @model Person
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (model) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.control.razor.directive.model
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.model.cshtml
+ - token from 7 to 13 (Person) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, storage.type.cs
+"
+`;
+
+exports[`Grammar tests @model directive Model provided spaced 1`] = `
+"Line: @model              Person         
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (model) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.control.razor.directive.model
+ - token from 6 to 20 (              ) with scopes text.aspnetcorerazor, meta.directive.model.cshtml
+ - token from 20 to 26 (Person) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, storage.type.cs
+ - token from 26 to 36 (         ) with scopes text.aspnetcorerazor, meta.directive.model.cshtml
+"
+`;
+
+exports[`Grammar tests @model directive No model 1`] = `
+"Line: @model
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (model) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.control.razor.directive.model
+"
+`;
+
+exports[`Grammar tests @model directive No model spaced 1`] = `
+"Line: @model              
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (model) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.control.razor.directive.model
+ - token from 6 to 21 (              ) with scopes text.aspnetcorerazor, meta.directive.model.cshtml
+"
+`;
+
 exports[`Grammar tests @page directive Incomplete route 1`] = `
 "Line: @page \\"
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.page.cshtml, keyword.control.cshtml.transition


### PR DESCRIPTION
- Ensured the new model directive grammar applied scopes that were compatible with the pre-existing Razor grammar.
- Add tests to validate the various forms of `@model`.

aspnet/AspNetCore#14287
