### PR TITLE
Add grammar support for the inherits directive.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -456,6 +456,9 @@
           "include": "#model-directive"
         },
         {
+          "include": "#inherits-directive"
+        },
+        {
           "include": "#namespace-directive"
         },
         {
@@ -644,6 +647,29 @@
         },
         "2": {
           "name": "keyword.control.razor.directive.model"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "source.cs#type"
+            }
+          ]
+        }
+      }
+    },
+    "inherits-directive": {
+      "name": "meta.directive.inherits.cshtml",
+      "match": "(@)(inherits)\\s+([^$]+)?",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.inherits"
         },
         "3": {
           "patterns": [

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -466,6 +466,9 @@
         },
         {
           "include": "#inject-directive"
+        },
+        {
+          "include": "#attribute-directive"
         }
       ]
     },
@@ -765,6 +768,28 @@
           "name": "entity.name.variable.property.cs"
         }
       }
+    },
+    "attribute-directive": {
+      "name": "meta.directive.attribute.razor",
+      "begin": "(@)(attribute)\\b",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.attribute"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.cs#attribute-section"
+        }
+      ],
+      "end": "(?<=\\])|$"
     },
     "await-prefix": {
       "name": "keyword.other.await.cs",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -459,6 +459,9 @@
           "include": "#inherits-directive"
         },
         {
+          "include": "#implements-directive"
+        },
+        {
           "include": "#namespace-directive"
         },
         {
@@ -670,6 +673,29 @@
         },
         "2": {
           "name": "keyword.control.razor.directive.inherits"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "source.cs#type"
+            }
+          ]
+        }
+      }
+    },
+    "implements-directive": {
+      "name": "meta.directive.implements.razor",
+      "match": "(@)(implements)\\s+([^$]+)?",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.implements"
         },
         "3": {
           "patterns": [

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -252,6 +252,7 @@ repository:
       - include: '#implements-directive'
       - include: '#namespace-directive'
       - include: '#inject-directive'
+      - include: '#attribute-directive'
 
   #>>>>> @code and @functions <<<<<
 
@@ -381,6 +382,18 @@ repository:
       2: { name: 'keyword.control.razor.directive.inject'}
       3: { patterns: [ include: 'source.cs#type' ] }
       4: { name: 'entity.name.variable.property.cs' }
+
+  #>>>>> @attribute <<<<<
+
+  attribute-directive:
+    name: 'meta.directive.attribute.razor'
+    begin: '(@)(attribute)\b'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.razor.directive.attribute'}
+    patterns:
+      - include: 'source.cs#attribute-section'
+    end: '(?<=\])|$'
 
   # ----------  Misc C# ------------
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -249,6 +249,7 @@ repository:
       - include: '#tagHelperPrefix-directive'
       - include: '#model-directive'
       - include: '#inherits-directive'
+      - include: '#implements-directive'
       - include: '#namespace-directive'
       - include: '#inject-directive'
 
@@ -328,7 +329,7 @@ repository:
     name: 'string.quoted.double.cs'
     match: '[^$]+'
 
-  #>>>>> @model and @inherits <<<<<
+  #>>>>> @model, @implements and @inherits <<<<<
 
   model-directive:
     name: 'meta.directive.model.cshtml'
@@ -344,6 +345,14 @@ repository:
     captures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.control.razor.directive.inherits'}
+      3: { patterns: [ include: 'source.cs#type' ] }
+
+  implements-directive:
+    name: 'meta.directive.implements.razor'
+    match: '(@)(implements)\s+([^$]+)?'
+    captures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.razor.directive.implements'}
       3: { patterns: [ include: 'source.cs#type' ] }
 
   #>>>>> @namespace <<<<<

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -248,6 +248,7 @@ repository:
       - include: '#removeTagHelper-directive'
       - include: '#tagHelperPrefix-directive'
       - include: '#model-directive'
+      - include: '#inherits-directive'
       - include: '#namespace-directive'
       - include: '#inject-directive'
 
@@ -327,7 +328,7 @@ repository:
     name: 'string.quoted.double.cs'
     match: '[^$]+'
 
-  #>>>>> @model <<<<<
+  #>>>>> @model and @inherits <<<<<
 
   model-directive:
     name: 'meta.directive.model.cshtml'
@@ -335,6 +336,14 @@ repository:
     captures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.control.razor.directive.model'}
+      3: { patterns: [ include: 'source.cs#type' ] }
+
+  inherits-directive:
+    name: 'meta.directive.inherits.cshtml'
+    match: '(@)(inherits)\s+([^$]+)?'
+    captures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.razor.directive.inherits'}
       3: { patterns: [ include: 'source.cs#type' ] }
 
   #>>>>> @namespace <<<<<

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/AttributeDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/AttributeDirective.ts
@@ -1,0 +1,41 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunAttributeDirectiveSuite() {
+    describe('@attribute directive', () => {
+        it('No attribute', async () => {
+            await assertMatchesSnapshot('@attribute');
+        });
+
+        it('No attribute spaced', async () => {
+            await assertMatchesSnapshot('@attribute              ');
+        });
+
+        it('Incomplete attribute, simple', async () => {
+            await assertMatchesSnapshot('@attribute [CustomAttribute');
+        });
+
+        it('Incomplete attribute, generic', async () => {
+            await assertMatchesSnapshot('@attribute [CustomAttribute(info = typeof(GenericClass1<string');
+        });
+
+        it('Single line, simple', async () => {
+            await assertMatchesSnapshot('@attribute [Authorize]');
+        });
+
+        it('Multi line, complex', async () => {
+            await assertMatchesSnapshot(`@attribute [
+    CustomAttribute(
+        Info = typeof(GenericClass<string>),
+        Foo = true
+    )
+]`);
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -9,6 +9,7 @@ import { RunCodeDirectiveSuite } from './CodeDirective';
 import { RunExplicitExpressionSuite } from './ExplicitExpressions';
 import { RunFunctionsDirectiveSuite } from './FunctionsDirective';
 import { RunImplicitExpressionSuite } from './ImplicitExpressions';
+import { RunInheritsDirectiveSuite } from './InheritsDirective';
 import { RunInjectDirectiveSuite } from './InjectDirective';
 import { RunModelDirectiveSuite } from './ModelDirective';
 import { RunNamespaceDirectiveSuite } from './NamespaceDirective';
@@ -36,6 +37,7 @@ describe('Grammar tests', () => {
     RunRemoveTagHelperDirectiveSuite();
     RunTagHelperPrefixDirectiveSuite();
     RunModelDirectiveSuite();
+    RunInheritsDirectiveSuite();
     RunNamespaceDirectiveSuite();
     RunInjectDirectiveSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -4,6 +4,7 @@
 * ------------------------------------------------------------------------------------------ */
 
 import { RunAddTagHelperDirectiveSuite } from './AddTagHelperDirective';
+import { RunAttributeDirectiveSuite } from './AttributeDirective';
 import { RunCodeBlockSuite } from './CodeBlock';
 import { RunCodeDirectiveSuite } from './CodeDirective';
 import { RunExplicitExpressionSuite } from './ExplicitExpressions';
@@ -42,4 +43,5 @@ describe('Grammar tests', () => {
     RunInheritsDirectiveSuite();
     RunNamespaceDirectiveSuite();
     RunInjectDirectiveSuite();
+    RunAttributeDirectiveSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -8,6 +8,7 @@ import { RunCodeBlockSuite } from './CodeBlock';
 import { RunCodeDirectiveSuite } from './CodeDirective';
 import { RunExplicitExpressionSuite } from './ExplicitExpressions';
 import { RunFunctionsDirectiveSuite } from './FunctionsDirective';
+import { RunImplementsDirectiveSuite } from './ImplementsDirective';
 import { RunImplicitExpressionSuite } from './ImplicitExpressions';
 import { RunInheritsDirectiveSuite } from './InheritsDirective';
 import { RunInjectDirectiveSuite } from './InjectDirective';
@@ -37,6 +38,7 @@ describe('Grammar tests', () => {
     RunRemoveTagHelperDirectiveSuite();
     RunTagHelperPrefixDirectiveSuite();
     RunModelDirectiveSuite();
+    RunImplementsDirectiveSuite();
     RunInheritsDirectiveSuite();
     RunNamespaceDirectiveSuite();
     RunInjectDirectiveSuite();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/ImplementsDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/ImplementsDirective.ts
@@ -1,0 +1,32 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunImplementsDirectiveSuite() {
+    describe('@implements directive', () => {
+        it('No type', async () => {
+            await assertMatchesSnapshot('@implements');
+        });
+
+        it('No type spaced', async () => {
+            await assertMatchesSnapshot('@implements              ');
+        });
+
+        it('Incomplete type, generic', async () => {
+            await assertMatchesSnapshot('@implements SomeInterface<string');
+        });
+
+        it('Type provided', async () => {
+            await assertMatchesSnapshot('@implements Person');
+        });
+
+        it('Type provided spaced', async () => {
+            await assertMatchesSnapshot('@implements              Person         ');
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/InheritsDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/InheritsDirective.ts
@@ -1,0 +1,32 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunInheritsDirectiveSuite() {
+    describe('@inherits directive', () => {
+        it('No type', async () => {
+            await assertMatchesSnapshot('@inherits');
+        });
+
+        it('No type spaced', async () => {
+            await assertMatchesSnapshot('@inherits              ');
+        });
+
+        it('Incomplete type, generic', async () => {
+            await assertMatchesSnapshot('@inherits SomeViewBase<string');
+        });
+
+        it('Type provided', async () => {
+            await assertMatchesSnapshot('@inherits Person');
+        });
+
+        it('Type provided spaced', async () => {
+            await assertMatchesSnapshot('@inherits              Person         ');
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -56,6 +56,106 @@ exports[`Grammar tests @addTagHelper directive Unquoted parameter 1`] = `
 "
 `;
 
+exports[`Grammar tests @attribute directive Incomplete attribute, generic 1`] = `
+"Line: @attribute [CustomAttribute(info = typeof(GenericClass1<string
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.control.cshtml.transition
+ - token from 1 to 10 (attribute) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.control.razor.directive.attribute
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.directive.attribute.razor
+ - token from 11 to 12 ([) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.squarebracket.open.cs
+ - token from 12 to 27 (CustomAttribute) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, storage.type.cs
+ - token from 27 to 28 (() with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.parenthesis.open.cs
+ - token from 28 to 32 (info) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, entity.name.variable.property.cs
+ - token from 32 to 33 ( ) with scopes text.aspnetcorerazor, meta.directive.attribute.razor
+ - token from 33 to 34 (=) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.operator.assignment.cs
+ - token from 34 to 35 ( ) with scopes text.aspnetcorerazor, meta.directive.attribute.razor
+ - token from 35 to 41 (typeof) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.other.typeof.cs
+ - token from 41 to 42 (() with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.parenthesis.open.cs
+ - token from 42 to 55 (GenericClass1) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, storage.type.cs
+ - token from 55 to 56 (<) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.definition.typeparameters.begin.cs
+ - token from 56 to 62 (string) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.type.cs
+"
+`;
+
+exports[`Grammar tests @attribute directive Incomplete attribute, simple 1`] = `
+"Line: @attribute [CustomAttribute
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.control.cshtml.transition
+ - token from 1 to 10 (attribute) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.control.razor.directive.attribute
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.directive.attribute.razor
+ - token from 11 to 12 ([) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.squarebracket.open.cs
+ - token from 12 to 27 (CustomAttribute) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, storage.type.cs
+"
+`;
+
+exports[`Grammar tests @attribute directive Multi line, complex 1`] = `
+"Line: @attribute [
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.control.cshtml.transition
+ - token from 1 to 10 (attribute) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.control.razor.directive.attribute
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.directive.attribute.razor
+ - token from 11 to 12 ([) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.squarebracket.open.cs
+
+Line:     CustomAttribute(
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.directive.attribute.razor
+ - token from 4 to 19 (CustomAttribute) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, storage.type.cs
+ - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.parenthesis.open.cs
+
+Line:         Info = typeof(GenericClass<string>),
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.directive.attribute.razor
+ - token from 8 to 12 (Info) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, entity.name.variable.property.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.directive.attribute.razor
+ - token from 13 to 14 (=) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.operator.assignment.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.directive.attribute.razor
+ - token from 15 to 21 (typeof) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.other.typeof.cs
+ - token from 21 to 22 (() with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.parenthesis.open.cs
+ - token from 22 to 34 (GenericClass) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, storage.type.cs
+ - token from 34 to 35 (<) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.definition.typeparameters.begin.cs
+ - token from 35 to 41 (string) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.type.cs
+ - token from 41 to 42 (>) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.definition.typeparameters.end.cs
+ - token from 42 to 43 ()) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.parenthesis.close.cs
+ - token from 43 to 44 (,) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.separator.comma.cs
+
+Line:         Foo = true
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.directive.attribute.razor
+ - token from 8 to 11 (Foo) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, entity.name.variable.property.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.directive.attribute.razor
+ - token from 12 to 13 (=) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.operator.assignment.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.directive.attribute.razor
+ - token from 14 to 18 (true) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, constant.language.boolean.true.cs
+
+Line:     )
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.directive.attribute.razor
+ - token from 4 to 5 ()) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.parenthesis.close.cs
+
+Line: ]
+ - token from 0 to 1 (]) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.squarebracket.close.cs
+"
+`;
+
+exports[`Grammar tests @attribute directive No attribute 1`] = `
+"Line: @attribute
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.control.cshtml.transition
+ - token from 1 to 10 (attribute) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.control.razor.directive.attribute
+"
+`;
+
+exports[`Grammar tests @attribute directive No attribute spaced 1`] = `
+"Line: @attribute              
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.control.cshtml.transition
+ - token from 1 to 10 (attribute) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.control.razor.directive.attribute
+ - token from 10 to 24 (              ) with scopes text.aspnetcorerazor, meta.directive.attribute.razor
+"
+`;
+
+exports[`Grammar tests @attribute directive Single line, simple 1`] = `
+"Line: @attribute [Authorize]
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.control.cshtml.transition
+ - token from 1 to 10 (attribute) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, keyword.control.razor.directive.attribute
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.directive.attribute.razor
+ - token from 11 to 12 ([) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.squarebracket.open.cs
+ - token from 12 to 21 (Authorize) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, storage.type.cs
+ - token from 21 to 22 (]) with scopes text.aspnetcorerazor, meta.directive.attribute.razor, punctuation.squarebracket.close.cs
+"
+`;
+
 exports[`Grammar tests @code directive Incomplete code block 1`] = `
 "Line: @code {
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -236,6 +236,51 @@ exports[`Grammar tests @functions directive Single line 1`] = `
 "
 `;
 
+exports[`Grammar tests @implements directive Incomplete type, generic 1`] = `
+"Line: @implements SomeInterface<string
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.implements.razor, keyword.control.cshtml.transition
+ - token from 1 to 11 (implements) with scopes text.aspnetcorerazor, meta.directive.implements.razor, keyword.control.razor.directive.implements
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.directive.implements.razor
+ - token from 12 to 25 (SomeInterface) with scopes text.aspnetcorerazor, meta.directive.implements.razor, storage.type.cs
+ - token from 25 to 26 (<) with scopes text.aspnetcorerazor, meta.directive.implements.razor, punctuation.definition.typeparameters.begin.cs
+ - token from 26 to 32 (string) with scopes text.aspnetcorerazor, meta.directive.implements.razor, keyword.type.cs
+"
+`;
+
+exports[`Grammar tests @implements directive No type 1`] = `
+"Line: @implements
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.implements.razor, keyword.control.cshtml.transition
+ - token from 1 to 11 (implements) with scopes text.aspnetcorerazor, meta.directive.implements.razor, keyword.control.razor.directive.implements
+"
+`;
+
+exports[`Grammar tests @implements directive No type spaced 1`] = `
+"Line: @implements              
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.implements.razor, keyword.control.cshtml.transition
+ - token from 1 to 11 (implements) with scopes text.aspnetcorerazor, meta.directive.implements.razor, keyword.control.razor.directive.implements
+ - token from 11 to 26 (              ) with scopes text.aspnetcorerazor, meta.directive.implements.razor
+"
+`;
+
+exports[`Grammar tests @implements directive Type provided 1`] = `
+"Line: @implements Person
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.implements.razor, keyword.control.cshtml.transition
+ - token from 1 to 11 (implements) with scopes text.aspnetcorerazor, meta.directive.implements.razor, keyword.control.razor.directive.implements
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.directive.implements.razor
+ - token from 12 to 18 (Person) with scopes text.aspnetcorerazor, meta.directive.implements.razor, storage.type.cs
+"
+`;
+
+exports[`Grammar tests @implements directive Type provided spaced 1`] = `
+"Line: @implements              Person         
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.implements.razor, keyword.control.cshtml.transition
+ - token from 1 to 11 (implements) with scopes text.aspnetcorerazor, meta.directive.implements.razor, keyword.control.razor.directive.implements
+ - token from 11 to 25 (              ) with scopes text.aspnetcorerazor, meta.directive.implements.razor
+ - token from 25 to 31 (Person) with scopes text.aspnetcorerazor, meta.directive.implements.razor, storage.type.cs
+ - token from 31 to 41 (         ) with scopes text.aspnetcorerazor, meta.directive.implements.razor
+"
+`;
+
 exports[`Grammar tests @inherits directive Incomplete type, generic 1`] = `
 "Line: @inherits SomeViewBase<string
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, keyword.control.cshtml.transition

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -236,6 +236,51 @@ exports[`Grammar tests @functions directive Single line 1`] = `
 "
 `;
 
+exports[`Grammar tests @inherits directive Incomplete type, generic 1`] = `
+"Line: @inherits SomeViewBase<string
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 9 (inherits) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, keyword.control.razor.directive.inherits
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml
+ - token from 10 to 22 (SomeViewBase) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, storage.type.cs
+ - token from 22 to 23 (<) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, punctuation.definition.typeparameters.begin.cs
+ - token from 23 to 29 (string) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, keyword.type.cs
+"
+`;
+
+exports[`Grammar tests @inherits directive No type 1`] = `
+"Line: @inherits
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 9 (inherits) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, keyword.control.razor.directive.inherits
+"
+`;
+
+exports[`Grammar tests @inherits directive No type spaced 1`] = `
+"Line: @inherits              
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 9 (inherits) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, keyword.control.razor.directive.inherits
+ - token from 9 to 24 (              ) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml
+"
+`;
+
+exports[`Grammar tests @inherits directive Type provided 1`] = `
+"Line: @inherits Person
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 9 (inherits) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, keyword.control.razor.directive.inherits
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml
+ - token from 10 to 16 (Person) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, storage.type.cs
+"
+`;
+
+exports[`Grammar tests @inherits directive Type provided spaced 1`] = `
+"Line: @inherits              Person         
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 9 (inherits) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, keyword.control.razor.directive.inherits
+ - token from 9 to 23 (              ) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml
+ - token from 23 to 29 (Person) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml, storage.type.cs
+ - token from 29 to 39 (         ) with scopes text.aspnetcorerazor, meta.directive.inherits.cshtml
+"
+`;
+
 exports[`Grammar tests @inject directive Fulfilled inject 1`] = `
 "Line: @inject DateTime TheTime
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.inject.cshtml, keyword.control.cshtml.transition


### PR DESCRIPTION
- Ensured the new inherits directive grammar applied scopes that were compatible with the pre-existing Razor grammar.
- Add tests to validate the various forms of `@inherits`.

aspnet/AspNetCore#14287
