### PR TITLE
Add grammar support for the section directive.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -286,7 +286,7 @@
           "include": "#implicit-expression-body"
         }
       ],
-      "end": "(?=[\\s<>])"
+      "end": "(?=[\\s<>\\{\\}\\)\\]])"
     },
     "implicit-expression-body": {
       "patterns": [
@@ -297,7 +297,7 @@
           "include": "#implicit-expression-accessor-start"
         }
       ],
-      "end": "(?=[\\s<>])"
+      "end": "(?=[\\s<>\\{\\}\\)\\]])"
     },
     "implicit-expression-invocation-start": {
       "begin": "([_[:alpha:]][_[:alnum:]]*)(?=\\()",
@@ -311,7 +311,7 @@
           "include": "#implicit-expression-continuation"
         }
       ],
-      "end": "(?=[\\s<>])"
+      "end": "(?=[\\s<>\\{\\}\\)\\]])"
     },
     "implicit-expression-accessor-start": {
       "begin": "([_[:alpha:]][_[:alnum:]]*)",
@@ -325,7 +325,7 @@
           "include": "#implicit-expression-continuation"
         }
       ],
-      "end": "(?=[\\s<>])"
+      "end": "(?=[\\s<>\\{\\}\\)\\]])"
     },
     "implicit-expression-continuation": {
       "patterns": [
@@ -345,7 +345,7 @@
           "include": "#implicit-expression-extension"
         }
       ],
-      "end": "(?=[\\s<>])"
+      "end": "(?=[\\s<>\\{\\}\\)\\]])"
     },
     "implicit-expression-accessor": {
       "match": "(?<=\\.)[_[:alpha:]][_[:alnum:]]*",
@@ -469,6 +469,9 @@
         },
         {
           "include": "#attribute-directive"
+        },
+        {
+          "include": "#section-directive"
         }
       ]
     },
@@ -790,6 +793,51 @@
         }
       ],
       "end": "(?<=\\])|$"
+    },
+    "section-directive": {
+      "name": "meta.directive.section.razor",
+      "begin": "(@)(section)\\b\\s*([_[:alpha:]][_[:alnum:]]*)?",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.section"
+        },
+        "3": {
+          "name": "variable.other.razor.directive.sectionName"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#directive-markupblock"
+        }
+      ],
+      "end": "(?<=})"
+    },
+    "directive-markupblock": {
+      "name": "meta.structure.razor.directive.markblock",
+      "begin": "(\\{)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.razor.directive.codeblock.open"
+        }
+      },
+      "patterns": [
+        {
+          "include": "$self"
+        }
+      ],
+      "end": "(\\})",
+      "endCaptures": {
+        "1": {
+          "name": "keyword.control.razor.directive.codeblock.close"
+        }
+      }
     },
     "await-prefix": {
       "name": "keyword.other.await.cs",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -475,6 +475,9 @@
         },
         {
           "include": "#layout-directive"
+        },
+        {
+          "include": "#using-directive"
         }
       ]
     },
@@ -862,6 +865,79 @@
       "endCaptures": {
         "1": {
           "name": "keyword.control.razor.directive.codeblock.close"
+        }
+      }
+    },
+    "using-directive": {
+      "name": "meta.directive.using.cshtml",
+      "match": "(@)(using)\\b\\s*(?!\\()(.+?)?(;)?$",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.other.using.cs"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#using-static-directive"
+            },
+            {
+              "include": "#using-alias-directive"
+            },
+            {
+              "include": "#using-standard-directive"
+            }
+          ]
+        },
+        "4": {
+          "name": "keyword.control.razor.optionalSemicolon"
+        }
+      }
+    },
+    "using-static-directive": {
+      "match": "(static)\\b\\s+(.+)",
+      "captures": {
+        "1": {
+          "name": "keyword.other.static.cs"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "source.cs#type"
+            }
+          ]
+        }
+      }
+    },
+    "using-alias-directive": {
+      "match": "([_[:alpha:]][_[:alnum:]]*)\\b\\s*(=)\\s*(.+)\\s*",
+      "captures": {
+        "1": {
+          "name": "entity.name.type.alias.cs"
+        },
+        "2": {
+          "name": "keyword.operator.assignment.cs"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "source.cs#type"
+            }
+          ]
+        }
+      }
+    },
+    "using-standard-directive": {
+      "match": "([_[:alpha:]][_[:alnum:]]*)\\s*",
+      "captures": {
+        "1": {
+          "name": "entity.name.type.namespace.cs"
         }
       }
     },

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -472,6 +472,9 @@
         },
         {
           "include": "#section-directive"
+        },
+        {
+          "include": "#layout-directive"
         }
       ]
     },
@@ -702,6 +705,29 @@
         },
         "2": {
           "name": "keyword.control.razor.directive.implements"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "source.cs#type"
+            }
+          ]
+        }
+      }
+    },
+    "layout-directive": {
+      "name": "meta.directive.layout.razor",
+      "match": "(@)(layout)\\s+([^$]+)?",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.layout"
         },
         "3": {
           "patterns": [

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -254,6 +254,7 @@ repository:
       - include: '#inject-directive'
       - include: '#attribute-directive'
       - include: '#section-directive'
+      - include: '#layout-directive'
 
   #>>>>> @code and @functions <<<<<
 
@@ -331,7 +332,7 @@ repository:
     name: 'string.quoted.double.cs'
     match: '[^$]+'
 
-  #>>>>> @model, @implements and @inherits <<<<<
+  #>>>>> @model, layout, @implements and @inherits <<<<<
 
   model-directive:
     name: 'meta.directive.model.cshtml'
@@ -355,6 +356,14 @@ repository:
     captures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.control.razor.directive.implements'}
+      3: { patterns: [ include: 'source.cs#type' ] }
+
+  layout-directive:
+    name: 'meta.directive.layout.razor'
+    match: '(@)(layout)\s+([^$]+)?'
+    captures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.razor.directive.layout'}
       3: { patterns: [ include: 'source.cs#type' ] }
 
   #>>>>> @namespace <<<<<

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -149,13 +149,13 @@ repository:
     patterns:
       - include: '#await-prefix'
       - include: '#implicit-expression-body'
-    end: '(?=[\s<>])'
+    end: '(?=[\s<>\{\}\)\]])'
 
   implicit-expression-body:
     patterns:
       - include: '#implicit-expression-invocation-start'
       - include: '#implicit-expression-accessor-start'
-    end: '(?=[\s<>])'
+    end: '(?=[\s<>\{\}\)\]])'
 
   # CSharp colors method invocations differently than accessors
   # This captures situations where you do @SomeMethod()
@@ -165,7 +165,7 @@ repository:
       1: { name: 'entity.name.function.cs' }
     patterns:
       - include: '#implicit-expression-continuation'
-    end: '(?=[\s<>])'
+    end: '(?=[\s<>\{\}\)\]])'
 
   # CSharp colors property accessors differently than methods
   # This captures situations where you do @SomeProperty
@@ -175,7 +175,7 @@ repository:
       1: { name: 'variable.other.object.cs' }
     patterns:
       - include: '#implicit-expression-continuation'
-    end: '(?=[\s<>])'
+    end: '(?=[\s<>\{\}\)\]])'
 
   implicit-expression-continuation:
     patterns:
@@ -184,7 +184,7 @@ repository:
       - include: '#implicit-expression-invocation'
       - include: '#implicit-expression-accessor'
       - include: '#implicit-expression-extension'
-    end: '(?=[\s<>])'
+    end: '(?=[\s<>\{\}\)\]])'
 
   implicit-expression-accessor:
     match: '(?<=\.)[_[:alpha:]][_[:alnum:]]*'
@@ -253,6 +253,7 @@ repository:
       - include: '#namespace-directive'
       - include: '#inject-directive'
       - include: '#attribute-directive'
+      - include: '#section-directive'
 
   #>>>>> @code and @functions <<<<<
 
@@ -394,6 +395,30 @@ repository:
     patterns:
       - include: 'source.cs#attribute-section'
     end: '(?<=\])|$'
+
+  #>>>>> @section <<<<<
+
+  section-directive:
+    name: 'meta.directive.section.razor'
+    begin: '(@)(section)\b\s*([_[:alpha:]][_[:alnum:]]*)?'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.razor.directive.section'}
+      3: { name: 'variable.other.razor.directive.sectionName' }
+    patterns:
+      - include: '#directive-markupblock'
+    end: '(?<=})'
+
+  directive-markupblock:
+    name: 'meta.structure.razor.directive.markblock'
+    begin: '(\{)'
+    beginCaptures:
+      1: { name: 'keyword.control.razor.directive.codeblock.open' }
+    patterns:
+      - include: '$self'
+    end: '(\})'
+    endCaptures:
+      1: { name: 'keyword.control.razor.directive.codeblock.close' }
 
   # ----------  Misc C# ------------
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -255,6 +255,7 @@ repository:
       - include: '#attribute-directive'
       - include: '#section-directive'
       - include: '#layout-directive'
+      - include: '#using-directive'
 
   #>>>>> @code and @functions <<<<<
 
@@ -428,6 +429,39 @@ repository:
     end: '(\})'
     endCaptures:
       1: { name: 'keyword.control.razor.directive.codeblock.close' }
+
+  #>>>>> @using <<<<<
+
+  using-directive:
+    name: 'meta.directive.using.cshtml'
+    match: '(@)(using)\b\s*(?!\()(.+?)?(;)?$'
+    captures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.other.using.cs'}
+      3:
+        patterns:
+          - include: '#using-static-directive'
+          - include: '#using-alias-directive'
+          - include: '#using-standard-directive'
+      4: { name: 'keyword.control.razor.optionalSemicolon'}
+
+  using-static-directive:
+    match: '(static)\b\s+(.+)'
+    captures:
+      1: { name: 'keyword.other.static.cs' }
+      2: { patterns: [ include: 'source.cs#type' ] }
+
+  using-alias-directive:
+    match: '([_[:alpha:]][_[:alnum:]]*)\b\s*(=)\s*(.+)\s*'
+    captures:
+      1: { name: 'entity.name.type.alias.cs' }
+      2: { name: 'keyword.operator.assignment.cs' }
+      3: { patterns: [ include: 'source.cs#type' ] }
+
+  using-standard-directive:
+    match: '([_[:alpha:]][_[:alnum:]]*)\s*'
+    captures:
+      1: { name: 'entity.name.type.namespace.cs' }
 
   # ----------  Misc C# ------------
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -13,6 +13,7 @@ import { RunImplementsDirectiveSuite } from './ImplementsDirective';
 import { RunImplicitExpressionSuite } from './ImplicitExpressions';
 import { RunInheritsDirectiveSuite } from './InheritsDirective';
 import { RunInjectDirectiveSuite } from './InjectDirective';
+import { RunLayoutDirectiveSuite } from './LayoutDirective';
 import { RunModelDirectiveSuite } from './ModelDirective';
 import { RunNamespaceDirectiveSuite } from './NamespaceDirective';
 import { RunPageDirectiveSuite } from './PageDirective';
@@ -46,4 +47,5 @@ describe('Grammar tests', () => {
     RunInjectDirectiveSuite();
     RunAttributeDirectiveSuite();
     RunSectionDirectiveSuite();
+    RunLayoutDirectiveSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -17,6 +17,7 @@ import { RunModelDirectiveSuite } from './ModelDirective';
 import { RunNamespaceDirectiveSuite } from './NamespaceDirective';
 import { RunPageDirectiveSuite } from './PageDirective';
 import { RunRemoveTagHelperDirectiveSuite } from './RemoveTagHelperDirective';
+import { RunSectionDirectiveSuite } from './SectionDirective';
 import { RunTagHelperPrefixDirectiveSuite } from './TagHelperPrefixDirective';
 import { RunTransitionsSuite } from './Transitions';
 
@@ -44,4 +45,5 @@ describe('Grammar tests', () => {
     RunNamespaceDirectiveSuite();
     RunInjectDirectiveSuite();
     RunAttributeDirectiveSuite();
+    RunSectionDirectiveSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -21,6 +21,7 @@ import { RunRemoveTagHelperDirectiveSuite } from './RemoveTagHelperDirective';
 import { RunSectionDirectiveSuite } from './SectionDirective';
 import { RunTagHelperPrefixDirectiveSuite } from './TagHelperPrefixDirective';
 import { RunTransitionsSuite } from './Transitions';
+import { RunUsingDirectiveSuite } from './UsingDirective';
 
 // We bring together all test suites and wrap them in one here. The reason behind this is that
 // modules get reloaded per test suite and the vscode-textmate library doesn't support the way
@@ -48,4 +49,5 @@ describe('Grammar tests', () => {
     RunAttributeDirectiveSuite();
     RunSectionDirectiveSuite();
     RunLayoutDirectiveSuite();
+    RunUsingDirectiveSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/ImplicitExpressions.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/ImplicitExpressions.ts
@@ -13,6 +13,22 @@ export function RunImplicitExpressionSuite() {
             await assertMatchesSnapshot('@');
         });
 
+        it('Open curly suffix', async () => {
+            await assertMatchesSnapshot('@DateTime.Now{');
+        });
+
+        it('Close curly suffix', async () => {
+            await assertMatchesSnapshot('@DateTime.Now}');
+        });
+
+        it('Close parenthesis suffix', async () => {
+            await assertMatchesSnapshot('@DateTime.Now)');
+        });
+
+        it('Close parenthesis suffix', async () => {
+            await assertMatchesSnapshot('@DateTime.Now]');
+        });
+
         it('Single line simple', async () => {
             await assertMatchesSnapshot('@DateTime.Now');
         });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/LayoutDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/LayoutDirective.ts
@@ -1,0 +1,32 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunLayoutDirectiveSuite() {
+    describe('@layout directive', () => {
+        it('No type', async () => {
+            await assertMatchesSnapshot('@layout');
+        });
+
+        it('No type spaced', async () => {
+            await assertMatchesSnapshot('@layout              ');
+        });
+
+        it('Incomplete type, generic', async () => {
+            await assertMatchesSnapshot('@layout MainLayout<string');
+        });
+
+        it('Type provided', async () => {
+            await assertMatchesSnapshot('@layout MainLayout');
+        });
+
+        it('Type provided spaced', async () => {
+            await assertMatchesSnapshot('@layout              MainLayout         ');
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/SectionDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/SectionDirective.ts
@@ -1,0 +1,48 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunSectionDirectiveSuite() {
+    describe('@section directive', () => {
+        it('No name', async () => {
+            await assertMatchesSnapshot('@section');
+        });
+
+        it('No name, spaced', async () => {
+            await assertMatchesSnapshot('@section                 ');
+        });
+
+        it('Invalid name', async () => {
+            await assertMatchesSnapshot('@section -$*&^');
+        });
+
+        it('Single line incomplete body', async () => {
+            await assertMatchesSnapshot('@section Name {');
+        });
+
+        it('Multi line incomplete body', async () => {
+            await assertMatchesSnapshot(`@section
+Name
+{`);
+        });
+
+        it('Single line', async () => {
+            await assertMatchesSnapshot('@section Name {@DateTime.Now}');
+        });
+
+        it('Multi line complex', async () => {
+            await assertMatchesSnapshot(
+`@section Name {
+    <section>
+        @DateTime.Now
+        @section INVALID {}
+    </section>
+}`);
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/UsingDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/UsingDirective.ts
@@ -1,0 +1,76 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunUsingDirectiveSuite() {
+    describe('@using directive', () => {
+        it('Standard using, no namespace', async () => {
+            await assertMatchesSnapshot('@using');
+        });
+
+        it('Standard using, no namespace spaced', async () => {
+            await assertMatchesSnapshot('@using              ');
+        });
+
+        it('Standard using', async () => {
+            await assertMatchesSnapshot('@using System.IO');
+        });
+
+        it('Standard using spaced', async () => {
+            await assertMatchesSnapshot('@using              System.IO         ');
+        });
+
+        it('Standard using, optional semicolon', async () => {
+            await assertMatchesSnapshot('@using System.IO;');
+        });
+
+        it('Static using, no namespace', async () => {
+            await assertMatchesSnapshot('@using static');
+        });
+
+        it('Static using, no namespace spaced', async () => {
+            await assertMatchesSnapshot('@using        static      ');
+        });
+
+        it('Static using', async () => {
+            await assertMatchesSnapshot('@using static System.Math');
+        });
+
+        it('Static using spaced', async () => {
+            await assertMatchesSnapshot('@using    static          System.Math         ');
+        });
+
+        it('Static using, optional semicolon', async () => {
+            await assertMatchesSnapshot('@using static System.Math;');
+        });
+
+        it('Using alias, no type', async () => {
+            await assertMatchesSnapshot('@using Something =');
+        });
+
+        it('Using alias, no type spaced', async () => {
+            await assertMatchesSnapshot('@using        Something   =    ');
+        });
+
+        it('Using alias, incomplete type, generic', async () => {
+            await assertMatchesSnapshot('@using TheTime = System.Collections.Generic.List<string');
+        });
+
+        it('Using alias', async () => {
+            await assertMatchesSnapshot('@using TheConsole = System.Console');
+        });
+
+        it('Using alias spaced', async () => {
+            await assertMatchesSnapshot('@using     TheConsole     =    System.Console   ');
+        });
+
+        it('Using alias, optional semicolon', async () => {
+            await assertMatchesSnapshot('@using TheConsole = System.Console;');
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -503,6 +503,51 @@ exports[`Grammar tests @inject directive No parameters spaced 1`] = `
 "
 `;
 
+exports[`Grammar tests @layout directive Incomplete type, generic 1`] = `
+"Line: @layout MainLayout<string
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.layout.razor, keyword.control.cshtml.transition
+ - token from 1 to 7 (layout) with scopes text.aspnetcorerazor, meta.directive.layout.razor, keyword.control.razor.directive.layout
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.directive.layout.razor
+ - token from 8 to 18 (MainLayout) with scopes text.aspnetcorerazor, meta.directive.layout.razor, storage.type.cs
+ - token from 18 to 19 (<) with scopes text.aspnetcorerazor, meta.directive.layout.razor, punctuation.definition.typeparameters.begin.cs
+ - token from 19 to 25 (string) with scopes text.aspnetcorerazor, meta.directive.layout.razor, keyword.type.cs
+"
+`;
+
+exports[`Grammar tests @layout directive No type 1`] = `
+"Line: @layout
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.layout.razor, keyword.control.cshtml.transition
+ - token from 1 to 7 (layout) with scopes text.aspnetcorerazor, meta.directive.layout.razor, keyword.control.razor.directive.layout
+"
+`;
+
+exports[`Grammar tests @layout directive No type spaced 1`] = `
+"Line: @layout              
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.layout.razor, keyword.control.cshtml.transition
+ - token from 1 to 7 (layout) with scopes text.aspnetcorerazor, meta.directive.layout.razor, keyword.control.razor.directive.layout
+ - token from 7 to 22 (              ) with scopes text.aspnetcorerazor, meta.directive.layout.razor
+"
+`;
+
+exports[`Grammar tests @layout directive Type provided 1`] = `
+"Line: @layout MainLayout
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.layout.razor, keyword.control.cshtml.transition
+ - token from 1 to 7 (layout) with scopes text.aspnetcorerazor, meta.directive.layout.razor, keyword.control.razor.directive.layout
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.directive.layout.razor
+ - token from 8 to 18 (MainLayout) with scopes text.aspnetcorerazor, meta.directive.layout.razor, storage.type.cs
+"
+`;
+
+exports[`Grammar tests @layout directive Type provided spaced 1`] = `
+"Line: @layout              MainLayout         
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.layout.razor, keyword.control.cshtml.transition
+ - token from 1 to 7 (layout) with scopes text.aspnetcorerazor, meta.directive.layout.razor, keyword.control.razor.directive.layout
+ - token from 7 to 21 (              ) with scopes text.aspnetcorerazor, meta.directive.layout.razor
+ - token from 21 to 31 (MainLayout) with scopes text.aspnetcorerazor, meta.directive.layout.razor, storage.type.cs
+ - token from 31 to 41 (         ) with scopes text.aspnetcorerazor, meta.directive.layout.razor
+"
+`;
+
 exports[`Grammar tests @model directive Incomplete model, generic 1`] = `
 "Line: @model List<string
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.model.cshtml, keyword.control.cshtml.transition

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -934,6 +934,209 @@ exports[`Grammar tests @tagHelperPrefix directive Unquoted parameter 1`] = `
 "
 `;
 
+exports[`Grammar tests @using directive Standard using 1`] = `
+"Line: @using System.IO
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 13 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+ - token from 13 to 14 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 14 to 16 (IO) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+"
+`;
+
+exports[`Grammar tests @using directive Standard using spaced 1`] = `
+"Line: @using              System.IO         
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 20 (              ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 20 to 26 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+ - token from 26 to 27 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 27 to 29 (IO) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+ - token from 29 to 38 (         ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+"
+`;
+
+exports[`Grammar tests @using directive Standard using, no namespace 1`] = `
+"Line: @using
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+"
+`;
+
+exports[`Grammar tests @using directive Standard using, no namespace spaced 1`] = `
+"Line: @using              
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 21 (              ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+"
+`;
+
+exports[`Grammar tests @using directive Standard using, optional semicolon 1`] = `
+"Line: @using System.IO;
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 13 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+ - token from 13 to 14 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 14 to 16 (IO) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+ - token from 16 to 17 (;) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.razor.optionalSemicolon
+"
+`;
+
+exports[`Grammar tests @using directive Static using 1`] = `
+"Line: @using static System.Math
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 13 (static) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.static.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 14 to 20 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 20 to 21 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 21 to 25 (Math) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+"
+`;
+
+exports[`Grammar tests @using directive Static using spaced 1`] = `
+"Line: @using    static          System.Math         
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 10 (    ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 10 to 16 (static) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.static.cs
+ - token from 16 to 26 (          ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 26 to 32 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 32 to 33 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 33 to 37 (Math) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 37 to 46 (         ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+"
+`;
+
+exports[`Grammar tests @using directive Static using, no namespace 1`] = `
+"Line: @using static
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 13 (static) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+"
+`;
+
+exports[`Grammar tests @using directive Static using, no namespace spaced 1`] = `
+"Line: @using        static      
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 14 (        ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 14 to 20 (static) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.static.cs
+ - token from 20 to 25 (     ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+"
+`;
+
+exports[`Grammar tests @using directive Static using, optional semicolon 1`] = `
+"Line: @using static System.Math;
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 13 (static) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.static.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 14 to 20 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 20 to 21 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 21 to 25 (Math) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 25 to 26 (;) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.razor.optionalSemicolon
+"
+`;
+
+exports[`Grammar tests @using directive Using alias 1`] = `
+"Line: @using TheConsole = System.Console
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 17 (TheConsole) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.alias.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 18 to 19 (=) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.operator.assignment.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 20 to 26 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 26 to 27 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 27 to 34 (Console) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+"
+`;
+
+exports[`Grammar tests @using directive Using alias spaced 1`] = `
+"Line: @using     TheConsole     =    System.Console   
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 11 (     ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 11 to 21 (TheConsole) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.alias.cs
+ - token from 21 to 26 (     ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 26 to 27 (=) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.operator.assignment.cs
+ - token from 27 to 31 (    ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 31 to 37 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 37 to 38 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 38 to 45 (Console) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 45 to 48 (   ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+"
+`;
+
+exports[`Grammar tests @using directive Using alias, incomplete type, generic 1`] = `
+"Line: @using TheTime = System.Collections.Generic.List<string
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 14 (TheTime) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.alias.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 15 to 16 (=) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.operator.assignment.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 17 to 23 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 23 to 24 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 24 to 35 (Collections) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 35 to 36 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 36 to 43 (Generic) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 43 to 44 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 44 to 48 (List) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 48 to 49 (<) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.definition.typeparameters.begin.cs
+ - token from 49 to 55 (string) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.type.cs
+"
+`;
+
+exports[`Grammar tests @using directive Using alias, no type 1`] = `
+"Line: @using Something =
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 16 (Something) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 17 to 18 (=) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+"
+`;
+
+exports[`Grammar tests @using directive Using alias, no type spaced 1`] = `
+"Line: @using        Something   =    
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 14 (        ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 14 to 23 (Something) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.alias.cs
+ - token from 23 to 26 (   ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 26 to 27 (=) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.operator.assignment.cs
+ - token from 27 to 30 (   ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+"
+`;
+
+exports[`Grammar tests @using directive Using alias, optional semicolon 1`] = `
+"Line: @using TheConsole = System.Console;
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 17 (TheConsole) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.alias.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 18 to 19 (=) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.operator.assignment.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 20 to 26 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 26 to 27 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 27 to 34 (Console) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 34 to 35 (;) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.razor.optionalSemicolon
+"
+`;
+
 exports[`Grammar tests Explicit expressions Empty 1`] = `
 "Line: @()
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml.transition

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -726,6 +726,113 @@ exports[`Grammar tests @removeTagHelper directive Unquoted parameter 1`] = `
 "
 `;
 
+exports[`Grammar tests @section directive Invalid name 1`] = `
+"Line: @section -$*&^
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.section.razor, keyword.control.cshtml.transition
+ - token from 1 to 8 (section) with scopes text.aspnetcorerazor, meta.directive.section.razor, keyword.control.razor.directive.section
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.directive.section.razor
+ - token from 9 to 15 (-$*&^) with scopes text.aspnetcorerazor, meta.directive.section.razor
+"
+`;
+
+exports[`Grammar tests @section directive Multi line complex 1`] = `
+"Line: @section Name {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.section.razor, keyword.control.cshtml.transition
+ - token from 1 to 8 (section) with scopes text.aspnetcorerazor, meta.directive.section.razor, keyword.control.razor.directive.section
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.directive.section.razor
+ - token from 9 to 13 (Name) with scopes text.aspnetcorerazor, meta.directive.section.razor, variable.other.razor.directive.sectionName
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.directive.section.razor
+ - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, keyword.control.razor.directive.codeblock.open
+
+Line:     <section>
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock
+ - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.tag.structure.section.start.html, punctuation.definition.tag.begin.html
+ - token from 5 to 12 (section) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.tag.structure.section.start.html, entity.name.tag.html
+ - token from 12 to 13 (>) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.tag.structure.section.start.html, punctuation.definition.tag.end.html
+
+Line:         @DateTime.Now
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (DateTime) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 17 to 18 (.) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml
+ - token from 18 to 21 (Now) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
+
+Line:         @section INVALID {}
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.directive.section.razor, keyword.control.cshtml.transition
+ - token from 9 to 16 (section) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.directive.section.razor, keyword.control.razor.directive.section
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.directive.section.razor
+ - token from 17 to 24 (INVALID) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.directive.section.razor, variable.other.razor.directive.sectionName
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.directive.section.razor
+ - token from 25 to 26 ({) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.directive.section.razor, meta.structure.razor.directive.markblock, keyword.control.razor.directive.codeblock.open
+ - token from 26 to 27 (}) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.directive.section.razor, meta.structure.razor.directive.markblock, keyword.control.razor.directive.codeblock.close
+
+Line:     </section>
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock
+ - token from 4 to 6 (</) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.tag.structure.section.end.html, punctuation.definition.tag.begin.html
+ - token from 6 to 13 (section) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.tag.structure.section.end.html, entity.name.tag.html
+ - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.tag.structure.section.end.html, punctuation.definition.tag.end.html
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests @section directive Multi line incomplete body 1`] = `
+"Line: @section
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.section.razor, keyword.control.cshtml.transition
+ - token from 1 to 8 (section) with scopes text.aspnetcorerazor, meta.directive.section.razor, keyword.control.razor.directive.section
+
+Line: Name
+ - token from 0 to 5 (Name) with scopes text.aspnetcorerazor, meta.directive.section.razor
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, keyword.control.razor.directive.codeblock.open
+"
+`;
+
+exports[`Grammar tests @section directive No name 1`] = `
+"Line: @section
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.section.razor, keyword.control.cshtml.transition
+ - token from 1 to 8 (section) with scopes text.aspnetcorerazor, meta.directive.section.razor, keyword.control.razor.directive.section
+"
+`;
+
+exports[`Grammar tests @section directive No name, spaced 1`] = `
+"Line: @section                 
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.section.razor, keyword.control.cshtml.transition
+ - token from 1 to 8 (section) with scopes text.aspnetcorerazor, meta.directive.section.razor, keyword.control.razor.directive.section
+ - token from 8 to 26 (                 ) with scopes text.aspnetcorerazor, meta.directive.section.razor
+"
+`;
+
+exports[`Grammar tests @section directive Single line 1`] = `
+"Line: @section Name {@DateTime.Now}
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.section.razor, keyword.control.cshtml.transition
+ - token from 1 to 8 (section) with scopes text.aspnetcorerazor, meta.directive.section.razor, keyword.control.razor.directive.section
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.directive.section.razor
+ - token from 9 to 13 (Name) with scopes text.aspnetcorerazor, meta.directive.section.razor, variable.other.razor.directive.sectionName
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.directive.section.razor
+ - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, keyword.control.razor.directive.codeblock.open
+ - token from 15 to 16 (@) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 16 to 24 (DateTime) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 24 to 25 (.) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml
+ - token from 25 to 28 (Now) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 28 to 29 (}) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests @section directive Single line incomplete body 1`] = `
+"Line: @section Name {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.section.razor, keyword.control.cshtml.transition
+ - token from 1 to 8 (section) with scopes text.aspnetcorerazor, meta.directive.section.razor, keyword.control.razor.directive.section
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.directive.section.razor
+ - token from 9 to 13 (Name) with scopes text.aspnetcorerazor, meta.directive.section.razor, variable.other.razor.directive.sectionName
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.directive.section.razor
+ - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.directive.section.razor, meta.structure.razor.directive.markblock, keyword.control.razor.directive.codeblock.open
+"
+`;
+
 exports[`Grammar tests @tagHelperPrefix directive Incomplete parameter 1`] = `
 "Line: @tagHelperPrefix \\"
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.tagHelperPrefix.razor, keyword.control.cshtml.transition
@@ -981,6 +1088,36 @@ exports[`Grammar tests Implicit Expressions Awaited property 1`] = `
 "
 `;
 
+exports[`Grammar tests Implicit Expressions Close curly suffix 1`] = `
+"Line: @DateTime.Now}
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 9 to 10 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
+ - token from 10 to 13 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 13 to 15 (}) with scopes text.aspnetcorerazor
+"
+`;
+
+exports[`Grammar tests Implicit Expressions Close parenthesis suffix 1`] = `
+"Line: @DateTime.Now)
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 9 to 10 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
+ - token from 10 to 13 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 13 to 15 ()) with scopes text.aspnetcorerazor
+"
+`;
+
+exports[`Grammar tests Implicit Expressions Close parenthesis suffix 2`] = `
+"Line: @DateTime.Now]
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 9 to 10 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
+ - token from 10 to 13 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 13 to 15 (]) with scopes text.aspnetcorerazor
+"
+`;
+
 exports[`Grammar tests Implicit Expressions Combined with HTML 1`] = `
 "Line: <p>@DateTime.Now</p>
  - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, punctuation.definition.tag.begin.html
@@ -1101,6 +1238,16 @@ Line:     return y ? x : 457;
 Line: })
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.curlybrace.close.cs
  - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+"
+`;
+
+exports[`Grammar tests Implicit Expressions Open curly suffix 1`] = `
+"Line: @DateTime.Now{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 9 to 10 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
+ - token from 10 to 13 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 13 to 15 ({) with scopes text.aspnetcorerazor
 "
 `;
 


### PR DESCRIPTION
- Found that for implicit expressions doing things such as `@section Foo {@DateTime.Now}` resulted in mis-coloring of the `}` suffix. This was due to our implicit expression handling not having proper exit criteria.
- Added tests to validate the new exit criteria of implicit expressions.
- Add tests to validate the various forms of `@section`.

aspnet/AspNetCore#14287