### PR TITLE
Add grammar support for the using directive.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -475,6 +475,9 @@
         },
         {
           "include": "#layout-directive"
+        },
+        {
+          "include": "#using-directive"
         }
       ]
     },
@@ -862,6 +865,79 @@
       "endCaptures": {
         "1": {
           "name": "keyword.control.razor.directive.codeblock.close"
+        }
+      }
+    },
+    "using-directive": {
+      "name": "meta.directive.using.cshtml",
+      "match": "(@)(using)\\b\\s*(?!=\\()(.+?)?(;)?$",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.other.using.cs"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#using-static-directive"
+            },
+            {
+              "include": "#using-alias-directive"
+            },
+            {
+              "include": "#using-standard-directive"
+            }
+          ]
+        },
+        "4": {
+          "name": "keyword.control.razor.optionalSemicolon"
+        }
+      }
+    },
+    "using-static-directive": {
+      "match": "(static)\\b\\s+(.+)",
+      "captures": {
+        "1": {
+          "name": "keyword.other.static.cs"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "source.cs#type"
+            }
+          ]
+        }
+      }
+    },
+    "using-alias-directive": {
+      "match": "([_[:alpha:]][_[:alnum:]]*)\\b\\s*(=)\\s*(.+)\\s*",
+      "captures": {
+        "1": {
+          "name": "entity.name.type.alias.cs"
+        },
+        "2": {
+          "name": "keyword.operator.assignment.cs"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "source.cs#type"
+            }
+          ]
+        }
+      }
+    },
+    "using-standard-directive": {
+      "match": "([_[:alpha:]][_[:alnum:]]*)\\s*",
+      "captures": {
+        "1": {
+          "name": "entity.name.type.namespace.cs"
         }
       }
     },

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -870,7 +870,7 @@
     },
     "using-directive": {
       "name": "meta.directive.using.cshtml",
-      "match": "(@)(using)\\b\\s*(?!=\\()(.+?)?(;)?$",
+      "match": "(@)(using)\\b\\s*(?!\\()(.+?)?(;)?$",
       "captures": {
         "1": {
           "patterns": [

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -255,6 +255,7 @@ repository:
       - include: '#attribute-directive'
       - include: '#section-directive'
       - include: '#layout-directive'
+      - include: '#using-directive'
 
   #>>>>> @code and @functions <<<<<
 
@@ -428,6 +429,39 @@ repository:
     end: '(\})'
     endCaptures:
       1: { name: 'keyword.control.razor.directive.codeblock.close' }
+
+  #>>>>> @using <<<<<
+
+  using-directive:
+    name: 'meta.directive.using.cshtml'
+    match: '(@)(using)\b\s*(?!=\()(.+?)?(;)?$'
+    captures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.other.using.cs'}
+      3:
+        patterns:
+          - include: '#using-static-directive'
+          - include: '#using-alias-directive'
+          - include: '#using-standard-directive'
+      4: { name: 'keyword.control.razor.optionalSemicolon'}
+
+  using-static-directive:
+    match: '(static)\b\s+(.+)'
+    captures:
+      1: { name: 'keyword.other.static.cs' }
+      2: { patterns: [ include: 'source.cs#type' ] }
+
+  using-alias-directive:
+    match: '([_[:alpha:]][_[:alnum:]]*)\b\s*(=)\s*(.+)\s*'
+    captures:
+      1: { name: 'entity.name.type.alias.cs' }
+      2: { name: 'keyword.operator.assignment.cs' }
+      3: { patterns: [ include: 'source.cs#type' ] }
+
+  using-standard-directive:
+    match: '([_[:alpha:]][_[:alnum:]]*)\s*'
+    captures:
+      1: { name: 'entity.name.type.namespace.cs' }
 
   # ----------  Misc C# ------------
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -434,7 +434,7 @@ repository:
 
   using-directive:
     name: 'meta.directive.using.cshtml'
-    match: '(@)(using)\b\s*(?!=\()(.+?)?(;)?$'
+    match: '(@)(using)\b\s*(?!\()(.+?)?(;)?$'
     captures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.other.using.cs'}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -21,6 +21,7 @@ import { RunRemoveTagHelperDirectiveSuite } from './RemoveTagHelperDirective';
 import { RunSectionDirectiveSuite } from './SectionDirective';
 import { RunTagHelperPrefixDirectiveSuite } from './TagHelperPrefixDirective';
 import { RunTransitionsSuite } from './Transitions';
+import { RunUsingDirectiveSuite } from './UsingDirective';
 
 // We bring together all test suites and wrap them in one here. The reason behind this is that
 // modules get reloaded per test suite and the vscode-textmate library doesn't support the way
@@ -48,4 +49,5 @@ describe('Grammar tests', () => {
     RunAttributeDirectiveSuite();
     RunSectionDirectiveSuite();
     RunLayoutDirectiveSuite();
+    RunUsingDirectiveSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/UsingDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/UsingDirective.ts
@@ -1,0 +1,76 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunUsingDirectiveSuite() {
+    describe('@using directive', () => {
+        it('Standard using, no namespace', async () => {
+            await assertMatchesSnapshot('@using');
+        });
+
+        it('Standard using, no namespace spaced', async () => {
+            await assertMatchesSnapshot('@using              ');
+        });
+
+        it('Standard using', async () => {
+            await assertMatchesSnapshot('@using System.IO');
+        });
+
+        it('Standard using spaced', async () => {
+            await assertMatchesSnapshot('@using              System.IO         ');
+        });
+
+        it('Standard using, optional semicolon', async () => {
+            await assertMatchesSnapshot('@using System.IO;');
+        });
+
+        it('Static using, no namespace', async () => {
+            await assertMatchesSnapshot('@using static');
+        });
+
+        it('Static using, no namespace spaced', async () => {
+            await assertMatchesSnapshot('@using        static      ');
+        });
+
+        it('Static using', async () => {
+            await assertMatchesSnapshot('@using static System.Math');
+        });
+
+        it('Static using spaced', async () => {
+            await assertMatchesSnapshot('@using    static          System.Math         ');
+        });
+
+        it('Static using, optional semicolon', async () => {
+            await assertMatchesSnapshot('@using static System.Math;');
+        });
+
+        it('Using alias, no type', async () => {
+            await assertMatchesSnapshot('@using Something =');
+        });
+
+        it('Using alias, no type spaced', async () => {
+            await assertMatchesSnapshot('@using        Something   =    ');
+        });
+
+        it('Using alias, incomplete type, generic', async () => {
+            await assertMatchesSnapshot('@using TheTime = System.Collections.Generic.List<string');
+        });
+
+        it('Using alias', async () => {
+            await assertMatchesSnapshot('@using TheConsole = System.Console');
+        });
+
+        it('Using alias spaced', async () => {
+            await assertMatchesSnapshot('@using     TheConsole     =    System.Console   ');
+        });
+
+        it('Using alias, optional semicolon', async () => {
+            await assertMatchesSnapshot('@using TheConsole = System.Console;');
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -934,6 +934,209 @@ exports[`Grammar tests @tagHelperPrefix directive Unquoted parameter 1`] = `
 "
 `;
 
+exports[`Grammar tests @using directive Standard using 1`] = `
+"Line: @using System.IO
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 13 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+ - token from 13 to 14 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 14 to 16 (IO) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+"
+`;
+
+exports[`Grammar tests @using directive Standard using spaced 1`] = `
+"Line: @using              System.IO         
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 20 (              ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 20 to 26 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+ - token from 26 to 27 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 27 to 29 (IO) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+ - token from 29 to 38 (         ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+"
+`;
+
+exports[`Grammar tests @using directive Standard using, no namespace 1`] = `
+"Line: @using
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+"
+`;
+
+exports[`Grammar tests @using directive Standard using, no namespace spaced 1`] = `
+"Line: @using              
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 21 (              ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+"
+`;
+
+exports[`Grammar tests @using directive Standard using, optional semicolon 1`] = `
+"Line: @using System.IO;
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 13 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+ - token from 13 to 14 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 14 to 16 (IO) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+ - token from 16 to 17 (;) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.razor.optionalSemicolon
+"
+`;
+
+exports[`Grammar tests @using directive Static using 1`] = `
+"Line: @using static System.Math
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 13 (static) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.static.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 14 to 20 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 20 to 21 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 21 to 25 (Math) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+"
+`;
+
+exports[`Grammar tests @using directive Static using spaced 1`] = `
+"Line: @using    static          System.Math         
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 10 (    ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 10 to 16 (static) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.static.cs
+ - token from 16 to 26 (          ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 26 to 32 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 32 to 33 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 33 to 37 (Math) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 37 to 46 (         ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+"
+`;
+
+exports[`Grammar tests @using directive Static using, no namespace 1`] = `
+"Line: @using static
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 13 (static) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+"
+`;
+
+exports[`Grammar tests @using directive Static using, no namespace spaced 1`] = `
+"Line: @using        static      
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 14 (        ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 14 to 20 (static) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.static.cs
+ - token from 20 to 25 (     ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+"
+`;
+
+exports[`Grammar tests @using directive Static using, optional semicolon 1`] = `
+"Line: @using static System.Math;
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 13 (static) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.static.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 14 to 20 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 20 to 21 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 21 to 25 (Math) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 25 to 26 (;) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.razor.optionalSemicolon
+"
+`;
+
+exports[`Grammar tests @using directive Using alias 1`] = `
+"Line: @using TheConsole = System.Console
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 17 (TheConsole) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.alias.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 18 to 19 (=) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.operator.assignment.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 20 to 26 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 26 to 27 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 27 to 34 (Console) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+"
+`;
+
+exports[`Grammar tests @using directive Using alias spaced 1`] = `
+"Line: @using     TheConsole     =    System.Console   
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 11 (     ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 11 to 21 (TheConsole) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.alias.cs
+ - token from 21 to 26 (     ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 26 to 27 (=) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.operator.assignment.cs
+ - token from 27 to 31 (    ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 31 to 37 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 37 to 38 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 38 to 45 (Console) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 45 to 48 (   ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+"
+`;
+
+exports[`Grammar tests @using directive Using alias, incomplete type, generic 1`] = `
+"Line: @using TheTime = System.Collections.Generic.List<string
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 14 (TheTime) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.alias.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 15 to 16 (=) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.operator.assignment.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 17 to 23 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 23 to 24 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 24 to 35 (Collections) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 35 to 36 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 36 to 43 (Generic) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 43 to 44 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 44 to 48 (List) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 48 to 49 (<) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.definition.typeparameters.begin.cs
+ - token from 49 to 55 (string) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.type.cs
+"
+`;
+
+exports[`Grammar tests @using directive Using alias, no type 1`] = `
+"Line: @using Something =
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 16 (Something) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.namespace.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 17 to 18 (=) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+"
+`;
+
+exports[`Grammar tests @using directive Using alias, no type spaced 1`] = `
+"Line: @using        Something   =    
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 14 (        ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 14 to 23 (Something) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.alias.cs
+ - token from 23 to 26 (   ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 26 to 27 (=) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.operator.assignment.cs
+ - token from 27 to 30 (   ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+"
+`;
+
+exports[`Grammar tests @using directive Using alias, optional semicolon 1`] = `
+"Line: @using TheConsole = System.Console;
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 17 (TheConsole) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, entity.name.type.alias.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 18 to 19 (=) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.operator.assignment.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 20 to 26 (System) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 26 to 27 (.) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, punctuation.accessor.cs
+ - token from 27 to 34 (Console) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, storage.type.cs
+ - token from 34 to 35 (;) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.razor.optionalSemicolon
+"
+`;
+
 exports[`Grammar tests Explicit expressions Empty 1`] = `
 "Line: @()
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml.transition


### PR DESCRIPTION
- Ensured the new using directive grammar applied scopes that were compatible with the pre-existing Razor grammar.
- Add tests to validate the various forms of `@using` (standard, static and alias).

aspnet/AspNetCore#14287