### PR TITLE
[release/3.0] Use Microsoft.NETCore.App.Internal for runtime version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -33,6 +33,10 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>547ae1f5f072d130b32ec3089876711070b2dc4f</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="3.0.2-servicing-19576-08" CoherentParentDependency="Microsoft.Extensions.Logging">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>547ae1f5f072d130b32ec3089876711070b2dc4f</Sha>
+    </Dependency>
     <!--
       Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
       All Runtime.$rid packages should have the same version.

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -55,6 +55,7 @@
     <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>3.0.2-servicing.19604.3</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>3.0.0</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>3.0.2-servicing-19576-08</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>3.0.2-servicing-19576-08</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0</MicrosoftNETCorePlatformsPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.6.0</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemTextEncodingsWebPackageVersion>4.6.0</SystemTextEncodingsWebPackageVersion>

--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
     "runtimes": {
       "dotnet": [
         "2.1.11",
-        "$(MicrosoftNETCoreAppRuntimeVersion)"
+        "$(MicrosoftNETCoreAppInternalPackageVersion)"
       ]
     },
     "vs": {


### PR DESCRIPTION
* Use Microsoft.NETCore.App.Internal for runtime version
For stable builds, core-setup is now publishing its artifacts to a suffixed directory (e.g. 3.0.1-servicing-19510-13) instead of 3.0.1. This ensures we don't have to overwrite outputs when we rebuild stable versions. Within that directory, it publishes the same set of files with the final file names as well as suffixed file names:
- https://dotnetcli.blob.core.windows.net/dotnet/Runtime/3.0.1-servicing-19510-13/dotnet-apphost-pack-3.0.1-win-x64.msi
- https://dotnetcli.blob.core.windows.net/dotnet/Runtime/3.0.1-servicing-19510-13/dotnet-apphost-pack-3.0.1-servicing-19510-13-win-x64.msi

Downstream repos should install the runtime using the full suffixed version.