### PR TITLE
Add grammar support for the using statement.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -25,6 +25,9 @@
           "include": "#directives"
         },
         {
+          "include": "#transitioned-csharp-control-structures"
+        },
+        {
           "include": "#implicit-expression"
         }
       ]
@@ -53,7 +56,7 @@
       },
       "patterns": [
         {
-          "include": "#razor-csharp-statement"
+          "include": "#razor-codeblock-body"
         }
       ],
       "end": "(\\})",
@@ -63,7 +66,7 @@
         }
       }
     },
-    "razor-csharp-statement": {
+    "razor-codeblock-body": {
       "patterns": [
         {
           "include": "#text-tag"
@@ -870,7 +873,7 @@
     },
     "using-directive": {
       "name": "meta.directive.using.cshtml",
-      "match": "(@)(using)\\b\\s*(?!\\()(.+?)?(;)?$",
+      "match": "(@)(using)\\b\\s*(?!\\(|\\s)(.+?)?(;)?$",
       "captures": {
         "1": {
           "patterns": [
@@ -941,9 +944,83 @@
         }
       }
     },
+    "transitioned-csharp-control-structures": {
+      "patterns": [
+        {
+          "include": "#using-statement"
+        }
+      ]
+    },
+    "using-statement": {
+      "name": "meta.statement.using.razor",
+      "begin": "(@)(using)\\s*(?=\\()",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.other.using.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#csharp-condition"
+        },
+        {
+          "include": "#csharp-code-block"
+        },
+        {
+          "include": "#razor-codeblock-body"
+        }
+      ],
+      "end": "(?<=})"
+    },
     "await-prefix": {
       "name": "keyword.other.await.cs",
       "match": "(await)\\s+"
+    },
+    "csharp-code-block": {
+      "name": "meta.structure.razor.csharp.codeblock",
+      "begin": "(\\{)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.curlybrace.open.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#razor-codeblock-body"
+        }
+      ],
+      "end": "(\\})",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.curlybrace.close.cs"
+        }
+      }
+    },
+    "csharp-condition": {
+      "begin": "(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.parenthesis.open.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.cs#expression"
+        }
+      ],
+      "end": "(\\))",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.parenthesis.close.cs"
+        }
+      }
     }
   }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -11,6 +11,7 @@ repository:
       - include: '#explicit-razor-expression'
       - include: '#escaped-transition'
       - include: '#directives'
+      - include: '#transitioned-csharp-control-structures'
       - include: '#implicit-expression'
 
   escaped-transition:
@@ -29,12 +30,12 @@ repository:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.control.razor.directive.codeblock.open' }
     patterns:
-      - include: '#razor-csharp-statement'
+      - include: '#razor-codeblock-body'
     end: '(\})'
     endCaptures:
       1: { name: 'keyword.control.razor.directive.codeblock.close' }
 
-  razor-csharp-statement:
+  razor-codeblock-body:
     patterns:
       - include: '#text-tag'
       - include: '#wellformed-html'
@@ -434,7 +435,7 @@ repository:
 
   using-directive:
     name: 'meta.directive.using.cshtml'
-    match: '(@)(using)\b\s*(?!\()(.+?)?(;)?$'
+    match: '(@)(using)\b\s*(?!\(|\s)(.+?)?(;)?$'
     captures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.other.using.cs'}
@@ -463,8 +464,50 @@ repository:
     captures:
       1: { name: 'entity.name.type.namespace.cs' }
 
+  # ----------  Razor C# Control Structures ------------
+
+  transitioned-csharp-control-structures:
+    patterns:
+      - include: '#using-statement'
+
+  #>>>>> @using (...) <<<<<
+
+  using-statement:
+    name: 'meta.statement.using.razor'
+    begin: '(@)(using)\s*(?=\()'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.other.using.cs' }
+    patterns:
+      - include: '#csharp-condition'
+      - include: '#csharp-code-block'
+      - include: '#razor-codeblock-body'
+    end: (?<=})
+
   # ----------  Misc C# ------------
 
   await-prefix:
     name: 'keyword.other.await.cs'
     match: '(await)\s+'
+
+  csharp-code-block:
+    name: 'meta.structure.razor.csharp.codeblock'
+    begin: '(\{)'
+    beginCaptures:
+      1: { name: 'punctuation.curlybrace.open.cs' }
+    patterns:
+      - include: '#razor-codeblock-body'
+    end: '(\})'
+    endCaptures:
+      1: { name: 'punctuation.curlybrace.close.cs' }
+
+  csharp-condition:
+    begin: '(\()'
+    beginCaptures:
+      1: { name: 'punctuation.parenthesis.open.cs' }
+    patterns:
+      - include: 'source.cs#expression'
+    end: '(\))'
+    endCaptures:
+      1: { name: 'punctuation.parenthesis.close.cs' }
+

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -22,6 +22,7 @@ import { RunSectionDirectiveSuite } from './SectionDirective';
 import { RunTagHelperPrefixDirectiveSuite } from './TagHelperPrefixDirective';
 import { RunTransitionsSuite } from './Transitions';
 import { RunUsingDirectiveSuite } from './UsingDirective';
+import { RunUsingStatementSuite } from './UsingStatement';
 
 // We bring together all test suites and wrap them in one here. The reason behind this is that
 // modules get reloaded per test suite and the vscode-textmate library doesn't support the way
@@ -50,4 +51,7 @@ describe('Grammar tests', () => {
     RunSectionDirectiveSuite();
     RunLayoutDirectiveSuite();
     RunUsingDirectiveSuite();
+
+    // Razor C# Control Structures
+    RunUsingStatementSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/UsingStatement.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/UsingStatement.ts
@@ -1,0 +1,49 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunUsingStatementSuite() {
+    describe('@using ( ... ) { ... }', () => {
+        it('Incomplete using statement, no condition or body', async () => {
+            await assertMatchesSnapshot('@using');
+        });
+
+        it('Incomplete using statement, no condition', async () => {
+            await assertMatchesSnapshot('@using {}');
+        });
+
+        it('Single line', async () => {
+            await assertMatchesSnapshot('@using (someDisposable) { var x = 123;<p>Hello World</p> }');
+        });
+
+        it('Multi line condition', async () => {
+            await assertMatchesSnapshot(
+`@using (
+    await GetSomeDisposableAsync(
+        () => true,
+        name: "The Good Disposable",
+        new {
+            Foo = false,
+        }
+)){}`);
+        });
+
+        it('Multi line body', async () => {
+            await assertMatchesSnapshot(
+`@using (SomeDisposable)
+{
+    var x = 123;
+    <div>
+        @using (GetAnotherDisposable()) {
+            <p></p>
+        }
+    </div>
+}`);
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -934,6 +934,180 @@ exports[`Grammar tests @tagHelperPrefix directive Unquoted parameter 1`] = `
 "
 `;
 
+exports[`Grammar tests @using ( ... ) { ... } Incomplete using statement, no condition 1`] = `
+"Line: @using {}
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+ - token from 7 to 9 ({}) with scopes text.aspnetcorerazor, meta.directive.using.cshtml
+"
+`;
+
+exports[`Grammar tests @using ( ... ) { ... } Incomplete using statement, no condition or body 1`] = `
+"Line: @using
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.other.using.cs
+"
+`;
+
+exports[`Grammar tests @using ( ... ) { ... } Multi line body 1`] = `
+"Line: @using (SomeDisposable)
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 22 (SomeDisposable) with scopes text.aspnetcorerazor, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 22 to 23 ()) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.close.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:     var x = 123;
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (x) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 15 (123) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
+ - token from 15 to 16 (;) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+
+Line:     <div>
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 5 to 8 (div) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 8 to 9 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:         @using (GetAnotherDisposable()) {
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.control.cshtml.transition
+ - token from 9 to 14 (using) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.other.using.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 16 to 36 (GetAnotherDisposable) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, entity.name.function.cs
+ - token from 36 to 37 (() with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 37 to 38 ()) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 38 to 39 ()) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 39 to 40 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 40 to 41 ({) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:             <p></p>
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 15 to 17 (</) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 17 to 18 (p) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:         }
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line:     </div>
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 6 (</) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 6 to 9 (div) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 9 to 10 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @using ( ... ) { ... } Multi line condition 1`] = `
+"Line: @using (
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.open.cs
+
+Line:     await GetSomeDisposableAsync(
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 4 to 9 (await) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.other.await.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 10 to 32 (GetSomeDisposableAsync) with scopes text.aspnetcorerazor, meta.statement.using.razor, entity.name.function.cs
+ - token from 32 to 33 (() with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.open.cs
+
+Line:         () => true,
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 9 to 10 ()) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 11 to 13 (=>) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.operator.arrow.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 14 to 18 (true) with scopes text.aspnetcorerazor, meta.statement.using.razor, constant.language.boolean.true.cs
+ - token from 18 to 19 (,) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.separator.comma.cs
+
+Line:         name: \\"The Good Disposable\\",
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 8 to 12 (name) with scopes text.aspnetcorerazor, meta.statement.using.razor, entity.name.variable.parameter.cs
+ - token from 12 to 13 (:) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.separator.colon.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 14 to 15 (\\") with scopes text.aspnetcorerazor, meta.statement.using.razor, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 15 to 34 (The Good Disposable) with scopes text.aspnetcorerazor, meta.statement.using.razor, string.quoted.double.cs
+ - token from 34 to 35 (\\") with scopes text.aspnetcorerazor, meta.statement.using.razor, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 35 to 36 (,) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.separator.comma.cs
+
+Line:         new {
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 8 to 11 (new) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.other.new.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 12 to 13 ({) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.curlybrace.open.cs
+
+Line:             Foo = false,
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 12 to 15 (Foo) with scopes text.aspnetcorerazor, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.operator.assignment.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 18 to 23 (false) with scopes text.aspnetcorerazor, meta.statement.using.razor, constant.language.boolean.false.cs
+ - token from 23 to 24 (,) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.separator.comma.cs
+
+Line:         }
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.curlybrace.close.cs
+
+Line: )){}
+ - token from 0 to 1 ()) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 2 to 3 ({) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 3 to 4 (}) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @using ( ... ) { ... } Single line 1`] = `
+"Line: @using (someDisposable) { var x = 123;<p>Hello World</p> }
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.control.cshtml.transition
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.other.using.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 22 (someDisposable) with scopes text.aspnetcorerazor, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 22 to 23 ()) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 24 to 25 ({) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 26 to 29 (var) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
+ - token from 29 to 30 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 30 to 31 (x) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 32 to 33 (=) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 33 to 34 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 34 to 37 (123) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
+ - token from 37 to 38 (;) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 38 to 39 (<) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 39 to 40 (p) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 40 to 41 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 41 to 52 (Hello World) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 52 to 54 (</) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 54 to 55 (p) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 55 to 56 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 56 to 57 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 57 to 58 (}) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
 exports[`Grammar tests @using directive Standard using 1`] = `
 "Line: @using System.IO
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition


### PR DESCRIPTION
- Does not support Razor templates or more than one level embedded HTML constructs.
- Add tests to validate the various forms of `@using (...) {...}`.

aspnet/AspNetCore#14287