### PR TITLE
Add grammar support for do-while statements.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -969,6 +969,9 @@
         },
         {
           "include": "#lock-statement"
+        },
+        {
+          "include": "#do-statement"
         }
       ]
     },
@@ -1166,9 +1169,37 @@
         }
       ]
     },
+    "do-statement": {
+      "name": "meta.statement.do.razor",
+      "begin": "(@)(do)\\b\\s*",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.loop.do.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#csharp-condition"
+        },
+        {
+          "include": "#csharp-code-block"
+        },
+        {
+          "include": "#razor-codeblock-body"
+        }
+      ],
+      "end": "(?<=})"
+    },
     "while-statement": {
       "name": "meta.statement.while.razor",
-      "begin": "(@)(while)\\b\\s*(?=\\()",
+      "begin": "(?:(@)|^\\s*|(?<=})\\s*)(while)\\b\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "patterns": [
@@ -1192,7 +1223,12 @@
           "include": "#razor-codeblock-body"
         }
       ],
-      "end": "(?<=})"
+      "end": "(?<=})|(;)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.cs"
+        }
+      }
     },
     "switch-statement": {
       "name": "meta.statement.switch.razor",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -972,6 +972,9 @@
         },
         {
           "include": "#do-statement"
+        },
+        {
+          "include": "#try-statement"
         }
       ]
     },
@@ -1300,6 +1303,120 @@
         {
           "include": "#csharp-condition"
         },
+        {
+          "include": "#csharp-code-block"
+        },
+        {
+          "include": "#razor-codeblock-body"
+        }
+      ],
+      "end": "(?<=})"
+    },
+    "try-statement": {
+      "patterns": [
+        {
+          "include": "#try-block"
+        },
+        {
+          "include": "#catch-clause"
+        },
+        {
+          "include": "#finally-clause"
+        }
+      ]
+    },
+    "try-block": {
+      "name": "meta.statement.try.razor",
+      "begin": "(@)(try)\\b\\s*",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.try.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#csharp-condition"
+        },
+        {
+          "include": "#csharp-code-block"
+        },
+        {
+          "include": "#razor-codeblock-body"
+        }
+      ],
+      "end": "(?<=})"
+    },
+    "catch-clause": {
+      "name": "meta.statement.catch.razor",
+      "begin": "(?:^|(?<=}))\\s*(catch)\\b\\s*?(?=[\\n\\(\\{])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.try.catch.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#catch-condition"
+        },
+        {
+          "include": "source.cs#when-clause"
+        },
+        {
+          "include": "#csharp-code-block"
+        },
+        {
+          "include": "#razor-codeblock-body"
+        }
+      ],
+      "end": "(?<=})"
+    },
+    "catch-condition": {
+      "begin": "\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.parenthesis.open.cs"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.parenthesis.close.cs"
+        }
+      },
+      "patterns": [
+        {
+          "match": "(?x)\n(?<type-name>\n  (?:\n    (?:\n      (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification\n      (?<name-and-type-args> # identifier + type arguments (if any)\n        \\g<identifier>\\s*\n        (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?\n      )\n      (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?\n      (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))\n    )\n    (?:\\s*\\?\\s*)? # nullable suffix?\n    (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?\n  )\n)\\s*\n(?:(\\g<identifier>)\\b)?",
+          "captures": {
+            "1": {
+              "patterns": [
+                {
+                  "include": "source.cs#type"
+                }
+              ]
+            },
+            "6": {
+              "name": "entity.name.variable.local.cs"
+            }
+          }
+        }
+      ]
+    },
+    "finally-clause": {
+      "name": "meta.statement.finally.razor",
+      "begin": "(?:^|(?<=}))\\s*(finally)\\b\\s*?(?=[\\n\\{])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.try.finally.cs"
+        }
+      },
+      "patterns": [
         {
           "include": "#csharp-code-block"
         },

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -477,6 +477,7 @@ repository:
       - include: '#switch-statement'
       - include: '#lock-statement'
       - include: '#do-statement'
+      - include: '#try-statement'
 
   #>>>>> @using (...) { ... } <<<<<
 
@@ -669,6 +670,85 @@ repository:
       2: { name: 'keyword.other.lock.cs' }
     patterns:
       - include: '#csharp-condition'
+      - include: '#csharp-code-block'
+      - include: '#razor-codeblock-body'
+    end: '(?<=})'
+
+  #>>>>> @try { ... } [catch|finally] (...) { ... } <<<<<
+
+  try-statement:
+    patterns:
+      - include: '#try-block'
+      - include: '#catch-clause'
+      - include: '#finally-clause'
+
+  try-block:
+    name: 'meta.statement.try.razor'
+    begin: '(@)(try)\b\s*'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.try.cs' }
+    patterns:
+      - include: '#csharp-condition'
+      - include: '#csharp-code-block'
+      - include: '#razor-codeblock-body'
+    end: '(?<=})'
+
+  catch-clause:
+    name: 'meta.statement.catch.razor'
+    begin: '(?:^|(?<=}))\s*(catch)\b\s*?(?=[\n\(\{])'
+    beginCaptures:
+      1: { name: 'keyword.control.try.catch.cs' }
+    patterns:
+      - include: '#catch-condition'
+      - include: 'source.cs#when-clause'
+      - include: '#csharp-code-block'
+      - include: '#razor-codeblock-body'
+    end: '(?<=})'
+
+  # This condition is pulled directly from the C# grammar for catch clauses
+  catch-condition:
+    begin: '\('
+    beginCaptures:
+      0: { name: 'punctuation.parenthesis.open.cs' }
+    end: '\)'
+    endCaptures:
+      0: { name: 'punctuation.parenthesis.close.cs' }
+    patterns:
+      - match: |-
+          (?x)
+          (?<type-name>
+            (?:
+              (?:
+                (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
+                (?<name-and-type-args> # identifier + type arguments (if any)
+                  \g<identifier>\s*
+                  (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+                )
+                (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+                (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
+              )
+              (?:\s*\?\s*)? # nullable suffix?
+              (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
+            )
+          )\s*
+          (?:(\g<identifier>)\b)?
+        captures:
+          1:
+            patterns:
+              - include: 'source.cs#type'
+          # '2': ?<identifier> is a sub-expression. It's final value is not considered.
+          # '3': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
+          # '4': ?<type-args> is a sub-expression. It's final value is not considered.
+          # '5': ?<tuple> is a sub-expression. It's final value is not considered.
+          6: { name: entity.name.variable.local.cs }
+
+  finally-clause:
+    name: 'meta.statement.finally.razor'
+    begin: '(?:^|(?<=}))\s*(finally)\b\s*?(?=[\n\{])'
+    beginCaptures:
+      1: { name: 'keyword.control.try.finally.cs' }
+    patterns:
       - include: '#csharp-code-block'
       - include: '#razor-codeblock-body'
     end: '(?<=})'

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -476,6 +476,7 @@ repository:
       - include: '#while-statement'
       - include: '#switch-statement'
       - include: '#lock-statement'
+      - include: '#do-statement'
 
   #>>>>> @using (...) { ... } <<<<<
 
@@ -602,11 +603,25 @@ repository:
           3: { name: 'keyword.control.loop.in.cs' }
       - include: 'source.cs#expression'
 
+  #>>>>> @do (...) while { ... } <<<<<
+
+  do-statement:
+    name: 'meta.statement.do.razor'
+    begin: '(@)(do)\b\s*'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.loop.do.cs' }
+    patterns:
+      - include: '#csharp-condition'
+      - include: '#csharp-code-block'
+      - include: '#razor-codeblock-body'
+    end: '(?<=})'
+
   #>>>>> @while (...) { ... } <<<<<
 
   while-statement:
     name: 'meta.statement.while.razor'
-    begin: '(@)(while)\b\s*(?=\()'
+    begin: '(?:(@)|^\s*|(?<=})\s*)(while)\b\s*(?=\()'
     beginCaptures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.control.loop.while.cs' }
@@ -614,7 +629,9 @@ repository:
       - include: '#csharp-condition'
       - include: '#csharp-code-block'
       - include: '#razor-codeblock-body'
-    end: '(?<=})'
+    end: '(?<=})|(;)'
+    endCaptures:
+      1: { name: 'punctuation.terminator.statement.cs'}
 
   #>>>>> @switch (...) { ... } <<<<<
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/DoStatement.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/DoStatement.ts
@@ -1,0 +1,56 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunDoStatementSuite() {
+    describe('@do { ... } while ( ... );', () => {
+        it('Incomplete do statement, no body', async () => {
+            await assertMatchesSnapshot('@do');
+        });
+
+        it('Incomplete do while statement, no condition', async () => {
+            await assertMatchesSnapshot('@do { } while ;');
+        });
+
+        it('Incomplete do while statement, no terminator', async () => {
+            await assertMatchesSnapshot('@do { } while');
+        });
+
+        it('Single line', async () => {
+            await assertMatchesSnapshot('@do { var x = 123;<p>Hello World</p> }while (   true  );');
+        });
+
+        it('Multi line condition', async () => {
+            await assertMatchesSnapshot(
+`@do
+{
+}
+while (
+    await GetATruthyValue(
+        () => true,
+        name: "Hello",
+        new {
+            Foo = false,
+        }
+));`);
+        });
+
+        it('Multi line body', async () => {
+            await assertMatchesSnapshot(
+`@do
+{
+    var x = 123;
+    <div>
+        @do {
+            <p></p>
+        } while(GetAnotherValue());
+    </div>
+}while(true);`);
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -7,6 +7,7 @@ import { RunAddTagHelperDirectiveSuite } from './AddTagHelperDirective';
 import { RunAttributeDirectiveSuite } from './AttributeDirective';
 import { RunCodeBlockSuite } from './CodeBlock';
 import { RunCodeDirectiveSuite } from './CodeDirective';
+import { RunDoStatementSuite } from './DoStatement';
 import { RunElsePartSuite } from './ElsePart';
 import { RunExplicitExpressionSuite } from './ExplicitExpressions';
 import { RunForeachStatementSuite } from './ForeachStatement';
@@ -68,4 +69,5 @@ describe('Grammar tests', () => {
     RunWhileStatementSuite();
     RunSwitchStatementSuite();
     RunLockStatementSuite();
+    RunDoStatementSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -28,6 +28,7 @@ import { RunSectionDirectiveSuite } from './SectionDirective';
 import { RunSwitchStatementSuite } from './SwitchStatement';
 import { RunTagHelperPrefixDirectiveSuite } from './TagHelperPrefixDirective';
 import { RunTransitionsSuite } from './Transitions';
+import { RunTryStatementSuite } from './TryStatement';
 import { RunUsingDirectiveSuite } from './UsingDirective';
 import { RunUsingStatementSuite } from './UsingStatement';
 import { RunWhileStatementSuite } from './WhileStatement';
@@ -70,4 +71,5 @@ describe('Grammar tests', () => {
     RunSwitchStatementSuite();
     RunLockStatementSuite();
     RunDoStatementSuite();
+    RunTryStatementSuite();
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/TryStatement.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/TryStatement.ts
@@ -1,0 +1,54 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunTryStatementSuite() {
+    describe('@try { ... } catch/finally { ... }', () => {
+        it('Incomplete try statement, no body', async () => {
+            await assertMatchesSnapshot('@try');
+        });
+
+        it('Incomplete try statement, no catch or finally', async () => {
+            await assertMatchesSnapshot('@try {}');
+        });
+
+        it('Single line', async () => {
+            await assertMatchesSnapshot('@try { var x = 123;<p>Hello World</p> } catch (Exception ex) {@DateTime.Now}finally{<section></section>var y = 456;}');
+        });
+
+        it('Multi line catch', async () => {
+            await assertMatchesSnapshot(
+`@try
+{
+}
+catch (
+    InvalidOperationException
+    ex){}`);
+        });
+
+        it('Multi line complex', async () => {
+            await assertMatchesSnapshot(
+`@try
+{
+    Console.WriteLine("Invoking!");
+    <div>Invoked: @SomeMethod()</div>
+} catch (InvalidOperationExeption ex) when (ex != null)
+{
+    var x = 123;
+    <div>
+        @try {
+            <p>Error occurred</p>
+            throw;
+        } catch(Exception ex) {
+
+        } finally { <strong>In the finally</strong> }
+    </div>
+}finally{}`);
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -246,6 +246,210 @@ exports[`Grammar tests @code directive Single line 1`] = `
 "
 `;
 
+exports[`Grammar tests @do { ... } while ( ... ); Incomplete do statement, no body 1`] = `
+"Line: @do
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.cshtml.transition
+ - token from 1 to 3 (do) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.loop.do.cs
+"
+`;
+
+exports[`Grammar tests @do { ... } while ( ... ); Incomplete do while statement, no condition 1`] = `
+"Line: @do { } while ;
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.cshtml.transition
+ - token from 1 to 3 (do) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.loop.do.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 6 to 7 (}) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 7 to 16 ( while ;) with scopes text.aspnetcorerazor
+"
+`;
+
+exports[`Grammar tests @do { ... } while ( ... ); Incomplete do while statement, no terminator 1`] = `
+"Line: @do { } while
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.cshtml.transition
+ - token from 1 to 3 (do) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.loop.do.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 6 to 7 (}) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 7 to 14 ( while) with scopes text.aspnetcorerazor
+"
+`;
+
+exports[`Grammar tests @do { ... } while ( ... ); Multi line body 1`] = `
+"Line: @do
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.cshtml.transition
+ - token from 1 to 3 (do) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.loop.do.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:     var x = 123;
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (x) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 15 (123) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
+ - token from 15 to 16 (;) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+
+Line:     <div>
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 5 to 8 (div) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 8 to 9 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:         @do {
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, keyword.control.cshtml.transition
+ - token from 9 to 11 (do) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, keyword.control.loop.do.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor
+ - token from 12 to 13 ({) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:             <p></p>
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 15 to 17 (</) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 17 to 18 (p) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:         } while(GetAnotherValue());
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 10 to 15 (while) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 16 to 31 (GetAnotherValue) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, entity.name.function.cs
+ - token from 31 to 32 (() with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 32 to 33 ()) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 34 to 35 (;) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.terminator.statement.cs
+
+Line:     </div>
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 6 (</) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 6 to 9 (div) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 9 to 10 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line: }while(true);
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 1 to 6 (while) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 6 to 7 (() with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 7 to 11 (true) with scopes text.aspnetcorerazor, meta.statement.while.razor, constant.language.boolean.true.cs
+ - token from 11 to 12 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 12 to 13 (;) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.terminator.statement.cs
+"
+`;
+
+exports[`Grammar tests @do { ... } while ( ... ); Multi line condition 1`] = `
+"Line: @do
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.cshtml.transition
+ - token from 1 to 3 (do) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.loop.do.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: while (
+ - token from 0 to 5 (while) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 6 to 7 (() with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.open.cs
+
+Line:     await GetATruthyValue(
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 4 to 9 (await) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.other.await.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 10 to 25 (GetATruthyValue) with scopes text.aspnetcorerazor, meta.statement.while.razor, entity.name.function.cs
+ - token from 25 to 26 (() with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.open.cs
+
+Line:         () => true,
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 9 to 10 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 11 to 13 (=>) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.arrow.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 14 to 18 (true) with scopes text.aspnetcorerazor, meta.statement.while.razor, constant.language.boolean.true.cs
+ - token from 18 to 19 (,) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.separator.comma.cs
+
+Line:         name: \\"Hello\\",
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 8 to 12 (name) with scopes text.aspnetcorerazor, meta.statement.while.razor, entity.name.variable.parameter.cs
+ - token from 12 to 13 (:) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.separator.colon.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 14 to 15 (\\") with scopes text.aspnetcorerazor, meta.statement.while.razor, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 15 to 20 (Hello) with scopes text.aspnetcorerazor, meta.statement.while.razor, string.quoted.double.cs
+ - token from 20 to 21 (\\") with scopes text.aspnetcorerazor, meta.statement.while.razor, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 21 to 22 (,) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.separator.comma.cs
+
+Line:         new {
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 8 to 11 (new) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.other.new.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 12 to 13 ({) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.curlybrace.open.cs
+
+Line:             Foo = false,
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 12 to 15 (Foo) with scopes text.aspnetcorerazor, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.assignment.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 18 to 23 (false) with scopes text.aspnetcorerazor, meta.statement.while.razor, constant.language.boolean.false.cs
+ - token from 23 to 24 (,) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.separator.comma.cs
+
+Line:         }
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.curlybrace.close.cs
+
+Line: ));
+ - token from 0 to 1 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 2 to 3 (;) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.terminator.statement.cs
+"
+`;
+
+exports[`Grammar tests @do { ... } while ( ... ); Single line 1`] = `
+"Line: @do { var x = 123;<p>Hello World</p> }while (   true  );
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.cshtml.transition
+ - token from 1 to 3 (do) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.loop.do.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 6 to 9 (var) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 10 to 11 (x) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (=) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 14 to 17 (123) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
+ - token from 17 to 18 (;) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 18 to 19 (<) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 19 to 20 (p) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 20 to 21 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 21 to 32 (Hello World) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 32 to 34 (</) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 34 to 35 (p) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 35 to 36 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 36 to 37 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 37 to 38 (}) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 38 to 43 (while) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 43 to 44 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 44 to 45 (() with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 45 to 48 (   ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 48 to 52 (true) with scopes text.aspnetcorerazor, meta.statement.while.razor, constant.language.boolean.true.cs
+ - token from 52 to 54 (  ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 54 to 55 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 55 to 56 (;) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.terminator.statement.cs
+"
+`;
+
 exports[`Grammar tests @for ( ... ) { ... } Incomplete for statement, no condition 1`] = `
 "Line: @for {}
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -2194,6 +2194,256 @@ exports[`Grammar tests @tagHelperPrefix directive Unquoted parameter 1`] = `
 "
 `;
 
+exports[`Grammar tests @try { ... } catch/finally { ... } Incomplete try statement, no body 1`] = `
+"Line: @try
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.cshtml.transition
+ - token from 1 to 4 (try) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.try.cs
+"
+`;
+
+exports[`Grammar tests @try { ... } catch/finally { ... } Incomplete try statement, no catch or finally 1`] = `
+"Line: @try {}
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.cshtml.transition
+ - token from 1 to 4 (try) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.try.cs
+ - token from 4 to 5 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor
+ - token from 5 to 6 ({) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 6 to 7 (}) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @try { ... } catch/finally { ... } Multi line catch 1`] = `
+"Line: @try
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.cshtml.transition
+ - token from 1 to 4 (try) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.try.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: catch (
+ - token from 0 to 5 (catch) with scopes text.aspnetcorerazor, meta.statement.catch.razor, keyword.control.try.catch.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 6 to 7 (() with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.open.cs
+
+Line:     InvalidOperationException
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 4 to 29 (InvalidOperationException) with scopes text.aspnetcorerazor, meta.statement.catch.razor, storage.type.cs
+
+Line:     ex){}
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 4 to 6 (ex) with scopes text.aspnetcorerazor, meta.statement.catch.razor, storage.type.cs
+ - token from 6 to 7 ()) with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.close.cs
+ - token from 7 to 8 ({) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @try { ... } catch/finally { ... } Multi line complex 1`] = `
+"Line: @try
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.cshtml.transition
+ - token from 1 to 4 (try) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.try.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:     Console.WriteLine(\\"Invoking!\\");
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 11 (Console) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, variable.other.object.cs
+ - token from 11 to 12 (.) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.accessor.cs
+ - token from 12 to 21 (WriteLine) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.function.cs
+ - token from 21 to 22 (() with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.parenthesis.open.cs
+ - token from 22 to 23 (\\") with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 23 to 32 (Invoking!) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, string.quoted.double.cs
+ - token from 32 to 33 (\\") with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.parenthesis.close.cs
+ - token from 34 to 35 (;) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+
+Line:     <div>Invoked: @SomeMethod()</div>
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 5 to 8 (div) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 8 to 9 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 9 to 18 (Invoked: ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 29 (SomeMethod) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 29 to 30 (() with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 30 to 31 ()) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 31 to 33 (</) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 33 to 36 (div) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 36 to 37 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line: } catch (InvalidOperationExeption ex) when (ex != null)
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 1 to 2 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 2 to 7 (catch) with scopes text.aspnetcorerazor, meta.statement.catch.razor, keyword.control.try.catch.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.open.cs
+ - token from 9 to 33 (InvalidOperationExeption) with scopes text.aspnetcorerazor, meta.statement.catch.razor, storage.type.cs
+ - token from 33 to 34 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 34 to 36 (ex) with scopes text.aspnetcorerazor, meta.statement.catch.razor, entity.name.variable.local.cs
+ - token from 36 to 37 ()) with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.close.cs
+ - token from 37 to 38 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 38 to 42 (when) with scopes text.aspnetcorerazor, meta.statement.catch.razor, keyword.control.try.when.cs
+ - token from 42 to 43 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 43 to 44 (() with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.open.cs
+ - token from 44 to 46 (ex) with scopes text.aspnetcorerazor, meta.statement.catch.razor, variable.other.readwrite.cs
+ - token from 46 to 47 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 47 to 49 (!=) with scopes text.aspnetcorerazor, meta.statement.catch.razor, keyword.operator.comparison.cs
+ - token from 49 to 50 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 50 to 54 (null) with scopes text.aspnetcorerazor, meta.statement.catch.razor, constant.language.null.cs
+ - token from 54 to 55 ()) with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.close.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:     var x = 123;
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (x) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 15 (123) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
+ - token from 15 to 16 (;) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+
+Line:     <div>
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 5 to 8 (div) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 8 to 9 (>) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:         @try {
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, keyword.control.cshtml.transition
+ - token from 9 to 12 (try) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, keyword.control.try.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor
+ - token from 13 to 14 ({) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:             <p>Error occurred</p>
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 15 to 29 (Error occurred) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 31 (</) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 31 to 32 (p) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 32 to 33 (>) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:             throw;
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 17 (throw) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.control.flow.throw.cs
+ - token from 17 to 18 (;) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+
+Line:         } catch(Exception ex) {
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor
+ - token from 10 to 15 (catch) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, keyword.control.try.catch.cs
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, punctuation.parenthesis.open.cs
+ - token from 16 to 25 (Exception) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, storage.type.cs
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor
+ - token from 26 to 28 (ex) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, entity.name.variable.local.cs
+ - token from 28 to 29 ()) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, punctuation.parenthesis.close.cs
+ - token from 29 to 30 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor
+ - token from 30 to 31 ({) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock
+
+Line:         } finally { <strong>In the finally</strong> }
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.finally.razor
+ - token from 10 to 17 (finally) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.finally.razor, keyword.control.try.finally.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.finally.razor
+ - token from 18 to 19 ({) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 21 (<) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 21 to 27 (strong) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 27 to 28 (>) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 28 to 42 (In the finally) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock
+ - token from 42 to 44 (</) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 44 to 50 (strong) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 50 to 51 (>) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock
+ - token from 52 to 53 (}) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line:     </div>
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 6 (</) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 6 to 9 (div) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 9 to 10 (>) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line: }finally{}
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 1 to 8 (finally) with scopes text.aspnetcorerazor, meta.statement.finally.razor, keyword.control.try.finally.cs
+ - token from 8 to 9 ({) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 9 to 10 (}) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @try { ... } catch/finally { ... } Single line 1`] = `
+"Line: @try { var x = 123;<p>Hello World</p> } catch (Exception ex) {@DateTime.Now}finally{<section></section>var y = 456;}
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.cshtml.transition
+ - token from 1 to 4 (try) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.try.cs
+ - token from 4 to 5 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor
+ - token from 5 to 6 ({) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 7 to 10 (var) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 11 to 12 (x) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 13 to 14 (=) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 15 to 18 (123) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
+ - token from 18 to 19 (;) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 19 to 20 (<) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 20 to 21 (p) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 22 to 33 (Hello World) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 33 to 35 (</) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 35 to 36 (p) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 36 to 37 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 37 to 38 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 38 to 39 (}) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 39 to 40 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 40 to 45 (catch) with scopes text.aspnetcorerazor, meta.statement.catch.razor, keyword.control.try.catch.cs
+ - token from 45 to 46 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 46 to 47 (() with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.open.cs
+ - token from 47 to 56 (Exception) with scopes text.aspnetcorerazor, meta.statement.catch.razor, storage.type.cs
+ - token from 56 to 57 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 57 to 59 (ex) with scopes text.aspnetcorerazor, meta.statement.catch.razor, entity.name.variable.local.cs
+ - token from 59 to 60 ()) with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.close.cs
+ - token from 60 to 61 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 61 to 62 ({) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 62 to 63 (@) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 63 to 71 (DateTime) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 71 to 72 (.) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml
+ - token from 72 to 75 (Now) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 75 to 76 (}) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 76 to 83 (finally) with scopes text.aspnetcorerazor, meta.statement.finally.razor, keyword.control.try.finally.cs
+ - token from 83 to 84 ({) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 84 to 85 (<) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 85 to 92 (section) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 92 to 93 (>) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 93 to 95 (</) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 95 to 102 (section) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 102 to 103 (>) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 103 to 106 (var) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
+ - token from 106 to 107 ( ) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock
+ - token from 107 to 108 (y) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 108 to 109 ( ) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock
+ - token from 109 to 110 (=) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 110 to 111 ( ) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock
+ - token from 111 to 114 (456) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
+ - token from 114 to 115 (;) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 115 to 116 (}) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
 exports[`Grammar tests @using ( ... ) { ... } Incomplete using statement, no condition 1`] = `
 "Line: @using {}
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.using.cshtml, keyword.control.cshtml.transition


### PR DESCRIPTION
- Does not support Razor templates or embedded HTML constructs within non-transitioned C#.
- Expanded the while statement support to work as continuations of the do statement.
- Add tests to validate the various forms of `@do { ... } while (...);`.

aspnet/AspNetCore#14287