### PR TITLE
Add grammar support for nested C# statements with markup in Razor code blocks.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -1013,7 +1013,7 @@
     },
     "using-statement": {
       "name": "meta.statement.using.razor",
-      "begin": "(@)(using)\\b\\s*(?=\\()",
+      "begin": "(?:^\\s*|(@))(using)\\b\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "patterns": [
@@ -1041,7 +1041,7 @@
     },
     "if-statement": {
       "name": "meta.statement.if.razor",
-      "begin": "(@)(if)\\b\\s*(?=\\()",
+      "begin": "(?:^\\s*|(@))(if)\\b\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "patterns": [
@@ -1093,7 +1093,7 @@
     },
     "for-statement": {
       "name": "meta.statement.for.razor",
-      "begin": "(@)(for)\\b\\s*(?=\\()",
+      "begin": "(?:^\\s*|(@))(for)\\b\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "patterns": [
@@ -1121,7 +1121,7 @@
     },
     "foreach-statement": {
       "name": "meta.statement.foreach.razor",
-      "begin": "(@)(foreach)\\b\\s*(?=\\()",
+      "begin": "(?:^\\s*|(@))(foreach)\\b\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "patterns": [
@@ -1207,7 +1207,7 @@
     },
     "do-statement": {
       "name": "meta.statement.do.razor",
-      "begin": "(@)(do)\\b\\s*",
+      "begin": "(?:^\\s*|(@))(do)\\b\\s*",
       "beginCaptures": {
         "1": {
           "patterns": [
@@ -1268,7 +1268,7 @@
     },
     "switch-statement": {
       "name": "meta.statement.switch.razor",
-      "begin": "(@)(switch)\\b\\s*(?=\\()",
+      "begin": "(?:^\\s*|(@))(switch)\\b\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "patterns": [
@@ -1319,7 +1319,7 @@
     },
     "lock-statement": {
       "name": "meta.statement.lock.razor",
-      "begin": "(@)(lock)\\b\\s*(?=\\()",
+      "begin": "(?:^\\s*|(@))(lock)\\b\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "patterns": [
@@ -1360,7 +1360,7 @@
     },
     "try-block": {
       "name": "meta.statement.try.razor",
-      "begin": "(@)(try)\\b\\s*",
+      "begin": "(?:^\\s*|(@))(try)\\b\\s*",
       "beginCaptures": {
         "1": {
           "patterns": [

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -497,7 +497,7 @@ repository:
 
   using-statement:
     name: 'meta.statement.using.razor'
-    begin: '(@)(using)\b\s*(?=\()'
+    begin: '(?:^\s*|(@))(using)\b\s*(?=\()'
     beginCaptures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.other.using.cs' }
@@ -511,7 +511,7 @@ repository:
 
   if-statement:
     name: 'meta.statement.if.razor'
-    begin: '(@)(if)\b\s*(?=\()'
+    begin: '(?:^\s*|(@))(if)\b\s*(?=\()'
     beginCaptures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.control.conditional.if.cs' }
@@ -521,7 +521,7 @@ repository:
       - include: '#razor-codeblock-body'
     end: '(?<=})'
 
-  #>>>>> @else [if (...)] { ... } <<<<<
+  #>>>>> else [if (...)] { ... } <<<<<
 
   else-part:
     name: 'meta.statement.else.razor'
@@ -539,7 +539,7 @@ repository:
 
   for-statement:
     name: 'meta.statement.for.razor'
-    begin: '(@)(for)\b\s*(?=\()'
+    begin: '(?:^\s*|(@))(for)\b\s*(?=\()'
     beginCaptures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.control.loop.for.cs' }
@@ -553,7 +553,7 @@ repository:
 
   foreach-statement:
     name: 'meta.statement.foreach.razor'
-    begin: '(@)(foreach)\b\s*(?=\()'
+    begin: '(?:^\s*|(@))(foreach)\b\s*(?=\()'
     beginCaptures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.control.loop.foreach.cs' }
@@ -622,7 +622,7 @@ repository:
 
   do-statement:
     name: 'meta.statement.do.razor'
-    begin: '(@)(do)\b\s*'
+    begin: '(?:^\s*|(@))(do)\b\s*'
     beginCaptures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.control.loop.do.cs' }
@@ -652,7 +652,7 @@ repository:
 
   switch-statement:
     name: 'meta.statement.switch.razor'
-    begin: '(@)(switch)\b\s*(?=\()'
+    begin: '(?:^\s*|(@))(switch)\b\s*(?=\()'
     beginCaptures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.control.switch.cs' }
@@ -678,7 +678,7 @@ repository:
 
   lock-statement:
     name: 'meta.statement.lock.razor'
-    begin: '(@)(lock)\b\s*(?=\()'
+    begin: '(?:^\s*|(@))(lock)\b\s*(?=\()'
     beginCaptures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.other.lock.cs' }
@@ -698,7 +698,7 @@ repository:
 
   try-block:
     name: 'meta.statement.try.razor'
-    begin: '(@)(try)\b\s*'
+    begin: '(?:^\s*|(@))(try)\b\s*'
     beginCaptures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.control.try.cs' }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/CodeBlock.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/CodeBlock.ts
@@ -39,14 +39,14 @@ export function RunCodeBlockSuite() {
 
         it('Single line markup simple', async () => {
             await assertMatchesSnapshot(
-`@{
+                `@{
     @: <p> Incomplete
 }`);
         });
 
         it('Single line markup complex', async () => {
             await assertMatchesSnapshot(
-`@{
+                `@{
     @:@DateTime.Now <text>Nope</text>
 }`);
         });
@@ -91,6 +91,118 @@ export function RunCodeBlockSuite() {
 
     if (true) {
         <p>alksdjfl</p>
+    }
+}`);
+        });
+
+        it('Nested if statement with markup', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    if (true)
+    {
+        <p>Hello World!</p>
+    }
+}`);
+        });
+
+        it('Nested for statement with markup', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    for (var i = 0; i % 2 == 0; i++)
+    {
+        <p>@i</p>
+    }
+}`);
+        });
+
+        it('Nested foreach statement with markup', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    foreach (var person in people)
+    {
+        <p>@person</p>
+    }
+}`);
+        });
+
+        it('Nested do while statement with markup', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    var i = 0;
+    do
+    {
+        <p>@i</p>
+    } while (i++ != 10);
+}`);
+        });
+
+        it('Nested while statement with markup', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    var i = 0;
+    while (i++ != 10)
+    {
+        <p>@i</p>
+    }
+}`);
+        });
+
+        it('Nested lock statement with markup', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    lock (someObject)
+    {
+        <p>Hello World</p>
+    }
+}`);
+        });
+
+        it('Nested using statement with markup', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    using (someDisposable)
+    {
+        <p>Hello World</p>
+    }
+}`);
+        });
+
+        it('Nested try statement with markup', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    try
+    {
+        <p>Hello World</p>
+    } catch (Exception ex){}
+}`);
+        });
+
+        it('Nested switch statement with markup', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    switch (something)
+    {
+        case true:
+            <p>Hello World</p>
+            break;
+    }
+}`);
+        });
+
+        it('Complex with various nested statements', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    if (true) {
+        <div>
+        @using (someDisposable) {
+            <p>Foo!</p>
+            var x = 123;
+            while (i++ % 2 == 0)
+            {
+                <strong>Bar</strong>
+            }
+        }
+        </div>
     }
 }`);
         });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -3451,6 +3451,113 @@ exports[`Grammar tests Razor code blocks @{ ... } Complex HTML tag structures 1`
 "
 `;
 
+exports[`Grammar tests Razor code blocks @{ ... } Complex with various nested statements 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     if (true) {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <div>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 12 (div) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 12 to 13 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:         @using (someDisposable) {
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.control.cshtml.transition
+ - token from 9 to 14 (using) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.other.using.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 16 to 30 (someDisposable) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 30 to 31 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 32 to 33 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:             <p>Foo!</p>
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 15 to 19 (Foo!) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 19 to 21 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 21 to 22 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:             var x = 123;
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 15 (var) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 16 to 17 (x) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 18 to 19 (=) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 23 (123) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+
+Line:             while (i++ % 2 == 0)
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 12 to 17 (while) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 19 to 20 (i) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 20 to 22 (++) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 23 to 24 (%) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.arithmetic.cs
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 25 to 26 (2) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 27 to 29 (==) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 29 to 30 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 30 to 31 (0) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 31 to 32 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
+
+Line:             {
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 12 to 13 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:                 <strong>Bar</strong>
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 16 to 17 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 17 to 23 (strong) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 23 to 24 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 24 to 27 (Bar) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 27 to 29 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 29 to 35 (strong) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 35 to 36 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:             }
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line:         }
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line:         </div>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 10 to 13 (div) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
 exports[`Grammar tests Razor code blocks @{ ... } Empty code block 1`] = `
 "Line: @{}
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
@@ -3670,29 +3777,305 @@ Line:
  - token from 0 to 1 () with scopes text.aspnetcorerazor
 
 Line:     if (true) {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 6 (if) with scopes text.aspnetcorerazor, keyword.control.conditional.if.cs
- - token from 6 to 7 ( ) with scopes text.aspnetcorerazor
- - token from 7 to 8 (() with scopes text.aspnetcorerazor, punctuation.parenthesis.open.cs
- - token from 8 to 12 (true) with scopes text.aspnetcorerazor, constant.language.boolean.true.cs
- - token from 12 to 13 ()) with scopes text.aspnetcorerazor, punctuation.parenthesis.close.cs
- - token from 13 to 14 ( ) with scopes text.aspnetcorerazor
- - token from 14 to 15 ({) with scopes text.aspnetcorerazor, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>alksdjfl</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, keyword.operator.relational.cs
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, variable.other.readwrite.cs
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, keyword.operator.relational.cs
- - token from 11 to 19 (alksdjfl) with scopes text.aspnetcorerazor, variable.other.readwrite.cs
- - token from 19 to 20 (<) with scopes text.aspnetcorerazor, keyword.operator.relational.cs
- - token from 20 to 21 (/) with scopes text.aspnetcorerazor, keyword.operator.arithmetic.cs
- - token from 21 to 22 (p) with scopes text.aspnetcorerazor, variable.other.readwrite.cs
- - token from 22 to 23 (>) with scopes text.aspnetcorerazor, keyword.operator.relational.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 19 (alksdjfl) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 19 to 21 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 21 to 22 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor code blocks @{ ... } Nested do while statement with markup 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     var i = 0;
  - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, punctuation.curlybrace.close.cs
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor
+ - token from 8 to 9 (i) with scopes text.aspnetcorerazor, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor
+ - token from 12 to 13 (0) with scopes text.aspnetcorerazor, constant.numeric.decimal.cs
+ - token from 13 to 14 (;) with scopes text.aspnetcorerazor, punctuation.terminator.statement.cs
+
+Line:     do
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor
+ - token from 4 to 6 (do) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.loop.do.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p>@i</p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 12 to 13 (i) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     } while (i++ != 10);
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 6 to 11 (while) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 14 to 16 (++) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 17 to 19 (!=) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 20 to 22 (10) with scopes text.aspnetcorerazor, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 22 to 23 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.terminator.statement.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor code blocks @{ ... } Nested for statement with markup 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     for (var i = 0; i % 2 == 0; i++)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 4 to 7 (for) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.control.loop.for.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.parenthesis.open.cs
+ - token from 9 to 12 (var) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.other.var.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, entity.name.variable.local.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 15 to 16 (=) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.assignment.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 17 to 18 (0) with scopes text.aspnetcorerazor, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 18 to 19 (;) with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.terminator.statement.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 20 to 21 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 22 to 23 (%) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.arithmetic.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 24 to 25 (2) with scopes text.aspnetcorerazor, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 26 to 28 (==) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.comparison.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 29 to 30 (0) with scopes text.aspnetcorerazor, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 30 to 31 (;) with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.terminator.statement.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 32 to 33 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 33 to 35 (++) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.increment.cs
+ - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p>@i</p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 12 to 13 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor code blocks @{ ... } Nested foreach statement with markup 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     foreach (var person in people)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 4 to 11 (foreach) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.control.loop.foreach.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.statement.foreach.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 16 (var) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.other.var.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 17 to 23 (person) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, entity.name.variable.local.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 24 to 26 (in) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.control.loop.in.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 27 to 33 (people) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, variable.other.readwrite.cs
+ - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p>@person</p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 12 to 18 (person) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 18 to 20 (</) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 20 to 21 (p) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor code blocks @{ ... } Nested if statement with markup 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     if (true)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p>Hello World!</p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 23 (Hello World!) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 23 to 25 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 25 to 26 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor code blocks @{ ... } Nested lock statement with markup 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     lock (someObject)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
+ - token from 4 to 8 (lock) with scopes text.aspnetcorerazor, meta.statement.lock.razor, keyword.other.lock.cs
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
+ - token from 9 to 10 (() with scopes text.aspnetcorerazor, meta.statement.lock.razor, punctuation.parenthesis.open.cs
+ - token from 10 to 20 (someObject) with scopes text.aspnetcorerazor, meta.statement.lock.razor, variable.other.readwrite.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.statement.lock.razor, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p>Hello World</p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 22 (Hello World) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 22 to 24 (</) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 24 to 25 (p) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor code blocks @{ ... } Nested switch statement with markup 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     switch (something)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
+ - token from 4 to 10 (switch) with scopes text.aspnetcorerazor, meta.statement.switch.razor, keyword.control.switch.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
+ - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.statement.switch.razor, punctuation.parenthesis.open.cs
+ - token from 12 to 21 (something) with scopes text.aspnetcorerazor, meta.statement.switch.razor, variable.other.readwrite.cs
+ - token from 21 to 22 ()) with scopes text.aspnetcorerazor, meta.statement.switch.razor, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.open.cs
+
+Line:         case true:
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 8 to 12 (case) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.case.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 13 to 17 (true) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, constant.language.boolean.true.cs
+ - token from 17 to 18 (:) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.separator.colon.cs
+
+Line:             <p>Hello World</p>
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.end.html
+ - token from 15 to 26 (Hello World) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 26 to 28 (</) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.begin.html
+ - token from 28 to 29 (p) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.tag.html
+ - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.end.html
+
+Line:             break;
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 12 to 17 (break) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.flow.break.cs
+ - token from 17 to 18 (;) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
@@ -3738,6 +4121,137 @@ exports[`Grammar tests Razor code blocks @{ ... } Nested text text tag 1`] = `
  - token from 27 to 34 (</text>) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition.textTag.close
  - token from 34 to 35 ( ) with scopes text.aspnetcorerazor
  - token from 35 to 36 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor code blocks @{ ... } Nested try statement with markup 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     try
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor
+ - token from 4 to 7 (try) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.try.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p>Hello World</p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 22 (Hello World) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 22 to 24 (</) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 24 to 25 (p) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     } catch (Exception ex){}
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 6 to 11 (catch) with scopes text.aspnetcorerazor, meta.statement.catch.razor, keyword.control.try.catch.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 22 (Exception) with scopes text.aspnetcorerazor, meta.statement.catch.razor, storage.type.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 23 to 25 (ex) with scopes text.aspnetcorerazor, meta.statement.catch.razor, entity.name.variable.local.cs
+ - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.close.cs
+ - token from 26 to 27 ({) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 27 to 28 (}) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor code blocks @{ ... } Nested using statement with markup 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     using (someDisposable)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 4 to 9 (using) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.other.using.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 11 to 25 (someDisposable) with scopes text.aspnetcorerazor, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p>Hello World</p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 22 (Hello World) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 22 to 24 (</) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 24 to 25 (p) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor code blocks @{ ... } Nested while statement with markup 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     var i = 0;
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor
+ - token from 8 to 9 (i) with scopes text.aspnetcorerazor, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor
+ - token from 12 to 13 (0) with scopes text.aspnetcorerazor, constant.numeric.decimal.cs
+ - token from 13 to 14 (;) with scopes text.aspnetcorerazor, punctuation.terminator.statement.cs
+
+Line:     while (i++ != 10)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 4 to 9 (while) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 11 to 12 (i) with scopes text.aspnetcorerazor, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 12 to 14 (++) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 15 to 17 (!=) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 18 to 20 (10) with scopes text.aspnetcorerazor, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p>@i</p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 12 to 13 (i) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
 "
 `;
 


### PR DESCRIPTION
- Basically we're now treating all statements similar to the `else` continuation for an `if`. Meaning, if we detect that a statement is being used at the beginning of a line and is followed by something logical like a parenthesis; we'll classify it as C#.
- Added tests and updated existing ones.

aspnet/AspNetCore#14287