### PR TITLE
[release/3.0] Move CPD tied dependencies up above pinned

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,6 +13,14 @@
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>6a3428047e05c1db442a0320b788dd8415144393</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="3.0.2-servicing.19604.3">
+      <Uri>https://github.com/aspnet/Extensions</Uri>
+      <Sha>6a3428047e05c1db442a0320b788dd8415144393</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Testing" Version="3.0.2-servicing.19604.3">
+      <Uri>https://github.com/aspnet/Extensions</Uri>
+      <Sha>6a3428047e05c1db442a0320b788dd8415144393</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging" Version="3.0.2-servicing.19604.3">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>6a3428047e05c1db442a0320b788dd8415144393</Sha>
@@ -37,6 +45,11 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>547ae1f5f072d130b32ec3089876711070b2dc4f</Sha>
     </Dependency>
+    <!-- Listed as a dependency to workaround https://github.com/dotnet/cli/issues/10528 -->
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.0" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
+    </Dependency>
     <!--
       Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
       All Runtime.$rid packages should have the same version.
@@ -52,19 +65,6 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <!-- Listed as a dependency to workaround https://github.com/dotnet/cli/issues/10528 -->
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.0" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="3.0.2-servicing.19604.3">
-      <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>6a3428047e05c1db442a0320b788dd8415144393</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Testing" Version="3.0.2-servicing.19604.3">
-      <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>6a3428047e05c1db442a0320b788dd8415144393</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19607.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>4d80b9cfa53e309c8f685abff3512f60c3d8a3d1</Sha>


### PR DESCRIPTION
I think this is still causing CPD problems in upstack updates. While MNP this isn't technically a product dependency, it's tied to a product dependency (core-setup). Also move extensions since all those versions will line up anyway.